### PR TITLE
Revert "fix encoding props (#305)"

### DIFF
--- a/utils/http.ts
+++ b/utils/http.ts
@@ -182,7 +182,7 @@ export const bodyFromUrl = (param: string, url: URL): Record<string, any> => {
     return start;
   }
   // frombase64
-  return JSON.parse(atob(decodeURIComponent(props)));
+  return JSON.parse(decodeURIComponent(atob(props)));
 };
 
 export const allowCorsFor = (req?: Request): Record<string, string> => ({


### PR DESCRIPTION
This reverts commit e9d4daacea210aaecc441410d5ca22841e1b3201.

The idea was that we were applying the transforms on the wrong order. Turns out it was right. More info at:
https://stackoverflow.com/questions/23223718/failed-to-execute-btoa-on-window-the-string-to-be-encoded-contains-characte