### PR TITLE
Expose path template & add observability on middlewares

### DIFF
--- a/blocks/function.ts
+++ b/blocks/function.ts
@@ -5,7 +5,7 @@ import { newSingleFlightGroup, SingleFlightKeyFunc } from "../blocks/utils.tsx";
 import JsonViewer from "../components/JsonViewer.tsx";
 import { HandlerContext } from "../deps.ts";
 import { Block, BlockModule } from "../engine/block.ts";
-import { LiveConfig, LoaderFunction } from "../types.ts";
+import { DecoState, LoaderFunction } from "../types.ts";
 
 export type Function<TProps = any, TState = any> = LoaderFunction<
   TProps,
@@ -45,7 +45,7 @@ const functionBlock: Block<FunctionModule> = {
             ...ctx.context.state,
             $live,
             resolve: ctx.resolve,
-          } as LiveConfig<any, any>,
+          } as DecoState<any, any>,
         },
         $live,
       );

--- a/blocks/handler.ts
+++ b/blocks/handler.ts
@@ -3,15 +3,15 @@ import { Handler as DenoHandler, ServeHandler } from "../deps.ts";
 import { Block, BlockModule, InstanceOf } from "../engine/block.ts";
 import { BaseContext } from "../engine/core/resolver.ts";
 import { PromiseOrValue } from "../engine/core/utils.ts";
-import { LiveConfig, StatefulContext } from "../types.ts";
+import { DecoState, StatefulContext } from "../types.ts";
 import { FnContext, fnContextFromHttpContext } from "./utils.tsx";
 
 export interface HttpContext<
   // deno-lint-ignore ban-types
   State = {},
   TConfig = any,
