### PR TITLE
fix content security policy to receive requests by itself

### DIFF
--- a/utils/http.ts
+++ b/utils/http.ts
@@ -157,7 +157,7 @@ export function setCSPHeaders(
     "127.0.0.1:* localhost:* http://localhost:* http://127.0.0.1:*";
   response.headers.set(
     "Content-Security-Policy",
-    `default-src 'self' frame-ancestors ${localhost} ${adminDomain} ${
+    `default-src 'self'; frame-ancestors ${localhost} ${adminDomain} ${
       referer && isOnAdmin
         ? "https://" + referer.startsWith("http")
           ? new URL(referer).host

--- a/utils/http.ts
+++ b/utils/http.ts
@@ -157,7 +157,7 @@ export function setCSPHeaders(
     "127.0.0.1:* localhost:* http://localhost:* http://127.0.0.1:*";
   response.headers.set(
     "Content-Security-Policy",
-    `frame-ancestors ${localhost} ${adminDomain} ${
+    `default-src 'self' frame-ancestors ${localhost} ${adminDomain} ${
       referer && isOnAdmin
         ? "https://" + referer.startsWith("http")
           ? new URL(referer).host


### PR DESCRIPTION
To place an iframe inside the website pointing to the proxied pages, I need this rule to be changed