### PR TITLE
Add new manifest proxy utilities

### DIFF
--- a/blocks/app.ts
+++ b/blocks/app.ts
@@ -16,12 +16,17 @@ import { DecoManifest, FnContext } from "../types.ts";
 export type Apps = InstanceOf<AppRuntime, "#/root/apps">;
 export type SourceMap = Record<string, string | null>;
 export type AppManifest = Omit<DecoManifest, "islands" | "routes">;
-
-export type ManifestOf<TApp extends App> =
-  & TApp["manifest"]
-  & (TApp extends { dependencies?: (infer Depedendency)[] }
-    ? Depedendency extends App ? ManifestOf<Depedendency> : {}
+type MergeAppsManifest<TCurrent extends App, TDeps> =
+  & TCurrent["manifest"]
+  & (TDeps extends [infer TNext, ...infer Rest]
+    ? TNext extends App ? MergeAppsManifest<TNext, Rest>
+    : {}
     : {});
+
+export type ManifestOf<TApp extends App> = MergeAppsManifest<
+  TApp,
+  TApp["dependencies"] extends (infer Deps) | undefined ? Deps : []
+>;
 
 export type AppContext<
   TApp extends App,

--- a/blocks/utils.tsx
+++ b/blocks/utils.tsx
@@ -20,6 +20,7 @@ import type { Manifest } from "../live.gen.ts";
 import { context } from "../live.ts";
 import { HttpContext } from "./handler.ts";
 import { ErrorBoundaryComponent } from "./section.ts";
+import type { InvocationProxy } from '../routes/live/invoke/index.ts';
 
 export type SingleFlightKeyFunc<TConfig = any, TCtx = any> = (
   args: TConfig,
@@ -67,7 +68,11 @@ export type FnContext<
 > = TState & {
   response: { headers: Headers };
   get: ResolveFunc;
-  invoke: InvocationFunc<TManifest>;
+  invoke:
+    & InvocationProxy<
+      TManifest
+    >
+    & InvocationFunc<TManifest>;
 };
 
 export type FnProps<

--- a/clients/proxy.ts
+++ b/clients/proxy.ts
@@ -1,0 +1,46 @@
+// deno-lint-ignore-file no-explicit-any
+import { AppManifest } from "$live/mod.ts";
+import { Invoke, InvokeAwaiter } from "$live/routes/live/invoke/index.ts";
+import { invokeKey } from "./withManifest.ts";
+
+export type InvocationProxyHandler = {
+  (props?: any, init?: RequestInit | undefined): Promise<any>;
+  [key: string]: InvocationProxyHandler;
+};
+
+export type InvocationProxyState = Omit<InvocationProxyHandler, "__parts"> | {
+  __parts?: string[] | undefined;
+};
+
+export const newHandler = <TManifest extends AppManifest>(
+  invoker: typeof invokeKey,
+) => {
+  const handler = {
+    get: function (
+      target: InvocationProxyState,
+      part: string,
+    ): InvocationProxyState {
+      const currentParts = [...(target.__parts as string[]) ?? [], part];
+      const newTarget: InvocationProxyState = function (
+        props?: any,
+        init?: RequestInit | undefined,
+      ): InvokeAwaiter<TManifest, any, any> {
+        const ext = part === "x" ? "tsx" : "ts";
+        return new InvokeAwaiter<TManifest, any, any>(
+          (payload, init) => invoker(payload.key, payload.props, init),
+          {
+            key: `${currentParts.join("/")}.${ext}`,
+            props,
+          } as Invoke<TManifest, any, any>,
+          init,
+        );
+      } as InvocationProxyState;
+      newTarget.__parts = currentParts;
+      return new Proxy(
+        newTarget,
+        handler,
+      );
+    },
+  };
+  return handler;
+};

--- a/clients/withManifest.ts
+++ b/clients/withManifest.ts
@@ -1,19 +1,23 @@
+// deno-lint-ignore-file no-explicit-any
 import { IS_BROWSER } from "$fresh/runtime.ts";
-import type { StreamProps } from "../mod.ts";
 import type { App, AppManifest, ManifestOf } from "../blocks/app.ts";
+import type { StreamProps } from "../mod.ts";
 import type {
   AvailableActions,
   AvailableFunctions,
   AvailableLoaders,
+  InvocationProxy,
   Invoke,
+  InvokeAsPayload,
   InvokeResult,
   ManifestAction,
   ManifestFunction,
+  ManifestInvocable,
   ManifestLoader,
 } from "../routes/live/invoke/index.ts";
+import { InvokeAwaiter } from "../routes/live/invoke/index.ts";
 import type { DotNestedKeys } from "../utils/object.ts";
 
-// deno-lint-ignore no-explicit-any
 export type GenericFunction = (...args: any[]) => Promise<any>;
 
 export const isStreamProps = <TProps>(
@@ -137,6 +141,47 @@ export type InvocationFunc<TManifest extends AppManifest> = <
     TManifest
   >
 >;
+
+export type AvailableInvocations<TManifest extends AppManifest> =
+  | AvailableFunctions<TManifest>
+  | AvailableActions<TManifest>
+  | AvailableLoaders<TManifest>;
+
+export type InvocationFuncFor<
+  TManifest extends AppManifest,
+  TInvocableKey extends string,
+  TFuncSelector extends TInvocableKey extends AvailableFunctions<TManifest>
+    ? DotNestedKeys<ManifestFunction<TManifest, TInvocableKey>["return"]>
+    : TInvocableKey extends AvailableActions<TManifest>
+      ? DotNestedKeys<ManifestAction<TManifest, TInvocableKey>["return"]>
+    : TInvocableKey extends AvailableLoaders<TManifest>
+      ? DotNestedKeys<ManifestLoader<TManifest, TInvocableKey>["return"]>
+    : never = TInvocableKey extends AvailableFunctions<TManifest>
+      ? DotNestedKeys<ManifestFunction<TManifest, TInvocableKey>["return"]>
+      : TInvocableKey extends AvailableActions<TManifest>
+        ? DotNestedKeys<ManifestAction<TManifest, TInvocableKey>["return"]>
+      : TInvocableKey extends AvailableLoaders<TManifest>
+        ? DotNestedKeys<ManifestLoader<TManifest, TInvocableKey>["return"]>
+      : never,
+> = (
+  props?: Invoke<TManifest, TInvocableKey, TFuncSelector>["props"],
+) => InvokeAwaiter<TManifest, TInvocableKey, TFuncSelector>;
+
+const isInvokeAwaiter = <
+  TManifest extends AppManifest,
+  TInvocableKey extends string,
+  TFuncSelector extends DotNestedKeys<
+    ManifestInvocable<TManifest, TInvocableKey>["return"]
+  >,
+>(
+  invoke: unknown | InvokeAwaiter<TManifest, TInvocableKey, TFuncSelector>,
+): invoke is InvokeAwaiter<TManifest, TInvocableKey, TFuncSelector> => {
+  return (invoke as InvokeAwaiter<TManifest, TInvocableKey, TFuncSelector>)
+        ?.then !== undefined &&
+    (invoke as InvokeAwaiter<TManifest, TInvocableKey, TFuncSelector>)
+        ?.payload !== undefined;
+};
+
 /**
  * Receives the function id as a parameter (e.g `#FUNC_ID`, the `#` will be ignored)
  * or the function name as a parameter (e.g `deco-sites/std/functions/vtexProductList.ts`) and invoke the target function passing the provided `props` as the partial input for the function.
@@ -159,9 +204,11 @@ export const invoke = <
     : never,
   TPayload extends
     | Invoke<TManifest, TInvocableKey, TFuncSelector>
+    | InvokeAsPayload<TManifest, TInvocableKey, TFuncSelector>
     | Record<
       string,
-      Invoke<TManifest, TInvocableKey, TFuncSelector>
+      | Invoke<TManifest, TInvocableKey, TFuncSelector>
+      | InvokeAsPayload<TManifest, TInvocableKey, TFuncSelector>
     >,
 >(
   payload: TPayload,
@@ -171,7 +218,23 @@ export const invoke = <
     TPayload,
     TManifest
   >
-> => batchInvoke(payload, init);
+> => {
+  if (typeof payload === "object") {
+    const reqs: Record<
+      string,
+      Invoke<TManifest, TInvocableKey, TFuncSelector>
+    > = {};
+    for (const [key, val] of Object.entries(payload)) {
+      if (isInvokeAwaiter(val)) {
+        reqs[key] = val.payload;
+      } else {
+        reqs[key] = val;
+      }
+    }
+    return batchInvoke(reqs, init);
+  }
+  return batchInvoke(payload, init);
+};
 
 export const create = <
   TManifest extends AppManifest,
@@ -220,10 +283,82 @@ export const withManifest = <TManifest extends AppManifest>() => {
   };
 };
 
+type InvocationProxyHandler = {
+  (props?: any, init?: RequestInit | undefined): Promise<any>;
+  [key: string]: InvocationProxyHandler;
+};
+type InvocationProxyState = Omit<InvocationProxyHandler, "__parts"> | {
+  __parts?: string[] | undefined;
+};
+
+const newHandler = <TManifest extends AppManifest>() => {
+  const handler = {
+    get: function (
+      target: InvocationProxyState,
+      part: string,
+    ): InvocationProxyState {
+      const currentParts = [...(target.__parts as string[]) ?? [], part];
+      const newTarget: InvocationProxyState = function (
+        props?: any,
+        init?: RequestInit | undefined,
+      ): InvokeAwaiter<TManifest, any, any> {
+        const ext = part === "x" ? "tsx" : "ts";
+        return new InvokeAwaiter<TManifest, any, any>(
+          (payload, init) => invokeKey(payload.key, payload.props, init),
+          {
+            key: `${currentParts.join("/")}.${ext}`,
+            props,
+          } as Invoke<TManifest, any, any>,
+          init,
+        );
+      } as InvocationProxyState;
+      newTarget.__parts = currentParts;
+      return new Proxy(
+        newTarget,
+        handler,
+      );
+    },
+  };
+  return handler;
+};
+
+type InvocationProxyWithBatcher<TManifest extends AppManifest> =
+  & InvocationProxy<
+    TManifest
+  >
+  & ReturnType<typeof invoke<TManifest>>;
+/**
+ * Creates a proxy that lets you invoke functions based on the declared actions and loaders.
+ * @returns the created proxy.
+ */
+export const proxyFor = <TManifest extends AppManifest>(
+  invoker: typeof batchInvoke,
+): InvocationProxyWithBatcher<
+  TManifest
+> => {
+  return new Proxy<InvocationProxyHandler>(
+    invoker as InvocationProxyHandler,
+    newHandler<TManifest>(),
+  ) as unknown as InvocationProxyWithBatcher<
+    TManifest
+  >;
+};
+/**
+ * Creates a proxy that lets you invoke functions based on the declared actions and loaders.
+ * @returns the created proxy.
+ */
+export const proxy = <
+  TManifest extends AppManifest,
+>(): InvocationProxyWithBatcher<
+  TManifest
+> => {
+  return proxyFor(batchInvoke);
+};
+
 export const forApp = <
   TApp extends App,
 >() => {
-  return withManifest<
+  return proxy<
     ManifestOf<TApp>
   >();
 };

--- a/clients/withManifest.ts
+++ b/clients/withManifest.ts
@@ -317,10 +317,15 @@ export const proxy = <
   return proxyFor(batchInvoke);
 };
 
+/**
+ * Creates a proxy that lets you invoke functions based on the declared actions and loaders. (compatibility with old invoke)
+ */
 export const forApp = <
   TApp extends App,
 >() => {
-  return proxy<
-    ManifestOf<TApp>
-  >();
+  return {
+    invoke: proxy<
+      ManifestOf<TApp>
+    >(),
+  };
 };

--- a/import_map.json
+++ b/import_map.json
@@ -11,6 +11,7 @@
     "partytown/": "https://deno.land/x/partytown@0.3.0/",
     "std/": "https://deno.land/std@0.190.0/",
     "$fresh/": "https://denopkg.com/deco-cx/fresh@1.3.3/",
-    "$live/": "./"
+    "$live/": "./",
+    "deco/": "./"
   }
 }