-  TCtx extends StatefulContext<LiveConfig<TConfig, State>> = StatefulContext<
-    LiveConfig<TConfig, State>
+  TCtx extends StatefulContext<DecoState<TConfig, State>> = StatefulContext<
+    DecoState<TConfig, State>
   >,
 > extends BaseContext {
   context: TCtx;

--- a/blocks/route.ts
+++ b/blocks/route.ts
@@ -27,7 +27,7 @@ import {
   payloadForFunc,
 } from "../routes/live/invoke/index.ts";
 import { setLogger } from "../runtime/fetch/fetchLog.ts";
-import { AppManifest, DecoManifest, LiveConfig, LiveState } from "../types.ts";
+import { AppManifest, DecoManifest, DecoState, DecoSiteState } from "../types.ts";
 import { formatIncomingRequest } from "../utils/log.ts";
 import { createServerTimings } from "../utils/timings.ts";
 import { SourceMap } from "./app.ts";
@@ -159,7 +159,7 @@ export const buildDecoState = <TManifest extends AppManifest = AppManifest>(
 ) =>
   async function (
     request: Request,
-    context: MiddlewareHandlerContext<LiveConfig<any, LiveState, TManifest>>,
+    context: MiddlewareHandlerContext<DecoState<any, DecoSiteState, TManifest>>,
   ) {
     context.state.sourceMap ??= sourceMap;
     const { enabled, action } = debug.fromRequest(request);
@@ -253,10 +253,10 @@ export const buildDecoState = <TManifest extends AppManifest = AppManifest>(
     return resp;
   };
 const mapMiddleware = (
-  mid: MiddlewareHandler<LiveConfig<any, LiveState>> | MiddlewareHandler<
-    LiveConfig<any, LiveState>
+  mid: MiddlewareHandler<DecoState<any, DecoSiteState>> | MiddlewareHandler<
+    DecoState<any, DecoSiteState>
   >[],
-): MiddlewareHandler<LiveConfig<any, LiveState>>[] => {
+): MiddlewareHandler<DecoState<any, DecoSiteState>>[] => {
   return [buildDecoState(middlewareKey), ...Array.isArray(mid) ? mid : [mid]];
 };
 
@@ -268,7 +268,7 @@ export const injectLiveStateForPath = (
     return mapObjKeys(handlers, (val) => {
       return withErrorHandler(path, async function (
         request: Request,
-        context: HandlerContext<any, LiveConfig<any, LiveState>>,
+        context: HandlerContext<any, DecoState<any, DecoSiteState>>,
       ) {
         const $live = await context?.state?.resolve?.(
           indexTsxToCatchAll[path] ?? path,
@@ -282,7 +282,7 @@ export const injectLiveStateForPath = (
   }
   return withErrorHandler(path, async function (
     request: Request,
-    context: HandlerContext<any, LiveConfig<any, LiveState>>,
+    context: HandlerContext<any, DecoState<any, DecoSiteState>>,
   ) {
     const $live = (await context?.state?.resolve?.(
       indexTsxToCatchAll[path] ?? path,
@@ -302,7 +302,7 @@ export type Route<TProps = any> = ComponentFunc<PageProps<TProps>>;
 export interface RouteMod extends BlockModule {
   handler?: (
     request: Request,
-    context: HandlerContext<any, LiveConfig>,
+    context: HandlerContext<any, DecoState>,
   ) => Promise<Response>;
   default: Route;
 }
@@ -316,7 +316,7 @@ const routeBlock: Block<RouteMod> = {
         handler: mapMiddleware(
           (routeModule as unknown as MiddlewareModule)
             .handler as MiddlewareHandler<
-              LiveConfig<any, LiveState>
+              DecoState<any, DecoSiteState>
             >,
         ),
       };

--- a/blocks/workflow.ts
+++ b/blocks/workflow.ts
@@ -19,7 +19,7 @@ import {
   ManifestFunction,
   ManifestLoader,
 } from "../routes/live/invoke/index.ts";
-import { AppManifest, LiveConfig, LiveState } from "../types.ts";
+import { AppManifest, DecoState, DecoSiteState } from "../types.ts";
 import { DotNestedKeys } from "../utils/object.ts";
 import { HttpContext } from "./handler.ts";
 import { FnContext, fnContextFromHttpContext } from "./utils.tsx";
@@ -32,7 +32,7 @@ export class WorkflowContext<
   TMetadata extends WorkflowMetadata = WorkflowMetadata,
 > extends DurableWorkflowContext<TMetadata> {
   constructor(
-    protected ctx: LiveConfig<unknown, LiveState, TManifest>,
+    protected ctx: DecoState<unknown, DecoSiteState, TManifest>,
     execution: WorkflowExecution<Arg, unknown, TMetadata>,
   ) {
     super(execution);

--- a/engine/manifest/manifest.ts
+++ b/engine/manifest/manifest.ts
@@ -14,7 +14,7 @@ import { integrityCheck } from "../../engine/integrity.ts";
 import defaultResolvers from "../../engine/manifest/defaults.ts";
 import { getComposedConfigStore } from "../../engine/releases/provider.ts";
 import { context } from "../../live.ts";
-import { LiveConfig } from "../../types.ts";
+import { DecoState } from "../../types.ts";
 
 import { parse } from "std/flags/mod.ts";
 import { AppManifest } from "../../blocks/app.ts";
@@ -31,12 +31,12 @@ export type FreshHandler<
   Resp = Response,
 > = (
   request: Request,
-  ctx: HandlerContext<TData, LiveConfig<TState, TConfig>>,
+  ctx: HandlerContext<TData, DecoState<TState, TConfig>>,
 ) => PromiseOrValue<Resp>;
 
 export interface FreshContext<Data = any, State = any, TConfig = any>
   extends BaseContext {
-  context: HandlerContext<Data, LiveConfig<State, TConfig>>;
+  context: HandlerContext<Data, DecoState<State, TConfig>>;
   request: Request;
 }
 

--- a/handlers/fresh.ts
+++ b/handlers/fresh.ts
@@ -1,7 +1,7 @@
 import { HandlerContext } from "$fresh/server.ts";
 import { ConnInfo } from "std/http/server.ts";
 import { Page } from "../blocks/page.ts";
-import { LiveConfig } from "../types.ts";
+import { DecoState } from "../types.ts";
 import { allowCorsFor } from "../utils/http.ts";
 
 /**
@@ -27,7 +27,7 @@ export default function Fresh(page: FreshConfig) {
     if (url.searchParams.get("asJson") !== null) {
       return Response.json(page, { headers: allowCorsFor(req) });
     }
-    if (isFreshCtx<LiveConfig>(ctx)) {
+    if (isFreshCtx<DecoState>(ctx)) {
       return await ctx.render({
         ...page,
         routerInfo: {

--- a/handlers/fresh.ts
+++ b/handlers/fresh.ts
@@ -1,7 +1,7 @@
 import { HandlerContext } from "$fresh/server.ts";
 import { ConnInfo } from "std/http/server.ts";
 import { Page } from "../blocks/page.ts";
-import { RouterContext } from "../types.ts";
+import { LiveConfig } from "../types.ts";
 import { allowCorsFor } from "../utils/http.ts";
 
 /**
@@ -27,8 +27,14 @@ export default function Fresh(page: FreshConfig) {
     if (url.searchParams.get("asJson") !== null) {
       return Response.json(page, { headers: allowCorsFor(req) });
     }
-    if (isFreshCtx<{ routerInfo: RouterContext }>(ctx)) {
-      return await ctx.render({ ...page, routerInfo: ctx.state.routerInfo });
+    if (isFreshCtx<LiveConfig>(ctx)) {
+      return await ctx.render({
+        ...page,
+        routerInfo: {
+          flags: ctx.state.flags,
+          pagePath: ctx.state.pathTemplate,
+        },
+      });
     }
     return Response.json({ message: "Fresh is not being used" }, {
       status: 500,

--- a/handlers/routesSelection.ts
+++ b/handlers/routesSelection.ts
@@ -2,15 +2,15 @@ import { ConnInfo, Handler } from "std/http/server.ts";
 import { ResolveOptions } from "../engine/core/mod.ts";
 import {
   BaseContext,
-  isDeferred,
   Resolvable,
   ResolveFunc,
+  isDeferred,
 } from "../engine/core/resolver.ts";
 import { isAwaitable } from "../engine/core/utils.ts";
 import { Route, Routes } from "../flags/audience.ts";
 import { isFreshCtx } from "../handlers/fresh.ts";
 import { observe } from "../observability/observe.ts";
-import { Flag, LiveState, RouterContext } from "../types.ts";
+import { LiveConfig, LiveState } from "../types.ts";
 
 export interface SelectionConfig {
   audiences: Routes[];
@@ -62,18 +62,11 @@ export const router = (
     ) => {
       const ctx = { ...connInfo, params: (groups ?? {}) } as ConnInfo & {
         params: Record<string, string>;
-        state: {
-          routes: Route[];
-          routerInfo: RouterContext;
-          flags: Flag[];
-        };
+        state: LiveConfig;
       };
 
       ctx.state.routes = routes;
-      ctx.state.routerInfo = {
-        flags: ctx.state.flags,
-        pagePath: routePath,
-      };
+      ctx.state.pathTemplate = routePath;
 
       const resolvedOrPromise =
         isDeferred<Handler, { context: typeof ctx } & BaseContext>(handler)

--- a/handlers/routesSelection.ts
+++ b/handlers/routesSelection.ts
@@ -2,15 +2,15 @@ import { ConnInfo, Handler } from "std/http/server.ts";
 import { ResolveOptions } from "../engine/core/mod.ts";
 import {
   BaseContext,
+  isDeferred,
   Resolvable,
   ResolveFunc,
-  isDeferred,
 } from "../engine/core/resolver.ts";
 import { isAwaitable } from "../engine/core/utils.ts";
 import { Route, Routes } from "../flags/audience.ts";
 import { isFreshCtx } from "../handlers/fresh.ts";
 import { observe } from "../observability/observe.ts";
-import { LiveConfig, LiveState } from "../types.ts";
+import { DecoState, DecoSiteState } from "../types.ts";
 
 export interface SelectionConfig {
   audiences: Routes[];
@@ -62,7 +62,7 @@ export const router = (
     ) => {
       const ctx = { ...connInfo, params: (groups ?? {}) } as ConnInfo & {
         params: Record<string, string>;
-        state: LiveConfig;
+        state: DecoState;
       };
 
       ctx.state.routes = routes;
@@ -163,7 +163,7 @@ export default function RoutesSelection(
   ctx: { get: ResolveFunc },
 ): Handler {
   return async (req: Request, connInfo: ConnInfo): Promise<Response> => {
-    const t = isFreshCtx<LiveState>(connInfo) ? connInfo.state.t : undefined;
+    const t = isFreshCtx<DecoSiteState>(connInfo) ? connInfo.state.t : undefined;
 
     // everyone should come first in the list given that we override the everyone value with the upcoming flags.
     const [routes, hrefRoutes] = buildRoutes(audiences);

--- a/handlers/workflowRunner.ts
+++ b/handlers/workflowRunner.ts
@@ -3,7 +3,7 @@ import { Handler } from "../blocks/handler.ts";
 import { Workflow, WorkflowContext } from "../blocks/workflow.ts";
 import { workflowHTTPHandler } from "../deps.ts";
 import type { Manifest } from "../live.gen.ts";
-import { LiveConfig, LiveState } from "../mod.ts";
+import { DecoState, DecoSiteState } from "../mod.ts";
 import { isFreshCtx } from "./fresh.ts";
 export interface Config {
   workflow: Workflow;
@@ -11,7 +11,7 @@ export interface Config {
 
 export default function WorkflowHandler({ workflow }: Config): Handler {
   return (req: Request, conn: ConnInfo) => {
-    if (isFreshCtx<LiveConfig<unknown, LiveState, Manifest>>(conn)) {
+    if (isFreshCtx<DecoState<unknown, DecoSiteState, Manifest>>(conn)) {
       const handler = workflowHTTPHandler(
         workflow,
         (exec) => new WorkflowContext(conn.state, exec),

--- a/observability/http.ts
+++ b/observability/http.ts
@@ -1,0 +1,33 @@
+import { client } from "./client.ts";
+import { defaultLabels, defaultLabelsValues } from "./labels.ts";
+
+const httpLabels = [
+  "method",
+  "path",
+  "status",
+  ...defaultLabels,
+];
+
+const httpDuration = new client.Histogram({
+  name: "http_request_duration",
+  help: "http request duration",
+  buckets: [100, 500, 1000, 5000],
+  labelNames: httpLabels,
+});
+
+/**
+ * @returns a end function that when gets called observe the duration of the operation.
+ */
+export const startObserve = () => {
+  const start = performance.now();
+  return (method: string, path: string, status: number) => {
+    httpDuration.labels({
+      method,
+      path,
+      status: `${status}`,
+      ...defaultLabelsValues,
+    }).observe(
+      performance.now() - start,
+    );
+  };
+};

--- a/observability/labels.ts
+++ b/observability/labels.ts
@@ -1,0 +1,27 @@
+import { context } from "../mod.ts";
+import meta from "../meta.json" assert { type: "json" };
+
+export const defaultLabels = [
+  "deployment_id",
+  "site",
+  "deco_ver",
+  "apps_ver",
+];
+
+const tryGetVersionOf = (pkg: string) => {
+  try {
+    const [_, ver] = import.meta.resolve(pkg).split("@");
+    return ver.substring(0, ver.length - 1);
+  } catch {
+    return undefined;
+  }
+};
+const apps_ver = tryGetVersionOf("apps/") ??
+  tryGetVersionOf("deco-sites/std/") ?? "_";
+
+export const defaultLabelsValues = {
+  deployment_id: context.deploymentId ?? Deno.hostname(),
+  site: context.site,
+  deco_ver: meta.version,
+  apps_ver,
+};

--- a/observability/observe.ts
+++ b/observability/observe.ts
@@ -1,37 +1,111 @@
-import { shouldCollectMetrics } from "../observability/metrics.ts";
 import { isWrappedError } from "../blocks/loader.ts";
 import meta from "../meta.json" assert { type: "json" };
 import { context } from "../mod.ts";
+import { shouldCollectMetrics } from "../observability/metrics.ts";
 import { client } from "./client.ts";
 
 const defaultLabels = [
-  "op",
-  "is_error",
   "deployment_id",
   "site",
   "deco_ver",
   "apps_ver",
-  "fresh_ver",
 ];
+
+const opLabels = [
+  "op",
+  "is_error",
+  ...defaultLabels,
+];
+
+type SystemInfoMemoryKey = keyof ReturnType<typeof Deno["systemMemoryInfo"]>;
+const systemMemoryToBeCollected: Array<
+  SystemInfoMemoryKey
+> = [
+  "available",
+  "buffers",
+  "cached",
+  "free",
+  "swapFree",
+  "swapTotal",
+  "total",
+];
+
+type MemoryInfoKey = keyof ReturnType<typeof Deno["memoryUsage"]>;
+
+const memoryInfoToBeCollected: Array<
+  MemoryInfoKey
+> = [
+  "external",
+  "heapTotal",
+  "heapUsed",
+  "rss",
+];
+
+const systemMemoryGauges: Partial<Record<SystemInfoMemoryKey, client.Gauge>> =
+  {};
+
+for (const memKey of systemMemoryToBeCollected) {
+  systemMemoryGauges[memKey] = new client.Gauge({
+    name: `isolate_system_memory_${memKey}_usage`,
+    help: `the isolate system memory ${memKey} usage`,
+    labelNames: defaultLabels,
+  });
+}
+
+const memoryGauges: Partial<Record<MemoryInfoKey, client.Gauge>> = {};
+
+for (const memKey of memoryInfoToBeCollected) {
+  memoryGauges[memKey] = new client.Gauge({
+    name: `isolate_v8_memory_${memKey}_usage`,
+    help: `the isolate v8 memory ${memKey} usage`,
+    labelNames: defaultLabels,
+  });
+}
 
 const operationDuration = new client.Histogram({
   name: "block_op_duration",
   help: "block operations duration",
-  buckets: [1, 10, 100, 500, 1000, 5000],
-  labelNames: defaultLabels,
+  buckets: [100, 500, 1000, 5000],
+  labelNames: opLabels,
 });
 
 const tryGetVersionOf = (pkg: string) => {
   try {
     const [_, ver] = import.meta.resolve(pkg).split("@");
-    return `${pkg}@${ver.substring(0, ver.length - 1)}`;
+    return ver.substring(0, ver.length - 1);
   } catch {
     return undefined;
   }
 };
 const apps_ver = tryGetVersionOf("apps/") ??
   tryGetVersionOf("deco-sites/std/") ?? "_";
-const fresh_ver = tryGetVersionOf("$fresh/") ?? "_";
+
+/**
+ * TODO (mcandeia) currently Deno deploy does not return valid values for this.
+ * Collects the current memory usage.
+ */
+export const collectMemoryUsage = () => {
+  const systemMemoryInfo = Deno
+    .systemMemoryInfo();
+
+  for (const memKey of systemMemoryToBeCollected) {
+    systemMemoryGauges[memKey]?.set({
+      deployment_id: context.deploymentId,
+      site: context.site,
+      deco_ver: meta.version,
+      apps_ver,
+    }, systemMemoryInfo[memKey]);
+  }
+  const memoryUsage = Deno.memoryUsage();
+  for (const memKey of memoryInfoToBeCollected) {
+    memoryGauges[memKey]?.set({
+      deployment_id: context.deploymentId,
+      site: context.site,
+      deco_ver: meta.version,
+      apps_ver,
+    }, memoryUsage[memKey]);
+  }
+};
 /**
  * Observe function durations based on the provided labels
  */
@@ -62,7 +136,6 @@ export const observe = async <T>(
       site: context.site,
       deco_ver: meta.version,
       apps_ver,
-      fresh_ver,
     }).observe(
       performance.now() - start,
     );

--- a/observability/observe.ts
+++ b/observability/observe.ts
@@ -82,33 +82,16 @@ export const collectMemoryUsage = () => {
 };
 
 /**
- * @returns a end function that when gets called observe the duration of the operation.
- */
-export const startMeasure = () => {
-  const start = performance.now();
-  return (op: string, err: unknown | null) => {
-    observe(
-      op,
-      () =>
-        new Promise<void>((resolve, reject) =>
-          err === null ? resolve() : reject(err)
-        ),
-      start,
-    );
-  };
-};
-/**
  * Observe function durations based on the provided labels
  */
 export const observe = async <T>(
   op: string,
   f: () => Promise<T>,
-  optStart?: number,
 ): Promise<T> => {
   if (!shouldCollectMetrics) {
     return f();
   }
-  const start = optStart ?? performance.now();
+  const start = performance.now();
   let isError = "false";
   try {
     return await f().then((resp) => {

--- a/plugins/deco.ts
+++ b/plugins/deco.ts
@@ -57,7 +57,7 @@ export default function decoPlugin(opt?: Options): Plugin {
                 : "./routes/_middleware.ts",
               opt?.sourceMap,
             ),
-            decoMiddleware,
+            ...decoMiddleware,
           ] as MiddlewareHandler<Record<string, unknown>>[],
         },
       },

--- a/routes/[...catchall].tsx
+++ b/routes/[...catchall].tsx
@@ -5,9 +5,13 @@ import { ConnInfo } from "std/http/server.ts";
 import { Handler } from "../blocks/handler.ts";
 import { Page } from "../blocks/page.ts";
 import { PageContext } from "../engine/block.ts";
-import { LiveConfig, LiveState, RouterContext } from "../types.ts";
+import { Flag, LiveConfig, LiveState } from "../types.ts";
 import { setCSPHeaders } from "../utils/http.ts";
 
+export interface RouterContext {
+  pagePath: string;
+  flags: Flag[];
+}
 const ctx = createContext<PageContext | undefined>(undefined);
 
 const routerCtx = createContext<RouterContext | undefined>(undefined);

--- a/routes/[...catchall].tsx
+++ b/routes/[...catchall].tsx
@@ -5,7 +5,7 @@ import { ConnInfo } from "std/http/server.ts";
 import { Handler } from "../blocks/handler.ts";
 import { Page } from "../blocks/page.ts";
 import { PageContext } from "../engine/block.ts";
-import { Flag, LiveConfig, LiveState } from "../types.ts";
+import { Flag, DecoState, DecoSiteState } from "../types.ts";
 import { setCSPHeaders } from "../utils/http.ts";
 
 export interface RouterContext {
@@ -61,7 +61,7 @@ export const handler = async (
   req: Request,
   ctx: HandlerContext<
     unknown,
-    LiveConfig<Handler, LiveState>
+    DecoState<Handler, DecoSiteState>
   >,
 ) => {
   const { state: { $live: handler } } = ctx;

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -45,140 +45,150 @@ const isAdminOrLocalhost = (req: Request): boolean => {
   return isOnAdmin || isLocalhost;
 };
 
-export const handler = async (
+export const handler = [async (
+  req: Request,
+  ctx: MiddlewareHandlerContext<LiveConfig<MiddlewareConfig, LiveState>>,
+) => {
+  return await ctx.next();
+}, async (
   req: Request,
   ctx: MiddlewareHandlerContext<LiveConfig<MiddlewareConfig, LiveState>>,
 ) => {
   const begin = performance.now();
   const url = new URL(req.url);
-  let initialResponse: Response | null = null;
+  let response: Response | null = null;
   try {
-    ctx.state.site = {
-      id: context.siteId,
-      name: context.site,
-    };
-
-    // FIXME (mcandeia) compatibility only.
-    if (
-      url.searchParams.has("editorData") &&
-      !url.pathname.startsWith("/live/editorData")
-    ) {
-      url.pathname = "/live/editorData";
-      url.searchParams.set("forceFresh", "");
-      return redirectTo(url);
-    }
-
-    if (url.pathname.startsWith("/_live/workbench")) {
-      url.pathname = "/live/workbench";
-      return redirectTo(url);
-    }
-
-    if (
-      !url.pathname.startsWith("/live/previews") &&
-      url.searchParams.has("pageId") &&
-      !url.searchParams.has("editorData")
-    ) {
-      return redirectToPreviewPage(url, url.searchParams.get("pageId")!);
-    }
-
-    const response = { headers: new Headers(defaultHeaders) };
-    const state = ctx.state?.$live?.state ?? {};
-    state.response = response;
-    state.flags = [];
-    Object.assign(ctx.state, state);
-    ctx.state.global = { ...ctx.state.global ?? {}, ...state }; // compatibility mode with functions.
-
-    const apps = ctx?.state?.$live?.apps;
-    if (Array.isArray(apps)) {
-      const buildManifest = function buildManifest(): [AppManifest, SourceMap] {
-        let [manifest, sourceMap] = [
-          context.manifest!,
-          buildSourceMap(context.manifest!),
-        ];
-        for (const app of apps) {
-          manifest = mergeManifests(
-            manifest,
-            app.manifest,
-          );
-          sourceMap = { ...sourceMap, ...app.sourceMap };
-        }
-        return [manifest, sourceMap];
-      };
-      const [manifest, sourceMap] = await ctx.state.resolve<
-        [AppManifest, SourceMap]
-      >({
-        func: buildManifest,
-        __resolveType: defaults["once"].name,
-      });
-      ctx.state.manifest = manifest;
-      ctx.state.sourceMap = { ...sourceMap, ...ctx?.state?.sourceMap ?? {} };
-    } else {
-      ctx.state.manifest = context.manifest!;
-    }
-
-    const shouldAllowCorsForOptions = (req.method === "OPTIONS") &&
-      isAdminOrLocalhost(req);
-    initialResponse = shouldAllowCorsForOptions
-      ? new Response()
-      : await ctx.next();
-
-    // Let rendering occur — handlers are responsible for calling ctx.state.loadPage
-    if (req.headers.get("upgrade") === "websocket") {
-      return initialResponse;
-    }
-    const newHeaders = new Headers(initialResponse.headers);
-    if (
-      (url.pathname.startsWith("/live/previews") &&
-        url.searchParams.has("mode") &&
-        url.searchParams.get("mode") == "showcase") ||
-      url.pathname.startsWith("/_frsh/") || shouldAllowCorsForOptions
-    ) {
-      Object.entries(allowCorsFor(req)).map(([name, value]) => {
-        newHeaders.set(name, value);
-      });
-    }
-    response.headers.forEach((value, key) => newHeaders.append(key, value));
-    const printTimings = ctx?.state?.t?.printTimings;
-    printTimings && newHeaders.set("Server-Timing", printTimings());
-
-    if (
-      url.pathname.startsWith("/_frsh/") &&
-      [400, 404, 500].includes(initialResponse.status)
-    ) {
-      newHeaders.set("Cache-Control", "no-cache, no-store, private");
-    }
-
-    // if there's no set cookie it means that none unstable matcher was evaluated
-    if (
-      Object.keys(getSetCookies(newHeaders)).length === 0 &&
-      Deno.env.has("DECO_ANONYMOUS_CACHE")
-    ) {
-      newHeaders.set("cache-control", "public, max-age=10");
-    }
-
-    for (const flag of state?.flags ?? []) {
-      newHeaders.append(
-        DECO_MATCHER_HEADER_QS,
-        `${flag.name}=${flag.value ? 1 : 0}`,
-      );
-    }
-
-    const newResponse = new Response(initialResponse.body, {
-      status: initialResponse.status,
-      headers: newHeaders,
-    });
-
-    return newResponse;
+    return response = await ctx.next();
   } finally {
-    // TODO: print these on debug mode when there's debug mode.
     if (!url.pathname.startsWith("/_frsh")) {
       console.info(
         formatLog({
-          status: initialResponse?.status ?? 500,
+          status: response?.status ?? 500,
           url,
           begin,
         }),
       );
     }
   }
-};
+}, async (
+  req: Request,
+  ctx: MiddlewareHandlerContext<LiveConfig<MiddlewareConfig, LiveState>>,
+) => {
+  const url = new URL(req.url);
+  ctx.state.site = {
+    id: context.siteId,
+    name: context.site,
+  };
+
+  // FIXME (mcandeia) compatibility only.
+  if (
+    url.searchParams.has("editorData") &&
+    !url.pathname.startsWith("/live/editorData")
+  ) {
+    url.pathname = "/live/editorData";
+    url.searchParams.set("forceFresh", "");
+    return redirectTo(url);
+  }
+
+  if (url.pathname.startsWith("/_live/workbench")) {
+    url.pathname = "/live/workbench";
+    return redirectTo(url);
+  }
+
+  if (
+    !url.pathname.startsWith("/live/previews") &&
+    url.searchParams.has("pageId") &&
+    !url.searchParams.has("editorData")
+  ) {
+    return redirectToPreviewPage(url, url.searchParams.get("pageId")!);
+  }
+
+  const response = { headers: new Headers(defaultHeaders) };
+  const state = ctx.state?.$live?.state ?? {};
+  state.response = response;
+  state.flags = [];
+  Object.assign(ctx.state, state);
+  ctx.state.global = { ...ctx.state.global ?? {}, ...state }; // compatibility mode with functions.
+
+  const apps = ctx?.state?.$live?.apps;
+  if (Array.isArray(apps)) {
+    const buildManifest = function buildManifest(): [AppManifest, SourceMap] {
+      let [manifest, sourceMap] = [
+        context.manifest!,
+        buildSourceMap(context.manifest!),
+      ];
+      for (const app of apps) {
+        manifest = mergeManifests(
+          manifest,
+          app.manifest,
+        );
+        sourceMap = { ...sourceMap, ...app.sourceMap };
+      }
+      return [manifest, sourceMap];
+    };
+    const [manifest, sourceMap] = await ctx.state.resolve<
+      [AppManifest, SourceMap]
+    >({
+      func: buildManifest,
+      __resolveType: defaults["once"].name,
+    });
+    ctx.state.manifest = manifest;
+    ctx.state.sourceMap = { ...sourceMap, ...ctx?.state?.sourceMap ?? {} };
+  } else {
+    ctx.state.manifest = context.manifest!;
+  }
+
+  const shouldAllowCorsForOptions = (req.method === "OPTIONS") &&
+    isAdminOrLocalhost(req);
+  const initialResponse = shouldAllowCorsForOptions
+    ? new Response()
+    : await ctx.next();
+
+  // Let rendering occur — handlers are responsible for calling ctx.state.loadPage
+  if (req.headers.get("upgrade") === "websocket") {
+    return initialResponse;
+  }
+  const newHeaders = new Headers(initialResponse.headers);
+  if (
+    (url.pathname.startsWith("/live/previews") &&
+      url.searchParams.has("mode") &&
+      url.searchParams.get("mode") == "showcase") ||
+    url.pathname.startsWith("/_frsh/") || shouldAllowCorsForOptions
+  ) {
+    Object.entries(allowCorsFor(req)).map(([name, value]) => {
+      newHeaders.set(name, value);
+    });
+  }
+  response.headers.forEach((value, key) => newHeaders.append(key, value));
+  const printTimings = ctx?.state?.t?.printTimings;
+  printTimings && newHeaders.set("Server-Timing", printTimings());
+
+  if (
+    url.pathname.startsWith("/_frsh/") &&
+    [400, 404, 500].includes(initialResponse.status)
+  ) {
+    newHeaders.set("Cache-Control", "no-cache, no-store, private");
+  }
+
+  // if there's no set cookie it means that none unstable matcher was evaluated
+  if (
+    Object.keys(getSetCookies(newHeaders)).length === 0 &&
+    Deno.env.has("DECO_ANONYMOUS_CACHE")
+  ) {
+    newHeaders.set("cache-control", "public, max-age=10");
+  }
+
+  for (const flag of state?.flags ?? []) {
+    newHeaders.append(
+      DECO_MATCHER_HEADER_QS,
+      `${flag.name}=${flag.value ? 1 : 0}`,
+    );
+  }
+
+  const newResponse = new Response(initialResponse.body, {
+    status: initialResponse.status,
+    headers: newHeaders,
+  });
+
+  return newResponse;
+}];

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -12,7 +12,7 @@ import defaults from "../engine/manifest/defaults.ts";
 import { context } from "../live.ts";
 import { AppManifest, Apps } from "../mod.ts";
 import { startObserve } from "../observability/http.ts";
-import { LiveConfig, LiveState } from "../types.ts";
+import { DecoState, DecoSiteState } from "../types.ts";
 import { isAdmin } from "../utils/admin.ts";
 import { allowCorsFor, defaultHeaders } from "../utils/http.ts";
 import { formatLog } from "../utils/log.ts";
@@ -48,7 +48,7 @@ const isAdminOrLocalhost = (req: Request): boolean => {
 
 export const handler = [async (
   req: Request,
-  ctx: MiddlewareHandlerContext<LiveConfig<MiddlewareConfig, LiveState>>,
+  ctx: MiddlewareHandlerContext<DecoState<MiddlewareConfig, DecoSiteState>>,
 ) => {
   const begin = performance.now();
   const url = new URL(req.url);
@@ -72,7 +72,7 @@ export const handler = [async (
   }
 }, async (
   req: Request,
-  ctx: MiddlewareHandlerContext<LiveConfig<MiddlewareConfig, LiveState>>,
+  ctx: MiddlewareHandlerContext<DecoState<MiddlewareConfig, DecoSiteState>>,
 ) => {
   const url = new URL(req.url);
   ctx.state.site = {

--- a/routes/live/_meta.ts
+++ b/routes/live/_meta.ts
@@ -9,7 +9,7 @@ import { namespaceOf } from "../../engine/schema/gen.ts";
 import { genSchemas } from "../../engine/schema/reader.ts";
 import { context } from "../../live.ts";
 import meta from "../../meta.json" assert { type: "json" };
-import { AppManifest, LiveConfig, LiveState } from "../../types.ts";
+import { AppManifest, DecoState, DecoSiteState } from "../../types.ts";
 import { resolvable } from "../../utils/admin.ts";
 import { allowCorsFor } from "../../utils/http.ts";
 
@@ -130,7 +130,7 @@ const sf = singleFlight<string>();
 const binaryId = context.deploymentId ?? crypto.randomUUID();
 export const handler = async (
   req: Request,
-  ctx: HandlerContext<unknown, LiveConfig<unknown, LiveState>>,
+  ctx: HandlerContext<unknown, DecoState<unknown, DecoSiteState>>,
 ) => {
   const end = ctx.state.t?.start("fetch-revision");
   const revision = await ctx.state.release.revision();

--- a/routes/live/invoke/[...key].ts
+++ b/routes/live/invoke/[...key].ts
@@ -1,5 +1,5 @@
 import { HandlerContext } from "$fresh/server.ts";
-import { LiveConfig, LiveState } from "../../../types.ts";
+import { DecoState, DecoSiteState } from "../../../types.ts";
 import { bodyFromUrl } from "../../../utils/http.ts";
 import { invokeToHttpResponse } from "../../../utils/invoke.ts";
 import { InvokeFunction, payloadToResolvable } from "./index.ts";
@@ -8,7 +8,7 @@ export const handler = async (
   req: Request,
   ctx: HandlerContext<
     unknown,
-    LiveConfig<unknown, LiveState>
+    DecoState<unknown, DecoSiteState>
   >,
 ): Promise<Response> => {
   const props = req.method === "POST"

--- a/routes/live/invoke/index.ts
+++ b/routes/live/invoke/index.ts
@@ -9,8 +9,8 @@ import type { UnionToIntersection } from "../../../deps.ts";
 import type { Resolvable } from "../../../engine/core/resolver.ts";
 import type { PromiseOrValue } from "../../../engine/core/utils.ts";
 import dfs from "../../../engine/manifest/defaults.ts";
-import type { LiveConfig } from "../../../mod.ts";
-import type { LiveState } from "../../../types.ts";
+import type { DecoState } from "../../../mod.ts";
+import type { DecoSiteState } from "../../../types.ts";
 import { bodyFromUrl } from "../../../utils/http.ts";
 import { invokeToHttpResponse } from "../../../utils/invoke.ts";
 import type { DeepPick, DotNestedKeys } from "../../../utils/object.ts";
@@ -353,7 +353,7 @@ export const handler = async (
   req: Request,
   ctx: HandlerContext<
     unknown,
-    LiveConfig<unknown, LiveState>
+    DecoState<unknown, DecoSiteState>
   >,
 ): Promise<Response> => {
   const { state: { resolve } } = ctx;

--- a/routes/live/previews/[...block].tsx
+++ b/routes/live/previews/[...block].tsx
@@ -2,7 +2,7 @@ import { HandlerContext, PageProps } from "$fresh/server.ts";
 import { Page } from "../../../blocks/page.ts";
 import LiveAnalytics from "../../../components/LiveAnalytics.tsx";
 import Render from "../../../routes/[...catchall].tsx";
-import { LiveConfig, LiveState } from "../../../types.ts";
+import { DecoState, DecoSiteState } from "../../../types.ts";
 import { bodyFromUrl } from "../../../utils/http.ts";
 
 const paramsFromUrl = (
@@ -52,7 +52,7 @@ export const handler = async (
   req: Request,
   ctx: HandlerContext<
     unknown,
-    LiveConfig<unknown, LiveState>
+    DecoState<unknown, DecoSiteState>
   >,
 ): Promise<Response> => {
   if (req.headers.get("upgrade") != "websocket") {
@@ -95,7 +95,7 @@ export const render = async (
   req: Request,
   ctx: HandlerContext<
     unknown,
-    LiveConfig<unknown, LiveState>
+    DecoState<unknown, DecoSiteState>
   >,
 ) => {
   const { state: { resolve } } = ctx;

--- a/routes/live/release.ts
+++ b/routes/live/release.ts
@@ -1,9 +1,9 @@
 import { HandlerContext } from "$fresh/server.ts";
-import { LiveConfig } from "../../mod.ts";
+import { DecoState } from "../../mod.ts";
 
 export const handler = async (
   _req: Request,
-  ctx: HandlerContext<unknown, LiveConfig>,
+  ctx: HandlerContext<unknown, DecoState>,
 ) => {
   return new Response(
     JSON.stringify(await ctx.state.release.state()),

--- a/routes/live/workflows/run.ts
+++ b/routes/live/workflows/run.ts
@@ -14,8 +14,8 @@ import {
   workflowWebSocketHandler,
 } from "../../../deps.ts";
 import type { Manifest } from "../../../live.gen.ts";
-import { LiveConfig } from "../../../mod.ts";
-import { LiveState } from "../../../types.ts";
+import { DecoState } from "../../../mod.ts";
+import { DecoSiteState } from "../../../types.ts";
 
 export type Props = HttpRunRequest<
   Arg,
@@ -28,7 +28,7 @@ export type Props = HttpRunRequest<
  */
 async function runWorkflow(
   props: Props,
-  ctx: LiveConfig<unknown, LiveState, Manifest>,
+  ctx: DecoState<unknown, DecoSiteState, Manifest>,
 ): Promise<Command> {
   const { execution: { metadata } } = props;
   const workflow = metadata!.workflow;
@@ -43,7 +43,7 @@ async function runWorkflow(
 
 const handleProps = async (
   props: Props,
-  ctx: HandlerContext<unknown, LiveConfig<unknown, LiveState, Manifest>>,
+  ctx: HandlerContext<unknown, DecoState<unknown, DecoSiteState, Manifest>>,
 ) => {
   const metadata = await ctx.state.resolve<WorkflowMetadata>(
     (props?.execution?.metadata ?? {}) as WorkflowMetadata,
@@ -56,7 +56,7 @@ const handleProps = async (
 
 export const handler = async (
   req: Request,
-  ctx: HandlerContext<unknown, LiveConfig<unknown, LiveState>>,
+  ctx: HandlerContext<unknown, DecoState<unknown, DecoSiteState>>,
 ): Promise<Response> => {
   initOnce();
   if (req.headers.get("upgrade") === "websocket") {
@@ -69,7 +69,7 @@ export const handler = async (
       workflowFn,
       (execution) =>
         new WorkflowContext(
-          ctx.state as unknown as LiveConfig<unknown, LiveState, Manifest>,
+          ctx.state as unknown as DecoState<unknown, DecoSiteState, Manifest>,
           execution,
         ),
     );
@@ -80,7 +80,7 @@ export const handler = async (
     props,
     ctx as unknown as HandlerContext<
       unknown,
-      LiveConfig<unknown, LiveState, Manifest>
+      DecoState<unknown, DecoSiteState, Manifest>
     >,
   );
   return new Response(

--- a/types.ts
+++ b/types.ts
@@ -25,15 +25,15 @@ import { ResolveFunc } from "./engine/core/resolver.ts";
 import { PromiseOrValue } from "./engine/core/utils.ts";
 import { Release } from "./engine/releases/provider.ts";
 import { Route } from "./flags/audience.ts";
-import { createServerTimings } from "./utils/timings.ts";
 import type { InvocationProxy } from "./routes/live/invoke/index.ts";
+import { createServerTimings } from "./utils/timings.ts";
 export type {
   ErrorBoundaryComponent,
-  ErrorBoundaryParams,
+  ErrorBoundaryParams
 } from "./blocks/section.ts";
 export type { AppContext, AppManifest, AppModule, AppRuntime };
 
-export type { App } from "./blocks/app.ts";
+  export type { App } from "./blocks/app.ts";
 
 export type JSONSchema = JSONSchema7;
 export type JSONSchemaDefinition = JSONSchema7Definition;
@@ -67,7 +67,7 @@ export interface SiteInfo {
   namespace: string;
 }
 
-export type LiveState<T = unknown> = {
+export type DecoSiteState<T = unknown> = {
   site: Site;
   t: ReturnType<typeof createServerTimings>;
   global: T;
@@ -83,7 +83,7 @@ export interface StatefulContext<T> {
   state: T;
 }
 
-export type LiveConfig<
+export type DecoState<
   TConfig = any,
   TState = {},
   TManifest extends AppManifest = AppManifest,
@@ -120,7 +120,7 @@ export type LoaderContext<
 > = FnContext<TState, TManifest>;
 
 export type FunctionContext<TProps = any, TState = {}> = StatefulContext<
-  LiveConfig<TProps, TState>
+  DecoState<TProps, TState>
 >;
 
 export type LoaderFunction<Props = any, Data = any, State = any> = (

--- a/types.ts
+++ b/types.ts
@@ -78,11 +78,6 @@ export interface Flag {
   value: boolean;
 }
 
-export type RouterContext = {
-  flags: Flag[];
-  pagePath: string;
-};
-
 export interface StatefulContext<T> {
   params: Record<string, string>;
   state: T;
@@ -106,6 +101,8 @@ export type LiveConfig<
       >
       & InvocationFunc<TManifest>;
     routes?: Route[];
+    flags: Flag[];
+    pathTemplate: string;
     manifest: TManifest;
     sourceMap: SourceMap;
   };


### PR DESCRIPTION
- I've decreased the cardinality of blocks metrics by decreasing the number of buckets and removing unnecessary information 
- Added http latency tracking
- Expose routePath for outer middlewares to be used as a observability metrics
- Renamed a Type from LiveConfig to DecoState