### PR TITLE
Allow extending resolvables and resolvers in runtime

### DIFF
--- a/blocks/route.ts
+++ b/blocks/route.ts
@@ -173,7 +173,7 @@ export const buildDecoState = (resolveKey: string | Resolvable) =>
 
     const isLiveMeta = url.pathname.startsWith("/live/_meta"); // live-meta
 
-    const resolver = liveContext.releaseResolver!.clone(); // cloning for allowing extensions.
+    const resolver = liveContext.releaseResolver!;
     const ctxResolver = resolver
       .resolverFor(
         { context, request },

--- a/blocks/route.ts
+++ b/blocks/route.ts
@@ -173,7 +173,7 @@ export const buildDecoState = (resolveKey: string | Resolvable) =>
 
     const isLiveMeta = url.pathname.startsWith("/live/_meta"); // live-meta
 
-    const resolver = liveContext.releaseResolver!;
+    const resolver = liveContext.releaseResolver!.clone(); // cloning for allowing extensions.
     const ctxResolver = resolver
       .resolverFor(
         { context, request },

--- a/clients/withManifest.ts
+++ b/clients/withManifest.ts
@@ -1,6 +1,6 @@
-// deno-lint-ignore-file no-explicit-any
+// deno-lint-ignore-file no-explicit-any ban-types
 import { IS_BROWSER } from "$fresh/runtime.ts";
-import { AppManifest } from "$live/blocks/app.ts";
+import type { App, AppManifest } from "$live/blocks/app.ts";
 import type {
   AvailableActions,
   AvailableFunctions,
@@ -180,4 +180,17 @@ export const withManifest = <TManifest extends AppManifest>() => {
      */
     create: create<TManifest>(),
   };
+};
+
+export const forApp = <
+  TApp extends App,
+  TDependantManifest = TApp extends
+    { dependencies?: ({ manifest: infer TManifestDependency })[] }
+    ? TManifestDependency extends AppManifest ? TManifestDependency : {}
+    : {},
+>() => {
+  return withManifest<
+    & TApp["manifest"]
+    & TDependantManifest
+  >();
 };

--- a/engine/block.ts
+++ b/engine/block.ts
@@ -145,11 +145,7 @@ export type ManifestSchemas = References<{}>; // FIXME (mcandeia) this was used 
 
 export type InstanceOf<
   T,
-  _Schema extends T extends Block
-    ? `#/root/${T["type"]}` & ManifestSchemas | string
-    : ManifestSchemas = T extends Block
-      ? `#/root/${T["type"]}` & ManifestSchemas
-      : ManifestSchemas,
+  _Schema,
 > = T extends Block<BlockModule<any, any, infer TSerializable>> ? TSerializable
   : T;
 

--- a/engine/core/mod.bench.ts
+++ b/engine/core/mod.bench.ts
@@ -17,6 +17,7 @@ Deno.bench(
       resolveHints,
       danglingRecover,
       extend: () => {},
+      runOnce: (_key, f) => f(),
       resolve: <T>(data: unknown) => {
         return data as T;
       },
@@ -46,6 +47,7 @@ Deno.bench(
       resolveHints: generatedHints,
       danglingRecover,
       extend: () => {},
+      runOnce: (_key, f) => f(),
       resolve: <T>(data: unknown) => {
         return data as T;
       },

--- a/engine/core/mod.bench.ts
+++ b/engine/core/mod.bench.ts
@@ -16,6 +16,7 @@ Deno.bench(
       resolvers: {},
       resolveHints,
       danglingRecover,
+      extend: () => {},
       resolve: <T>(data: unknown) => {
         return data as T;
       },
@@ -44,6 +45,7 @@ Deno.bench(
       resolvers: {},
       resolveHints: generatedHints,
       danglingRecover,
+      extend: () => {},
       resolve: <T>(data: unknown) => {
         return data as T;
       },
@@ -74,6 +76,7 @@ Deno.bench(
       resolvers: {},
       resolveHints,
       danglingRecover,
+      extend: () => {},
       resolve: <T>(data: unknown) => {
         return data as T;
       },

--- a/engine/core/mod.test.ts
+++ b/engine/core/mod.test.ts
@@ -15,6 +15,7 @@ Deno.test("resolve", async (t) => {
     resolvables: {},
     resolvers: {},
     resolveHints: {},
+    extend: () => {},
     resolve: <T>(data: unknown) => {
       return data as T;
     },

--- a/engine/core/mod.test.ts
+++ b/engine/core/mod.test.ts
@@ -16,6 +16,7 @@ Deno.test("resolve", async (t) => {
     resolvers: {},
     resolveHints: {},
     extend: () => {},
+    runOnce: (_key, f) => f(),
     resolve: <T>(data: unknown) => {
       return data as T;
     },

--- a/engine/core/mod.ts
+++ b/engine/core/mod.ts
@@ -11,6 +11,7 @@ import {
   ResolverMap,
 } from "$live/engine/core/resolver.ts";
 import { Release } from "$live/engine/releases/provider.ts";
+import { once, SyncOnce } from "$live/utils/sync.ts";
 import { ResolvableMap } from "./resolver.ts";
 
 export interface ResolverOptions<TContext extends BaseContext = BaseContext> {
@@ -48,25 +49,36 @@ export class ReleaseResolver<TContext extends BaseContext = BaseContext> {
   protected resolvers: ResolverMap<TContext>;
   protected resolvables?: ResolvableMap;
   protected danglingRecover?: Resolver;
+  protected runOncePerRelease: Record<string, SyncOnce<any>>;
   private resolveHints: ResolveHints;
-  constructor(config: ResolverOptions<TContext>, hints?: ResolveHints) {
+  constructor(
+    config: ResolverOptions<TContext>,
+    hints?: ResolveHints,
+    oncePerRelease?: Record<string, SyncOnce<any>>,
+  ) {
     this.resolvers = config.resolvers;
     this.release = config.release;
     this.resolvables = config.resolvables;
     this.danglingRecover = config.danglingRecover;
     this.resolveHints = hints ?? {};
+    this.runOncePerRelease = oncePerRelease ?? {};
     this.release.onChange(() => {
+      this.runOncePerRelease = {};
       this.resolveHints = {};
     });
   }
 
   public clone = () => {
-    return new ReleaseResolver<TContext>({
-      resolvables: { ...this.resolvables },
-      release: this.release,
-      resolvers: { ...this.resolvers },
-      danglingRecover: this.danglingRecover?.bind(this),
-    }, this.resolveHints);
+    return new ReleaseResolver<TContext>(
+      {
+        resolvables: { ...this.resolvables },
+        release: this.release,
+        resolvers: { ...this.resolvers },
+        danglingRecover: this.danglingRecover?.bind(this),
+      },
+      this.resolveHints,
+      this.runOncePerRelease,
+    );
   };
 
   public extend = (
@@ -137,6 +149,9 @@ export class ReleaseResolver<TContext extends BaseContext = BaseContext> {
       resolvers,
       monitoring: options?.monitoring,
       extend: this.extend.bind(this),
+      runOnce: (key, f) => {
+        return (this.runOncePerRelease[key] ??= once()).do(f);
+      },
     };
     const ctx = {
       ...context,

--- a/engine/core/mod.ts
+++ b/engine/core/mod.ts
@@ -31,6 +31,7 @@ export interface ResolveOptions {
   monitoring?: Monitoring;
   forceFresh?: boolean;
   nullIfDangling?: boolean;
+  propagateOptions?: boolean;
   propsIsResolved?: boolean;
   resolveChain?: FieldResolver[];
 }
@@ -164,6 +165,9 @@ export class ReleaseResolver<TContext extends BaseContext = BaseContext> {
         ? { // null if dangling, force fresh and propsIsResolved should not be reused across inner resolvables calls
           overrides: options?.overrides,
           monitoring: options?.monitoring,
+          ...(options?.propagateOptions
+            ? { nullIfDangling: options?.nullIfDangling }
+            : {}),
         }
         : {},
     );

--- a/engine/core/resolver.ts
+++ b/engine/core/resolver.ts
@@ -35,6 +35,7 @@ export interface Monitoring {
 export type ExtensionFunc<TContext extends BaseContext = BaseContext> = (
   opts: ExtensionOptions<TContext>,
 ) => void;
+
 export interface BaseContext<TContext extends BaseContext = any> {
   resolveChain: FieldResolver[];
   resolveId: string;
@@ -45,6 +46,7 @@ export interface BaseContext<TContext extends BaseContext = any> {
   danglingRecover?: Resolver;
   resolveHints: ResolveHints;
   extend: ExtensionFunc<TContext>;
+  runOnce: <T>(key: string, f: () => PromiseOrValue<T>) => PromiseOrValue<T>;
 }
 
 export interface PropFieldResolver {
@@ -174,6 +176,7 @@ export type AsyncResolver<
     context: TContext,
   ): Promise<Resolvable<T, TContext, any>>;
   onBeforeResolveProps?: OnBeforeResolveProps;
+  type?: string;
 };
 
 export type SyncResolver<
@@ -183,6 +186,7 @@ export type SyncResolver<
 > = {
   (parent: TParent, context: TContext): Resolvable<T, TContext, any>;
   onBeforeResolveProps?: OnBeforeResolveProps;
+  type?: string;
 };
 
 export type Resolver<

--- a/engine/core/resolver.ts
+++ b/engine/core/resolver.ts
@@ -13,6 +13,7 @@ import {
 } from "$live/engine/core/utils.ts";
 import { identity } from "$live/utils/object.ts";
 import { createServerTimings } from "$live/utils/timings.ts";
+import { ExtensionOptions } from "./mod.ts";
 
 export class DanglingReference extends Error {
   public resolverType: string;
@@ -31,7 +32,10 @@ export interface Monitoring {
   t: Omit<ReturnType<typeof createServerTimings>, "printTimings">;
 }
 
-export interface BaseContext {
+export type ExtensionFunc<TContext extends BaseContext = BaseContext> = (
+  opts: ExtensionOptions<TContext>,
+) => void
+export interface BaseContext<TContext extends BaseContext = any> {
   resolveChain: FieldResolver[];
   resolveId: string;
   resolve: ResolveFunc;
@@ -40,6 +44,7 @@ export interface BaseContext {
   resolvers: Record<string, Resolver>;
   danglingRecover?: Resolver;
   resolveHints: ResolveHints;
+  extend: ExtensionFunc<TContext>;
 }
 
 export interface PropFieldResolver {

--- a/engine/core/resolver.ts
+++ b/engine/core/resolver.ts
@@ -34,7 +34,7 @@ export interface Monitoring {
 
 export type ExtensionFunc<TContext extends BaseContext = BaseContext> = (
   opts: ExtensionOptions<TContext>,
-) => void
+) => void;
 export interface BaseContext<TContext extends BaseContext = any> {
   resolveChain: FieldResolver[];
   resolveId: string;

--- a/engine/core/utils.ts
+++ b/engine/core/utils.ts
@@ -53,7 +53,7 @@ export const isPrimitive = <T>(v: T): boolean => {
   return !Array.isArray(v) && typeof v !== "object" && typeof v !== "function";
 };
 
-interface SingleFlight<T> {
+export interface SingleFlight<T> {
   do: (key: string, f: () => Promise<T>) => Promise<T>;
 }
 

--- a/engine/fresh/manifest.ts
+++ b/engine/fresh/manifest.ts
@@ -166,6 +166,7 @@ export const buildRuntime = <
       (mod.Preview ? usePreviewFunc(mod.Preview) : blk.defaultPreview);
     if (previewFunc) {
       previewFunc.onBeforeResolveProps = mod.onBeforeResolveProps;
+      previewFunc.type = blk.type;
       return { ...prv, [`${PREVIEW_PREFIX_KEY}${key}`]: previewFunc };
     }
     return prv;
@@ -176,6 +177,7 @@ export const buildRuntime = <
       const invokeFunc = mod.invoke ?? blk.defaultInvoke;
       if (invokeFunc) {
         invokeFunc.onBeforeResolveProps = mod.onBeforeResolveProps;
+        invokeFunc.type = blk.type;
         return { ...invk, [`${INVOKE_PREFIX_KEY}${key}`]: invokeFunc };
       }
       return invk;
@@ -192,6 +194,7 @@ export const buildRuntime = <
           ? compose(...resolver)
           : resolver;
         composed.onBeforeResolveProps = mod.onBeforeResolveProps;
+        composed.type = blk.type;
         return composed;
       },
     )

--- a/mod.ts
+++ b/mod.ts
@@ -10,6 +10,6 @@ export { badRequest, notFound, redirect } from "$live/engine/errors.ts";
 export { $live } from "$live/engine/fresh/manifest.ts";
 export * from "$live/types.ts";
 export type { WorkflowGen } from "./deps.ts";
-export type { App, AppContext, AppRuntime, AppModule } from "./types.ts";
+export type { App, AppContext, AppModule, AppRuntime } from "./types.ts";
 export type { StreamProps } from "./utils/invoke.ts";
 export { stylesPlugin };

--- a/mod.ts
+++ b/mod.ts
@@ -13,3 +13,4 @@ export type { WorkflowGen } from "./deps.ts";
 export type { App, AppContext, AppModule, AppRuntime } from "./types.ts";
 export type { StreamProps } from "./utils/invoke.ts";
 export { stylesPlugin };
+

--- a/mod.ts
+++ b/mod.ts
@@ -10,6 +10,6 @@ export { badRequest, notFound, redirect } from "$live/engine/errors.ts";
 export { $live } from "$live/engine/fresh/manifest.ts";
 export * from "$live/types.ts";
 export type { WorkflowGen } from "./deps.ts";
-export type { App, AppContext, AppRuntime } from "./types.ts";
+export type { App, AppContext, AppRuntime, AppModule } from "./types.ts";
 export type { StreamProps } from "./utils/invoke.ts";
 export { stylesPlugin };

--- a/plugins/deco.ts
+++ b/plugins/deco.ts
@@ -1,6 +1,5 @@
 import { MiddlewareHandler, Plugin } from "$fresh/server.ts";
 import { buildDecoState, injectLiveStateForPath } from "$live/blocks/route.ts";
-import { context } from "$live/live.ts";
 import { $live, AppManifest, SiteInfo } from "$live/mod.ts";
 import {
   default as Render,
@@ -40,9 +39,7 @@ export default function decoPlugin(opt?: Options): Plugin {
             buildDecoState(
               opt
                 ? {
-                  apps: [{
-                    __resolveType: context.site,
-                  }],
+                  __resolveType: "bootstrap",
                 }
                 : "./routes/_middleware.ts",
             ),

--- a/plugins/deco.ts
+++ b/plugins/deco.ts
@@ -27,7 +27,11 @@ export interface Options<TManifest extends AppManifest = AppManifest> {
 }
 export default function decoPlugin(opt?: Options): Plugin {
   if (opt) {
-    $live(opt.manifest, opt.site, opt.useLocalStorageOnly);
+    $live(
+      { apps: { ...opt.manifest.apps } },
+      opt.site,
+      opt.useLocalStorageOnly,
+    );
   }
   return {
     name: "deco",

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -103,7 +103,8 @@ export const handler = async (
     const newHeaders = new Headers(initialResponse.headers);
     if (
       (url.pathname.startsWith("/live/previews") &&
-      url.searchParams.has("mode") && url.searchParams.get("mode") == "showcase") ||
+        url.searchParams.has("mode") &&
+        url.searchParams.get("mode") == "showcase") ||
       url.pathname.startsWith("/_frsh/") || shouldAllowCorsForOptions
     ) {
       Object.entries(allowCorsFor(req)).map(([name, value]) => {

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -41,7 +41,7 @@ const isAdminOrLocalhost = (req: Request): boolean => {
   const url = new URL(req.url);
   const isLocalhost = ["localhost", "127.0.0.1"].includes(url.hostname);
   return isOnAdmin || isLocalhost;
-}
+};
 
 export const handler = async (
   req: Request,
@@ -93,8 +93,11 @@ export const handler = async (
       ctx.state.manifest = mergeManifests(ctx.state.manifest, app.manifest);
     }
 
-    const shouldAllowCorsForOptions = (req.method === "OPTIONS") && isAdminOrLocalhost(req);
-    initialResponse = shouldAllowCorsForOptions ? new Response() : await ctx.next();
+    const shouldAllowCorsForOptions = (req.method === "OPTIONS") &&
+      isAdminOrLocalhost(req);
+    initialResponse = shouldAllowCorsForOptions
+      ? new Response()
+      : await ctx.next();
 
     // Let rendering occur — handlers are responsible for calling ctx.state.loadPage
     if (req.headers.get("upgrade") === "websocket") {

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -1,5 +1,5 @@
 import { MiddlewareHandlerContext } from "$fresh/server.ts";
-import { mergeRuntimes } from "$live/blocks/app.ts";
+import { mergeManifests } from "$live/blocks/app.ts";
 import { DECO_MATCHER_HEADER_QS } from "$live/blocks/matcher.ts";
 import {
   getPagePathTemplate,
@@ -8,7 +8,7 @@ import {
 import { Resolvable } from "$live/engine/core/resolver.ts";
 import { context } from "$live/live.ts";
 import { Apps } from "$live/mod.ts";
-import { AppRuntime, LiveConfig, LiveState } from "$live/types.ts";
+import { LiveConfig, LiveState } from "$live/types.ts";
 import { allowCorsFor, defaultHeaders } from "$live/utils/http.ts";
 import { formatLog } from "$live/utils/log.ts";
 import { getSetCookies } from "std/http/mod.ts";
@@ -90,27 +90,9 @@ export const handler = async (
     const apps = ctx?.state?.$live?.apps;
     ctx.state.manifest = context.manifest!;
     if (apps) {
-      const currentAppRuntime: AppRuntime = {
-        resolvers: context.releaseResolver!.getResolvers(),
-        manifest: context.manifest!,
-      };
-      const { resolvers, manifest, resolvables } = apps.reduce(
-        mergeRuntimes,
-        currentAppRuntime,
-      );
-      ctx.state.manifest = manifest;
-      const newReleaseResolver = context.releaseResolver!.with(
-        { resolvers, resolvables },
-      );
-      const ctxResolver = newReleaseResolver
-        .resolverFor(
-          { context: ctx, request: req },
-          {
-            monitoring: { t: ctx.state.t },
-          },
-        )
-        .bind(newReleaseResolver);
-      ctx.state.resolve = ctxResolver;
+      for (const app of apps) {
+        ctx.state.manifest = mergeManifests(ctx.state.manifest, app.manifest)
+      }
     }
 
     const shouldAllowCorsForOptions = (req.method === "OPTIONS") && isAdminOrLocalhost(req);

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -91,7 +91,7 @@ export const handler = async (
     ctx.state.manifest = context.manifest!;
     if (apps) {
       for (const app of apps) {
-        ctx.state.manifest = mergeManifests(ctx.state.manifest, app.manifest)
+        ctx.state.manifest = mergeManifests(ctx.state.manifest, app.manifest);
       }
     }
 

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -89,10 +89,8 @@ export const handler = async (
     }
     const apps = ctx?.state?.$live?.apps;
     ctx.state.manifest = context.manifest!;
-    if (apps) {
-      for (const app of apps) {
-        ctx.state.manifest = mergeManifests(ctx.state.manifest, app.manifest);
-      }
+    for (const app of Array.isArray(apps) ? apps : []) {
+      ctx.state.manifest = mergeManifests(ctx.state.manifest, app.manifest);
     }
 
     const shouldAllowCorsForOptions = (req.method === "OPTIONS") && isAdminOrLocalhost(req);

--- a/scripts/apps/templates/app.mod.ts.ts
+++ b/scripts/apps/templates/app.mod.ts.ts
@@ -4,24 +4,27 @@ import { InitContext } from "../init.ts";
 export default async function Deco(_ctx: InitContext) {
   return await format(
     `
-import manifest, { name } from "./manifest.gen.ts";
-import type { Manifest } from "./manifest.gen.ts";
-export { name };
-import type { App, AppContext as AC } from "../deps.ts";
-
-export interface State {
-  url: string;
-}
-export default function App(
-  state: State,
-): App<Manifest, State> {
-  return {
-    manifest,
-    state,
-  };
-}
-
-export type AppContext = AC<ReturnType<typeof App>>;
+    import type { App, AppContext as AC } from "$live/mod.ts";
+    import manifest, { Manifest, name } from "./manifest.gen.ts";
+    export { manifest, name };
+    
+    export interface State {
+      url: string;
+    }
+    // you can freely add dependencies by just importing the app mod and put here
+    export const dependencies = [];
+    /**
+     * @title App
+     */
+    export default function App(
+      state: State,
+    ): App<State> {
+      return {
+        state,
+      };
+    }
+    
+    export type AppContext = AC<State, Manifest, typeof dependencies>;
 `,
   );
 }

--- a/scripts/apps/templates/app.mod.ts.ts
+++ b/scripts/apps/templates/app.mod.ts.ts
@@ -4,22 +4,21 @@ import { InitContext } from "../init.ts";
 export default async function Deco(_ctx: InitContext) {
   return await format(
     `
-    import type { App, AppContext as AC } from "$live/mod.ts";
-    import manifest, { Manifest, name } from "./manifest.gen.ts";
-    export { manifest, name };
-    
+    import manifest, { name } from "./manifest.gen.ts";
+    import type { Manifest } from "./manifest.gen.ts";
+    export { name };
+    import type { App, AppContext as AC, AppModule } from "../deps.ts";
+
+    export const dependencies = [] satisfies AppModule[];
+
     export interface State {
       url: string;
     }
-    // you can freely add dependencies by just importing the app mod and put here
-    export const dependencies = [];
-    /**
-     * @title App
-     */
     export default function App(
       state: State,
-    ): App<State> {
+    ): App<Manifest, State> {
       return {
+        manifest,
         state,
       };
     }

--- a/scripts/apps/templates/app.mod.ts.ts
+++ b/scripts/apps/templates/app.mod.ts.ts
@@ -6,10 +6,7 @@ export default async function Deco(_ctx: InitContext) {
     `
     import manifest, { name } from "./manifest.gen.ts";
     import type { Manifest } from "./manifest.gen.ts";
-    export { name };
-    import type { App, AppContext as AC, AppModule } from "../deps.ts";
-
-    export const dependencies = [] satisfies AppModule[];
+    import type { App, FnContext } from "../deps.ts";
 
     export interface State {
       url: string;
@@ -18,12 +15,13 @@ export default async function Deco(_ctx: InitContext) {
       state: State,
     ): App<Manifest, State> {
       return {
+        name,
         manifest,
         state,
       };
     }
     
-    export type AppContext = AC<State, Manifest, typeof dependencies>;
+    export type AppContext = FnContext<State, Manifest>;
 `,
   );
 }

--- a/types.ts
+++ b/types.ts
@@ -19,14 +19,19 @@ import { PromiseOrValue } from "$live/engine/core/utils.ts";
 import { Release } from "$live/engine/releases/provider.ts";
 import { Route } from "$live/flags/audience.ts";
 import { createServerTimings } from "$live/utils/timings.ts";
-import { AppContext, AppManifest, AppRuntime, AppModule } from "./blocks/app.ts";
+import {
+  AppContext,
+  AppManifest,
+  AppModule,
+  AppRuntime,
+} from "./blocks/app.ts";
 import type { InvocationFunc } from "./clients/withManifest.ts";
 import type { Manifest as LiveManifest } from "./live.gen.ts";
 export type {
   ErrorBoundaryComponent,
   ErrorBoundaryParams,
 } from "$live/blocks/section.ts";
-export type { AppContext, AppManifest, AppRuntime, AppModule };
+export type { AppContext, AppManifest, AppModule, AppRuntime };
 
 export type { App } from "$live/blocks/app.ts";
 

--- a/types.ts
+++ b/types.ts
@@ -19,16 +19,16 @@ import { PromiseOrValue } from "$live/engine/core/utils.ts";
 import { Release } from "$live/engine/releases/provider.ts";
 import { Route } from "$live/flags/audience.ts";
 import { createServerTimings } from "$live/utils/timings.ts";
-import { AppManifest, AppRuntime } from "./blocks/app.ts";
+import { AppContext, AppManifest, AppRuntime } from "./blocks/app.ts";
 import type { InvocationFunc } from "./clients/withManifest.ts";
 import type { Manifest as LiveManifest } from "./live.gen.ts";
-export type { AppManifest, AppRuntime };
 export type {
   ErrorBoundaryComponent,
   ErrorBoundaryParams,
 } from "$live/blocks/section.ts";
+export type { AppContext, AppManifest, AppRuntime };
 
-export type { App, AppContext } from "$live/blocks/app.ts";
+export type { App } from "$live/blocks/app.ts";
 
 export type JSONSchema = JSONSchema7;
 export type JSONSchemaDefinition = JSONSchema7Definition;

--- a/types.ts
+++ b/types.ts
@@ -19,14 +19,14 @@ import { PromiseOrValue } from "$live/engine/core/utils.ts";
 import { Release } from "$live/engine/releases/provider.ts";
 import { Route } from "$live/flags/audience.ts";
 import { createServerTimings } from "$live/utils/timings.ts";
-import { AppContext, AppManifest, AppRuntime } from "./blocks/app.ts";
+import { AppContext, AppManifest, AppRuntime, AppModule } from "./blocks/app.ts";
 import type { InvocationFunc } from "./clients/withManifest.ts";
 import type { Manifest as LiveManifest } from "./live.gen.ts";
 export type {
   ErrorBoundaryComponent,
   ErrorBoundaryParams,
 } from "$live/blocks/section.ts";
-export type { AppContext, AppManifest, AppRuntime };
+export type { AppContext, AppManifest, AppRuntime, AppModule };
 
 export type { App } from "$live/blocks/app.ts";
 


### PR DESCRIPTION
Previously, it wasn't possible to use the manifest from defendant apps because it requires the self evaluation first. Now, when resolving dependencies the resolved dependencies will be available to resolve current app dependencies.