--- a/routes/live/invoke/index.ts
+++ b/routes/live/invoke/index.ts
@@ -9,7 +9,6 @@ import type { UnionToIntersection } from "../../../deps.ts";
 import type { Resolvable } from "../../../engine/core/resolver.ts";
 import type { PromiseOrValue } from "../../../engine/core/utils.ts";
 import dfs from "../../../engine/fresh/defaults.ts";
-import type { Manifest } from "../../../live.gen.ts";
 import type { LiveConfig } from "../../../mod.ts";
 import type { LiveState } from "../../../types.ts";
 import { bodyFromUrl } from "../../../utils/http.ts";
@@ -324,8 +323,8 @@ const isInvokeFunc = (
   return (p as InvokeFunction).key !== undefined;
 };
 
-export const payloadForFunc = (
-  func: InvokeFunction<Manifest>,
+export const payloadForFunc = <TManifest extends AppManifest = AppManifest>(
+  func: InvokeFunction<TManifest>,
 ) => ({
   keys: func.select,
   obj: {

--- a/routes/live/invoke/index.ts
+++ b/routes/live/invoke/index.ts
@@ -35,8 +35,8 @@ type PathToDots<
   : { [key in TRest]: InvocationFuncFor<TManifest, `${Current}/${TRest}`> };
 
 type AllTypesOf<TManifest extends AppManifest, App extends string> =
-  AvailableInvocations<TManifest> extends `${App}/${infer type}/${string}`
-    ? type
+  AvailableInvocations<TManifest> & `${App}/${string}` extends
+    `${App}/${infer type}/${string}` ? type
     : never;
 /**
  * Promise.prototype.then onfufilled callback type.

--- a/routes/live/invoke/index.ts
+++ b/routes/live/invoke/index.ts
@@ -1,16 +1,127 @@
 // deno-lint-ignore-file no-explicit-any
-import { HandlerContext } from "$fresh/src/server/types.ts";
-import { AppManifest } from "../../../blocks/app.ts";
-import { UnionToIntersection } from "../../../deps.ts";
-import { Resolvable } from "../../../engine/core/resolver.ts";
-import { PromiseOrValue } from "../../../engine/core/utils.ts";
+import type { HandlerContext } from "$fresh/src/server/types.ts";
+import {
+  AvailableInvocations,
+  InvocationFuncFor,
+} from "$live/clients/withManifest.ts";
+import type { AppManifest } from "../../../blocks/app.ts";
+import type { UnionToIntersection } from "../../../deps.ts";
+import type { Resolvable } from "../../../engine/core/resolver.ts";
+import type { PromiseOrValue } from "../../../engine/core/utils.ts";
 import dfs from "../../../engine/fresh/defaults.ts";
 import type { Manifest } from "../../../live.gen.ts";
-import { LiveConfig } from "../../../mod.ts";
+import type { LiveConfig } from "../../../mod.ts";
 import type { LiveState } from "../../../types.ts";
 import { bodyFromUrl } from "../../../utils/http.ts";
 import { invokeToHttpResponse } from "../../../utils/invoke.ts";
-import { DeepPick, DotNestedKeys } from "../../../utils/object.ts";
+import type { DeepPick, DotNestedKeys } from "../../../utils/object.ts";
+
+type AppsOf<TManifest extends AppManifest> = (
+  AvailableInvocations<TManifest>
+) extends `${infer app}/${"loaders" | "actions" | "functions"}/${string}` ? app
+  : never;
+type PathToDots<
+  TRest extends string,
+  Current extends string,
+  TManifest extends AppManifest,
+> = TRest extends `${infer part}/${infer rest}`
+  ? { [key in part]: PathToDots<rest, `${Current}/${part}`, TManifest> }
+  : TRest extends `${infer name}.ts`
+    ? { [key in name]: InvocationFuncFor<TManifest, `${Current}/${TRest}`> }
+  : TRest extends `${infer name}.tsx` ? {
+      [key in name]: {
+        "x": InvocationFuncFor<TManifest, `${Current}/${TRest}`>;
+      };
+    }
+  : { [key in TRest]: InvocationFuncFor<TManifest, `${Current}/${TRest}`> };
+
+type AllTypesOf<TManifest extends AppManifest, App extends string> =
+  AvailableInvocations<TManifest> extends `${App}/${infer type}/${string}`
+    ? type
+    : never;
+/**
+ * Promise.prototype.then onfufilled callback type.
+ */
+type Fulfilled<R, T> = ((result: R) => T | PromiseLike<T>) | null;
+
+/**
+ * Promise.then onrejected callback type.
+ */
+type Rejected<E> = ((reason: any) => E | PromiseLike<E>) | null;
+
+export interface InvokeAsPayload<
+  TManifest extends AppManifest,
+  TInvocableKey extends string,
+  TFuncSelector extends DotNestedKeys<
+    ManifestInvocable<TManifest, TInvocableKey>["return"]
+  >,
+> {
+  payload: Invoke<TManifest, TInvocableKey, TFuncSelector>;
+}
+
+export class InvokeAwaiter<
+  TManifest extends AppManifest,
+  TInvocableKey extends string,
+  TFuncSelector extends DotNestedKeys<
+    ManifestInvocable<TManifest, TInvocableKey>["return"]
+  >,
+> implements
+  PromiseLike<
+    InvokeResult<
+      Invoke<TManifest, TInvocableKey, TFuncSelector>,
+      TManifest
+    >
+  >,
+  InvokeAsPayload<TManifest, TInvocableKey, TFuncSelector> {
+  constructor(
+    protected invoker: (
+      payload: Invoke<TManifest, TInvocableKey, TFuncSelector>,
+      init: RequestInit | undefined,
+    ) => Promise<
+      InvokeResult<Invoke<TManifest, TInvocableKey, TFuncSelector>, TManifest>
+    >,
+    public payload: Invoke<TManifest, TInvocableKey, TFuncSelector>,
+    protected init?: RequestInit | undefined,
+  ) {
+  }
+
+  public get() {
+    return this.payload;
+  }
+
+  then<TResult1, TResult2 = TResult1>(
+    onfufilled?: Fulfilled<
+      InvokeResult<
+        Invoke<TManifest, TInvocableKey, TFuncSelector>,
+        TManifest
+      >,
+      TResult1
+    >,
+    onrejected?: Rejected<TResult2>,
+  ): Promise<TResult1 | TResult2> {
+    return this.invoker(this.payload, this.init).then(onfufilled).catch(
+      onrejected,
+    );
+  }
+}
+type InvocationObj<TManifest extends AppManifest> = {
+  [app in AppsOf<TManifest>]: {
+    [type in AllTypesOf<TManifest, app>]:
+      AvailableInvocations<TManifest> & `${app}/${type}/${string}` extends
+        `${app}/${type}/${infer rest}` ? UnionToIntersection<
+          PathToDots<
+            rest,
+            `${app}/${type}`,
+            TManifest
+          >
+        >
+        : never;
+  };
+};
+
+export type InvocationProxy<TManifest extends AppManifest> = InvocationObj<
+  TManifest
+>;
 
 export type AvailableFunctions<TManifest extends AppManifest> =
   & keyof TManifest["functions"]
@@ -184,16 +295,20 @@ export type DotNestedReturn<
 export type InvokeResult<
   TPayload extends
     | Invoke<TManifest, any, any>
+    | InvokeAsPayload<TManifest, any, any>
     | Record<
       string,
-      Invoke<TManifest, any, any>
+      Invoke<TManifest, any, any> | InvokeAsPayload<TManifest, any, any>
     >,
   TManifest extends AppManifest = AppManifest,
-> = TPayload extends Invoke<TManifest, infer TFunc, any>
+> = TPayload extends
+  | Invoke<TManifest, infer TFunc, any>
+  | InvokeAsPayload<TManifest, infer TFunc, any>
   ? ReturnWith<ManifestInvocable<TManifest, TFunc>["return"], TPayload>
   : TPayload extends Record<string, any> ? {
       [key in keyof TPayload]: TPayload[key] extends
-        Invoke<TManifest, infer TFunc, any> ? ReturnWith<
+        | Invoke<TManifest, infer TFunc, any>
+        | InvokeAsPayload<TManifest, infer TFunc, any> ? ReturnWith<
           ManifestInvocable<TManifest, TFunc>["return"],
           TPayload[key]
         >

--- a/scripts/apps/serve.ts
+++ b/scripts/apps/serve.ts
@@ -9,6 +9,7 @@ import { join, toFileUrl } from "std/path/mod.ts";
 import { getDecoConfig } from "./config.ts";
 import { AppManifest, SourceMap } from "deco/blocks/app.ts";
 
+const site = Deno.args[0] ?? "playground";
 const { apps = [] } = await getDecoConfig(Deno.cwd());
 
 const runningApps: AppManifest = {
@@ -20,7 +21,7 @@ const runningApps: AppManifest = {
 const sourceMap: SourceMap = {};
 
 for (const app of apps) {
-  const appTs = `${app.name}/apps/mod.ts`;
+  const appTs = `${site}/apps/${app.name}.ts`;
   const appFolder = join(Deno.cwd(), app.dir, "mod.ts");
   runningApps.apps![appTs] = await import(
     appFolder
@@ -36,7 +37,7 @@ await start({
     decoPlugin({
       sourceMap,
       manifest: runningApps,
-      site: { namespace: Deno.args[0] ?? "playground" },
+      site: { namespace: site },
     }),
   ],
 });

--- a/scripts/apps/serve.ts
+++ b/scripts/apps/serve.ts
@@ -1,0 +1,34 @@
+/// <reference no-default-lib="true"/>
+/// <reference lib="dom" />
+/// <reference lib="deno.ns" />
+/// <reference lib="esnext" />
+
+import { start } from "$fresh/server.ts";
+import decoPlugin from "deco/plugins/deco.ts";
+import { join, toFileUrl } from "std/path/mod.ts";
+
+const appFolder = join(Deno.cwd(), Deno.args[0]);
+await start({
+  islands: {},
+  routes: {},
+  baseUrl: toFileUrl(join(appFolder, "fresh.gen.ts")).toString(),
+}, {
+  plugins: [
+    decoPlugin({
+      sourceMap: {
+        [`${Deno.args[0]}/apps/mod.ts`]: toFileUrl(join(appFolder, "mod.ts"))
+          .toString(),
+      },
+      manifest: {
+        baseUrl: toFileUrl(join(appFolder, "manifest.gen.ts")).toString(),
+        name: Deno.args[0],
+        apps: {
+          [`${Deno.args[0]}/apps/mod.ts`]: await import(
+            join(appFolder, "mod.ts")
+          ),
+        },
+      },
+      site: { namespace: Deno.args[1] ?? Deno.args[0] },
+    }),
+  ],
+});

--- a/scripts/apps/templates/app.mod.ts.ts
+++ b/scripts/apps/templates/app.mod.ts.ts
@@ -6,7 +6,7 @@ export default async function AppMod(_ctx: InitContext) {
     `
     import manifest from "./manifest.gen.ts";
     import type { Manifest } from "./manifest.gen.ts";
-    import type { App, AppContext as AC } from "../deps.ts";
+    import type { App, AppContext as AC } from "deco/mod.ts";
 
     export interface State {
       url: string;

--- a/scripts/apps/templates/deno.json.ts
+++ b/scripts/apps/templates/deno.json.ts
@@ -11,6 +11,7 @@ export default function DenoJson(_ctx: InitContext) {
           "start": "deno eval 'import \"$live/scripts/apps/bundle.ts\"'",
           "link": "deno eval 'import \"$live/scripts/apps/link.ts\"'",
           "unlink": "deno eval 'import \"$live/scripts/apps/unlink.ts\"'",
+          "serve": "deno eval 'import \"$live/scripts/apps/serve.ts\"'"
         },
         "githooks": {
           "pre-commit": "check",

--- a/scripts/apps/templates/deno.json.ts
+++ b/scripts/apps/templates/deno.json.ts
@@ -7,11 +7,11 @@ export default function DenoJson(_ctx: InitContext) {
         "lock": false,
         "tasks": {
           "check": "deno fmt && deno lint",
-          "release": "deno eval 'import \"$live/scripts/release.ts\"'",
-          "start": "deno eval 'import \"$live/scripts/apps/bundle.ts\"'",
-          "link": "deno eval 'import \"$live/scripts/apps/link.ts\"'",
-          "unlink": "deno eval 'import \"$live/scripts/apps/unlink.ts\"'",
-          "serve": "deno eval 'import \"$live/scripts/apps/serve.ts\"'"
+          "release": "deno eval 'import \"deco/scripts/release.ts\"'",
+          "start": "deno eval 'import \"deco/scripts/apps/bundle.ts\"'",
+          "link": "deno eval 'import \"deco/scripts/apps/link.ts\"'",
+          "unlink": "deno eval 'import \"deco/scripts/apps/unlink.ts\"'",
+          "serve": "deno eval 'import \"deco/scripts/apps/serve.ts\"'",
         },
         "githooks": {
           "pre-commit": "check",

--- a/scripts/apps/templates/deps.ts.ts
+++ b/scripts/apps/templates/deps.ts.ts
@@ -1,8 +1,0 @@
-import { format } from "../../../utils/formatter.ts";
-import { InitContext } from "../init.ts";
-
-export default async function DepsTs({ decoVersion }: InitContext) {
-  return await format(
-    `export * from "https://denopkg.com/deco-cx/deco@${decoVersion}/mod.ts";`,
-  );
-}

--- a/scripts/apps/templates/import_map.json.ts
+++ b/scripts/apps/templates/import_map.json.ts
@@ -7,7 +7,8 @@ export default function ImportMapJSON(
     {
       "imports": {
         "$live/": `https://denopkg.com/deco-cx/deco@${decoVersion}/`,
-        "$fresh/": "https://denopkg.com/deco-cx/fresh@1.3.3/",
+        "deco/": `https://denopkg.com/deco-cx/deco@${decoVersion}/`,
+        "$fresh/": "https://denopkg.com/deco-cx/fresh@1.3.6/",
         "preact": "https://esm.sh/preact@10.15.1",
         "preact/": "https://esm.sh/preact@10.15.1/",
         "preact-render-to-string":
@@ -15,6 +16,7 @@ export default function ImportMapJSON(
         "@preact/signals": "https://esm.sh/*@preact/signals@1.1.3",
         "@preact/signals-core": "https://esm.sh/@preact/signals-core@1.3.0",
         "std/": "https://deno.land/std@0.190.0/",
+        "partytown/": "https://deno.land/x/partytown@0.3.0/",
       },
     },
     null,

--- a/types.ts
+++ b/types.ts
@@ -26,6 +26,7 @@ import { PromiseOrValue } from "./engine/core/utils.ts";
 import { Release } from "./engine/releases/provider.ts";
 import { Route } from "./flags/audience.ts";
 import { createServerTimings } from "./utils/timings.ts";
+import type { InvocationProxy } from "./routes/live/invoke/index.ts";
 export type {
   ErrorBoundaryComponent,
   ErrorBoundaryParams,
@@ -99,7 +100,11 @@ export type LiveConfig<
     $live: TConfig;
     resolve: ResolveFunc;
     release: Release;
-    invoke: InvocationFunc<TManifest>;
+    invoke:
+      & InvocationProxy<
+        TManifest
+      >
+      & InvocationFunc<TManifest>;
     routes?: Route[];
     manifest: TManifest;
     sourceMap: SourceMap;

--- a/utils/update.ts
+++ b/utils/update.ts
@@ -8,7 +8,7 @@ import { join } from "std/path/mod.ts";
 import { stringifyForWrite } from "../utils/json.ts";
 
 // map of `packageAlias` to `packageRepo`
-const PACKAGES_TO_CHECK = /(\$live)|(deco-sites\/.*\/$)/;
+const PACKAGES_TO_CHECK = /(deco)|(\$live)|(deco-sites\/.*\/$)/;
 
 interface ImportMap {
   imports: Record<string, string>;


### PR DESCRIPTION
Big improvements around DevX using invoke:

previously:

```ts
ctx.invoke("$live/actions/secrets/encrypt.ts", {})
```
Now:

```ts
const result = await ctx.invoke.$live.actions.secrets.encrypt({})
```

This change is backwards compatible because the invoke itself is a function.

Also you can batch requests using the same signature

```ts
const {cart} = await ctx.invoke({
     cart: ctx.invoke.vtex.loaders.cart({}),
})
```
This is only possible because `InvokeAwaiter` implements `PromiseLike` so we can defer the trigger of the request until the `await` is used, in case of batching the function will return the payload.

PS: Took the opportunity to add a `serve.ts` app command (sorry for the mess)