### PR TITLE
Add a newline when writing stringified JSONs

### DIFF
--- a/engine/releases/fs.ts
+++ b/engine/releases/fs.ts
@@ -4,6 +4,7 @@ import { exists } from "../../utils/filesystem.ts";
 import { singleFlight } from "../core/utils.ts";
 import { ENTRYPOINT } from "./constants.ts";
 import { OnChangeCallback, Release } from "./provider.ts";
+import stringifyForWrite from "$live/utils/stringifyForWrite.ts";
 
 const sample = {
   "audience-everyone": {
@@ -42,7 +43,7 @@ export const newFsProvider = (
     let dataText: string | null = null;
     try {
       if (!(await exists(fullPath))) {
-        dataText = JSON.stringify(sample, null, 2);
+        dataText = stringifyForWrite(sample);
         await Deno.writeTextFile(fullPath, dataText);
         return sample;
       }

--- a/engine/schema/reader.ts
+++ b/engine/schema/reader.ts
@@ -2,6 +2,7 @@ import { Schemas } from "$live/engine/schema/builder.ts";
 import { context } from "$live/live.ts";
 import { join } from "https://deno.land/std@0.61.0/path/mod.ts";
 import { genSchemasFromManifest } from "./gen.ts";
+import stringifyForWrite from "$live/utils/stringifyForWrite.ts";
 
 let schemas: Promise<Schemas> | null = null;
 const schemaFile = "schemas.gen.json";
@@ -15,11 +16,7 @@ export const genSchemas = async () => {
 
   await Deno.writeTextFile(
     join(Deno.cwd(), schemaFile),
-    JSON.stringify(
-      schema,
-      null,
-      2,
-    ),
+    stringifyForWrite(schema),
   );
 
   console.log(

--- a/scripts/order_imports.ts
+++ b/scripts/order_imports.ts
@@ -1,3 +1,5 @@
+import stringifyForWrite from "$live/utils/stringifyForWrite.ts";
+
 export async function orderImports() {
   const importMapFile = await Deno.readTextFile("./import_map.json");
   const importMap = JSON.parse(importMapFile);
@@ -25,7 +27,7 @@ export async function orderImports() {
   const newImportMap = { imports: newImports };
   await Deno.writeTextFile(
     "./import_map.json",
-    JSON.stringify(newImportMap, null, 2),
+    stringifyForWrite(newImportMap),
   );
 }
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -2,6 +2,7 @@ import { join } from "https://deno.land/std@0.181.0/path/mod.ts";
 import { increment } from "https://deno.land/std@0.181.0/semver/mod.ts";
 import { Select } from "https://deno.land/x/cliffy@v0.25.5/prompt/mod.ts";
 import { exec, OutputMode } from "https://deno.land/x/exec@0.0.5/mod.ts";
+import stringifyForWrite from "$live/utils/stringifyForWrite.ts";
 
 await exec("git fetch --tags");
 
@@ -64,7 +65,7 @@ if (await exists(metaJSONFilePath)) {
 
   await Deno.writeTextFile(
     metaJSONFilePath,
-    JSON.stringify({ ...meta, version: newVersion }, null, 2),
+    stringifyForWrite({ ...meta, version: newVersion }),
   );
 
   const GIT_ADD_COMMAND = `git add ${metaJSONFilePath}`;

--- a/utils/namespace.ts
+++ b/utils/namespace.ts
@@ -1,6 +1,7 @@
 import { join } from "https://deno.land/std@0.170.0/path/mod.ts";
 import { siteJSON } from "../dev.ts";
 import { exists } from "./filesystem.ts";
+import stringifyForWrite from "$live/utils/stringifyForWrite.ts";
 
 const sanitizer = (str: string | undefined) =>
   str?.endsWith("/") ? str : `${str}/`;
@@ -22,7 +23,7 @@ export const updateImportMap = async (dir: string, ns: string) => {
     if (!imports[namespace]) {
       await Deno.writeTextFile(
         importMapPath,
-        JSON.stringify(
+        stringifyForWrite(
           {
             ...(importMap ?? {}),
             imports: {
@@ -30,8 +31,6 @@ export const updateImportMap = async (dir: string, ns: string) => {
               ...imports,
             },
           },
-          null,
-          2,
         ),
       );
     }

--- a/utils/stringifyForWrite.ts
+++ b/utils/stringifyForWrite.ts
@@ -1,0 +1,5 @@
+export default function stringifyForWrite(
+  object: Object,
+): string {
+  return `${JSON.stringify(object, null, 2)}\n`;
+}

--- a/utils/update.ts
+++ b/utils/update.ts
@@ -3,6 +3,7 @@ import {
   REGISTRIES,
 } from "https://denopkg.com/hayd/deno-udd@0.8.2/registry.ts";
 import { join } from "std/path/mod.ts";
+import stringifyForWrite from "$live/utils/stringifyForWrite.ts";
 
 // map of `packageAlias` to `packageRepo`
 const PACKAGES_TO_CHECK = /(\$live)|(deco-sites\/.*\/$)/;
@@ -66,7 +67,7 @@ export async function update() {
 
   await Deno.writeTextFile(
     importMapPath,
-    JSON.stringify(newImportMap, null, 2),
+    stringifyForWrite(newImportMap),
   );
   console.info("Upgraded successfully");
 }


### PR DESCRIPTION
While developing a site I've realised that `deno fmt` adds a newline to end of every tracked git file. Since the logic here does not add newlines to end of JSON.strinfigy before adding it to a file, it is not following the format commited to the repository.

This is a small nuisance and since I'm trying things out decided to try and fix it.

Before:
- Clone a repo which uses deco
- Run `deno task start`
- Run `git diff` or `git status` and notice that there's a whitespace removed at the end of `schemas.gen.json`
- Run `deno fmt`
- Run `git diff` or `git status` and notice that such space is gone

After:
- Clone a repo which uses deco
- Run `deno task start`
- Run `git diff` or `git status` and see that there's no change

The video demonstrates those versions:

https://github.com/deco-cx/deco/assets/3386440/f5872794-b379-4632-9fcd-7e5af4d680f3

