### PR TITLE
Allow string literals as keys on object from tsTypeElements.

### DIFF
--- a/engine/schema/transform.ts
+++ b/engine/schema/transform.ts
@@ -128,7 +128,7 @@ const tsTypeElementsToObjectSchemeable = async (
       continue;
     }
     const key = prop.key;
-    if (key.type !== "Identifier") {
+    if (key.type !== "Identifier" && key.type !== "StringLiteral") {
       continue;
     }
     keysPromise.push(


### PR DESCRIPTION
The current behavior involves an issue where TSTypes containing strings as keys are not being properly evaluated during transformation.

```
export interface Theme = {
"base-100": string,
primary: string,
}
```

Will generate an schema where `Theme` has only the `primary` property.

As a result of this, the generated schema for the Theme interface only includes the primary property.

This PR addresses this concern by rectifying the behavior. It ensures that both string properties are also processed appropriately during schema generation.