### PR TITLE
Accepting specific sections using its type

### DIFF
--- a/blocks/section.ts
+++ b/blocks/section.ts
@@ -20,7 +20,9 @@ import { withSection } from "../components/section.tsx";
 /**
  * @widget none
  */
-export type Section = InstanceOf<typeof sectionBlock, "#/root/sections">;
+export type Section<
+  _TSectionReturn extends JSX.Element | null = JSX.Element | null,
+> = InstanceOf<typeof sectionBlock, "#/root/sections">;
 
 export const isSection = <
   TManifest extends AppManifest = Manifest,
@@ -69,7 +71,7 @@ export const createSectionBlock = (
   type: "sections" | "pages",
 ): Block<SectionModule> => ({
   type,
-  introspect: { funcNames: ["loader", "default"] },
+  introspect: { funcNames: ["loader", "default"], includeReturn: true },
   adapt: <TConfig = any, TProps = any>(
     mod: SectionModule<TConfig, TProps>,
     resolver: string,

--- a/engine/schema/transform.ts
+++ b/engine/schema/transform.ts
@@ -457,6 +457,12 @@ const wellKnownTypeReferenceToSchemeable = async (
         },
       };
     }
+    case "Section": {
+      if (typeParams.length === 0) {
+        return undefined;
+      }
+      return tsTypeToSchemeable(typeParams[0], ctx);
+    }
     case "InstanceOf": {
       if (typeParams.length < 2) {
         return undefined;


### PR DESCRIPTION
## Description

This PR allow users to require specific sections instead of the generic one keeping backwards compatibility. Currently this is possible using `BlockInstance<"BLOCK STRING", Manifest>` the problem with this approach is because the string is strictly required so you cannot swap out using another section that has the same "semantic" behavior. Also, using the block address `deco-sites/storefront/sections/MySection.tsx` prevents the code to be used as template since the name of the template is used, thus the site based on such template will not inherit the same name as template does. So, for instance, if you create a site from storefront the `MySection.tsx` needs to be renamed to `deco-sites/YOUR_SITE/sections/MySection.tsx`, so it will require changing the sourecode.

# Example of usage

```tsx
// ./sections/Minicart.tsx
import { JSX } from "preact";

export type Minicart = JSX.Element;

export interface Props {
     whateverYouWant: string
}
export default function Minicart( {whateverYouWant}: Props): Minicart { // this is the substential change, by only typing the return now you can use it directly in another section
    return <div>{whateverYouWant}</div>
}

// ./sections/MySection.tsx
import { Section } from "deco/blocks/section.ts";
import { Minicart } from "./Minicart.tsx";

interface Props {
   anySection: Section;
   minicart: Section<Minicart>; // only the sections that returns minicart is allowed to be used here
}

export default function MySection({minicart: {Component props}}: Props) {
     return <Component {...props} />
}
```
