### PR TITLE
feat: Section Props typings

### DIFF
--- a/blocks/section.ts
+++ b/blocks/section.ts
@@ -46,7 +46,8 @@ export const isSection = <
   return (s as Section)?.metadata?.component === section;
 };
 
-export type SectionProps<T> = T extends PropsLoader<any, infer Props> ? Props
+export type SectionProps<T> = T extends PropsLoader<any, infer Props>
+  ? Props & { id: string }
   : unknown;
 
 export interface ErrorBoundaryParams<TProps> {


### PR DESCRIPTION
Add id to sectionProps typings since we now have an `id` on all sections after the partial feature