### PR TITLE
Add service instance id on Resource attributes for OTEL

### DIFF
--- a/observability/otel/config.ts
+++ b/observability/otel/config.ts
@@ -35,6 +35,7 @@ export const resource = Resource.default().merge(
       "deco",
     [SemanticResourceAttributes.SERVICE_VERSION]: context.deploymentId ??
       Deno.hostname(),
+    [SemanticResourceAttributes.SERVICE_INSTANCE_ID]: crypto.randomUUID(),
     "deco.runtime.version": meta.version,
     "deco.apps.version": apps_ver,
   }),


### PR DESCRIPTION
## Description

This pr simply adds a service instance on OTEL attributes, making possible to distinguish between isolates instances