### PR TITLE
feat: Caching loaders

### DIFF
--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -88,7 +88,7 @@ let maybeCache: Promise<unknown> | Cache | undefined = caches.open("loader")
   .then((c) => maybeCache = c)
   .catch(() => maybeCache = undefined);
 
-const MAX_AGE_S = 30 * 60; // 30min in seconds
+const MAX_AGE_S = 60; // 60 seconds
 
 const isCache = (c: any): c is Cache => typeof c?.put === "function";
 

--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -126,7 +126,7 @@ const wrapLoader = ({
     ): Promise<ReturnType<typeof handler>> => {
       const loader = ctx.resolverId || "unknown";
       const start = performance.now();
-      const skipCache = mode === "no-store" || ENABLE_LOADER_CACHE ||
+      const skipCache = mode === "no-store" || !ENABLE_LOADER_CACHE ||
         !isCache(maybeCache);
 
       let status: "bypass" | "miss" | "stale" | "hit" | undefined;

--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -1,22 +1,33 @@
 // deno-lint-ignore-file no-explicit-any
-import { HttpContext } from "../blocks/handler.ts";
+import hash from "npm:object-hash";
+import JsonViewer from "../components/JsonViewer.tsx";
+import { ValueType } from "../deps.ts";
+import { Block, BlockModule, InstanceOf } from "../engine/block.ts";
+import { singleFlight } from "../engine/core/utils.ts";
+import { ResolverMiddlewareContext } from "../engine/middleware.ts";
+import { meter } from "../observability/otel/metrics.ts";
+import { caches } from "../runtime/caches/denoKV.ts";
+import { HttpContext } from "./handler.ts";
 import {
   applyProps,
+  FnContext,
   FnProps,
-  newSingleFlightGroup,
   SingleFlightKeyFunc,
-} from "../blocks/utils.tsx";
-import JsonViewer from "../components/JsonViewer.tsx";
-import { Block, BlockModule, InstanceOf } from "../engine/block.ts";
-import { ResolverMiddlewareContext } from "../engine/middleware.ts";
+} from "./utils.tsx";
 
 export type Loader = InstanceOf<typeof loaderBlock, "#/root/loaders">;
 
 export interface LoaderModule<
   TProps = any,
+  TState = any,
 > extends BlockModule<FnProps<TProps>> {
+  cache?: "no-store" | "stale-while-revalidate";
+  cacheKey?: (req: Request, ctx: FnContext<TState>) => string;
+
+  /** @deprecated use cacheKey instead */
   singleFlightKey?: SingleFlightKeyFunc<TProps, HttpContext>;
 }
+
 export interface WrappedError {
   __isErr: true;
 }
@@ -57,24 +68,145 @@ export const wrapCaughtErrors = async <
     });
   }
 };
+
+export const DISABLE_LOADER_CACHE =
+  Deno.env.get("DISABLE_LOADER_CACHE") !== undefined;
+
+const stats = {
+  cache: meter.createCounter("loader_cache", {
+    unit: "1",
+    valueType: ValueType.INT,
+  }),
+  latency: meter.createHistogram("resolver_latency", {
+    description: "resolver latency",
+    unit: "ms",
+    valueType: ValueType.DOUBLE,
+  }),
+};
+
+let maybeCache: Promise<unknown> | Cache | undefined = caches.open("loader")
+  .then((c) => maybeCache = c)
+  .catch(() => maybeCache = undefined);
+
+const MAX_AGE_S = 30 * 60; // 30min in seconds
+
+const isCache = (c: any): c is Cache => typeof c?.put === "function";
+
+const inFuture = (maybeDate: string) => {
+  try {
+    return new Date(maybeDate) > new Date();
+  } catch {
+    return false;
+  }
+};
+
+const noop = () => "";
+
+const wrapLoader = ({
+  default: handler,
+  cache: mode = "no-store",
+  cacheKey = noop,
+  singleFlightKey,
+  ...rest
+}: LoaderModule) => {
+  const flights = singleFlight();
+
+  if (typeof singleFlightKey === "function") {
+    console.warn(
+      "singleFlightKey is deprecated and does not work anymore. Please use cacheKey instead",
+    );
+  }
+
+  return {
+    ...rest,
+    default: async (
+      props: Parameters<typeof handler>[0],
+      req: Request,
+      ctx: FnContext<unknown, any>,
+    ): Promise<ReturnType<typeof handler>> => {
+      const loader = ctx.resolverId || "unknown";
+      const start = performance.now();
+      const skipCache = mode === "no-store" || DISABLE_LOADER_CACHE ||
+        !isCache(maybeCache);
+
+      let status: "bypass" | "miss" | "stale" | "hit" | undefined;
+
+      try {
+        if (skipCache) {
+          status = "bypass";
+          stats.cache.add(1, { status, loader });
+
+          return await handler(props, req, ctx);
+        }
+
+        // Somehow typescript does not understand maybeCache is Cache
+        const cache = maybeCache as Cache;
+
+        // TODO: Resolve props cache key statically
+        const key = `${hash(props)}-${cacheKey(req, ctx)}`;
+        const request = new Request(
+          `https://localhost?propsKey=${hash(props)}&requestKey=${key}`,
+        );
+
+        const callHandlerAndCache = async () => {
+          const json = await handler(props, req, ctx);
+
+          cache.put(
+            request,
+            new Response(JSON.stringify(json), {
+              headers: {
+                "expires": new Date(Date.now() + (MAX_AGE_S * 1e3))
+                  .toUTCString(),
+              },
+            }),
+          ).catch(console.error);
+
+          return json;
+        };
+
+        const staleWhileRevalidate = async () => {
+          const matched = await cache.match(request).catch(() => null);
+
+          if (!matched) {
+            status = "miss";
+            stats.cache.add(1, { status, loader });
+
+            return await callHandlerAndCache();
+          }
+
+          const expires = matched.headers.get("expires");
+          const isStale = expires ? !inFuture(expires) : false;
+
+          if (isStale) {
+            status = "stale";
+            stats.cache.add(1, { status, loader });
+
+            callHandlerAndCache().catch((error) => console.error(error));
+          } else {
+            status = "hit";
+            stats.cache.add(1, { status, loader });
+          }
+
+          return await matched.json();
+        };
+
+        return await flights.do(key, staleWhileRevalidate);
+      } finally {
+        const dimension = { loader, status };
+        stats.latency.record(performance.now() - start, dimension);
+        ctx.monitoring?.currentSpan?.setDesc(status);
+      }
+    },
+  };
+};
+
 const loaderBlock: Block<LoaderModule> = {
   type: "loaders",
   introspect: { includeReturn: true },
-  adapt: <
-    TProps = any,
-  >(
-    { singleFlightKey, ...mod }: LoaderModule<TProps>,
-  ) =>
-    singleFlightKey
-      ? [
-        wrapCaughtErrors,
-        newSingleFlightGroup(singleFlightKey),
-        applyProps(mod),
-      ]
-      : [
-        wrapCaughtErrors,
-        applyProps(mod),
-      ],
+  adapt: <TProps = any>(mod: LoaderModule<TProps>) => [
+    wrapCaughtErrors,
+    applyProps(wrapLoader(mod)),
+  ],
   defaultPreview: (result) => {
     return {
       Component: JsonViewer,

--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -69,8 +69,8 @@ export const wrapCaughtErrors = async <
   }
 };
 
-export const DISABLE_LOADER_CACHE =
-  Deno.env.get("DISABLE_LOADER_CACHE") !== undefined;
+export const ENABLE_LOADER_CACHE =
+  Deno.env.get("ENABLE_LOADER_CACHE") !== undefined;
 
 const stats = {
   cache: meter.createCounter("loader_cache", {
@@ -126,7 +126,7 @@ const wrapLoader = ({
     ): Promise<ReturnType<typeof handler>> => {
       const loader = ctx.resolverId || "unknown";
       const start = performance.now();
-      const skipCache = mode === "no-store" || DISABLE_LOADER_CACHE ||
+      const skipCache = mode === "no-store" || ENABLE_LOADER_CACHE ||
         !isCache(maybeCache);
 
       let status: "bypass" | "miss" | "stale" | "hit" | undefined;

--- a/blocks/route.ts
+++ b/blocks/route.ts
@@ -38,7 +38,6 @@ import {
   DecoSiteState,
   DecoState,
 } from "../types.ts";
-import { formatIncomingRequest } from "../utils/log.ts";
 import { createServerTimings } from "../utils/timings.ts";
 
 export interface LiveRouteConfig extends RouteConfig {
@@ -215,10 +214,9 @@ export const buildDecoState = <TManifest extends AppManifest = AppManifest>(
     };
 
     // Logs  ?__d is present in localhost
-    context.state.monitoring.logger.log(
-      formatIncomingRequest(request, liveContext.site),
-    );
-    setLogger(context.state.monitoring.logger.log);
+    if (enabled) {
+      setLogger(context.state.monitoring.logger.log);
+    }
 
     const url = new URL(request.url);
     const isEchoRoute = url.pathname.startsWith("/live/_echo"); // echoing
@@ -251,7 +249,7 @@ export const buildDecoState = <TManifest extends AppManifest = AppManifest>(
     if (
       context.destination !== "internal" && context.destination !== "static"
     ) {
-      const endTiming = context?.state?.t?.start("load-page");
+      const timing = context?.state?.t?.start("load-page");
       const $live = typeof resolveKeyOrInstallPromise === "string"
         ? (await ctxResolver(
           resolveKeyOrInstallPromise,
@@ -265,7 +263,7 @@ export const buildDecoState = <TManifest extends AppManifest = AppManifest>(
         )) ?? {}
         : await resolveKeyOrInstallPromise.then(() => ({}));
 
-      endTiming?.();
+      timing?.end();
       context.state.$live = $live;
     }
 

--- a/blocks/utils.tsx
+++ b/blocks/utils.tsx
@@ -10,11 +10,16 @@ import {
   ComponentFunc,
   PreactComponent,
 } from "../engine/block.ts";
-import { Monitoring, ResolveFunc, Resolver } from "../engine/core/resolver.ts";
+import {
+  BaseContext,
+  Monitoring,
+  ResolveFunc,
+  Resolver,
+} from "../engine/core/resolver.ts";
 import { PromiseOrValue, singleFlight } from "../engine/core/utils.ts";
 import { ResolverMiddlewareContext } from "../engine/middleware.ts";
-import type { Manifest } from "../live.gen.ts";
-import type { InvocationProxy } from "../routes/live/invoke/index.ts";
+import { type Manifest } from "../live.gen.ts";
+import { type InvocationProxy } from "../routes/live/invoke/index.ts";
 import { Flag } from "../types.ts";
 import { HttpContext } from "./handler.ts";
 
@@ -82,6 +87,7 @@ export type FnContext<
   TState = {},
   TManifest extends AppManifest = Manifest,
 > = TState & RequestState & {
+  resolverId?: string;
   monitoring?: Monitoring;
   get: ResolveFunc;
   invoke:
@@ -95,9 +101,10 @@ export type FnProps<
   TProps = any,
   TResp = any,
   TState = any,
+  TRequest = Request,
 > = (
   props: TProps,
-  request: Request,
+  request: TRequest,
   ctx: FnContext<TState>,
 ) => PromiseOrValue<TResp>;
 
@@ -110,6 +117,7 @@ export const fnContextFromHttpContext = <TState = {}>(
 ): FnContext<TState> => {
   return {
     ...ctx?.context?.state?.global,
+    resolverId: ctx.resolverId,
     monitoring: ctx.monitoring,
     get: ctx.resolve,
     response: ctx.context.state.response,

--- a/clients/withManifest.ts
+++ b/clients/withManifest.ts
@@ -15,9 +15,8 @@ import type {
   ManifestInvocable,
   ManifestLoader,
 } from "../routes/live/invoke/index.ts";
-import { InvokeAwaiter } from "../routes/live/invoke/index.ts";
 import type { DotNestedKeys } from "../utils/object.ts";
-import { InvocationProxyHandler, newHandler } from "./proxy.ts";
+import { InvocationProxyHandler, InvokeAwaiter, newHandler } from "./proxy.ts";
 
 export interface InvokerRequestInit extends RequestInit {
   fetcher?: typeof fetch;

--- a/engine/core/mod.bench.ts
+++ b/engine/core/mod.bench.ts
@@ -12,6 +12,7 @@ Deno.bench(
     const context: BaseContext = {
       resolveChain: [],
       resolveId: "1",
+      resolverId: "unknown",
       resolvables: releaseJSON,
       resolvers: {},
       memo: {},
@@ -42,6 +43,7 @@ Deno.bench(
     const context: BaseContext = {
       resolveChain: [],
       resolveId: "1",
+      resolverId: "unknown",
       memo: {},
       resolvables: releaseJSON,
       resolvers: {},

--- a/engine/core/mod.test.ts
+++ b/engine/core/mod.test.ts
@@ -12,6 +12,7 @@ Deno.test("resolve", async (t) => {
   const context: BaseContext = {
     resolveChain: [],
     resolveId: "1",
+    resolverId: "unknown",
     resolvables: {},
     resolvers: {},
     resolveHints: {},

--- a/engine/schema/comments.ts
+++ b/engine/schema/comments.ts
@@ -100,7 +100,7 @@ export const commentsFromSpannable = (item: any) => {
  */
 const commentsToJSONSchema = (comments: Comment[]): JSONSchema7 => {
   const jsdocRegex = /@(\w+)\s+([^\n@]+)/g;
-  const jsDoc: Record<string, number | string | boolean> = {};
+  const jsDoc: Record<string, number | string | boolean | string[]> = {};
 
   for (const comment of comments) {
     let match;

--- a/handlers/fresh.ts
+++ b/handlers/fresh.ts
@@ -34,7 +34,7 @@ export default function Fresh(
     if (req.method === "HEAD") {
       return new Response(null, { status: 200 });
     }
-    const endResolvePage = appContext?.monitoring?.timings?.start?.(
+    const timing = appContext?.monitoring?.timings?.start?.(
       "load-data",
     );
 
@@ -55,14 +55,16 @@ export default function Fresh(
         }
       },
     );
+    timing?.end();
 
-    endResolvePage?.();
     const url = new URL(req.url);
     if (url.searchParams.get("asJson") !== null) {
       return Response.json(page, { headers: allowCorsFor(req) });
     }
     if (isFreshCtx<DecoState>(ctx)) {
-      const end = appContext?.monitoring?.timings?.start?.("render-to-string");
+      const timing = appContext?.monitoring?.timings?.start?.(
+        "render-to-string",
+      );
       const response = await appContext.monitoring!.tracer.startActiveSpan?.(
         "render-to-string",
         async (span) => {
@@ -79,10 +81,10 @@ export default function Fresh(
             throw err;
           } finally {
             span.end();
+            timing?.end();
           }
         },
       );
-      end?.();
 
       return response;
     }

--- a/handlers/routesSelection.ts
+++ b/handlers/routesSelection.ts
@@ -81,11 +81,11 @@ export const router = (
             { context: ctx, request: req },
           );
 
-      const end = configs?.monitoring?.timings.start("resolve-handler");
+      const timing = configs?.monitoring?.timings.start("resolve-handler");
       const hand = isAwaitable(resolvedOrPromise)
         ? await resolvedOrPromise
         : resolvedOrPromise;
-      end?.();
+      timing?.end();
 
       return await hand(
         req,

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -13,7 +13,6 @@ import { startObserve } from "../observability/http.ts";
 import { DecoSiteState, DecoState } from "../types.ts";
 import { isAdminOrLocalhost } from "../utils/admin.ts";
 import { allowCorsFor, defaultHeaders } from "../utils/http.ts";
-
 import { formatLog } from "../utils/log.ts";
 
 export const redirectToPreviewPage = async (url: URL, pageId: string) => {
@@ -117,6 +116,9 @@ export const handler = [
                 status: response?.status ?? 500,
                 url,
                 begin,
+                timings: ctx.state.debugEnabled
+                  ? ctx.state.monitoring.timings.get()
+                  : undefined,
               }),
             );
           }

--- a/routes/live/_meta.ts
+++ b/routes/live/_meta.ts
@@ -138,9 +138,9 @@ export const handler = async (
   ctx: HandlerContext<unknown, DecoState<unknown, DecoSiteState>>,
 ) => {
   const skipSchemaGen = new URL(req.url).searchParams.has("skipSchemaGen");
-  const end = ctx.state.t?.start("fetch-revision");
+  const timing = ctx.state.t?.start("fetch-revision");
   const revision = await ctx.state.release.revision();
-  end?.();
+  timing?.end();
   const etag = `${revision}@${binaryId}`;
   const ifNoneMatch = req.headers.get("if-none-match");
   if (ifNoneMatch === etag || ifNoneMatch === `W/${etag}`) { // weak etags should be tested as well.
@@ -153,7 +153,7 @@ export const handler = async (
     );
     if (revision !== latestRevision || mschema === null) {
       if (!skipSchemaGen) {
-        const endBuildSchema = ctx.state?.t?.start("build-resolvables");
+        const timing = ctx.state?.t?.start("build-resolvables");
         mschema = buildSchemaWithResolvables(
           manfiestBlocks,
           await genSchemas(manifest, sourceMap),
@@ -164,7 +164,7 @@ export const handler = async (
           },
         );
         latestRevision = revision;
-        endBuildSchema?.();
+        timing?.end();
       } else {
         mschema = {
           definitions: {},

--- a/routes/live/invoke/index.ts
+++ b/routes/live/invoke/index.ts
@@ -39,15 +39,6 @@ type AllTypesOf<TManifest extends AppManifest, App extends string> =
   AvailableInvocations<TManifest> & `${App}/${string}` extends
     `${App}/${infer type}/${string}` ? type
     : never;
-/**
- * Promise.prototype.then onfufilled callback type.
- */
-type Fulfilled<R, T> = ((result: R) => T | PromiseLike<T>) | null;
-
-/**
- * Promise.then onrejected callback type.
- */
-type Rejected<E> = ((reason: any) => E | PromiseLike<E>) | null;
 
 export interface InvokeAsPayload<
   TManifest extends AppManifest,
@@ -59,51 +50,6 @@ export interface InvokeAsPayload<
   payload: Invoke<TManifest, TInvocableKey, TFuncSelector>;
 }
 
-export class InvokeAwaiter<
-  TManifest extends AppManifest,
-  TInvocableKey extends string,
-  TFuncSelector extends DotNestedKeys<
-    ManifestInvocable<TManifest, TInvocableKey>["return"]
-  >,
-> implements
-  PromiseLike<
-    InvokeResult<
-      Invoke<TManifest, TInvocableKey, TFuncSelector>,
-      TManifest
-    >
-  >,
-  InvokeAsPayload<TManifest, TInvocableKey, TFuncSelector> {
-  constructor(
-    protected invoker: (
-      payload: Invoke<TManifest, TInvocableKey, TFuncSelector>,
-      init: RequestInit | undefined,
-    ) => Promise<
-      InvokeResult<Invoke<TManifest, TInvocableKey, TFuncSelector>, TManifest>
-    >,
-    public payload: Invoke<TManifest, TInvocableKey, TFuncSelector>,
-    protected init?: RequestInit | undefined,
-  ) {
-  }
-
-  public get() {
-    return this.payload;
-  }
-
-  then<TResult1, TResult2 = TResult1>(
-    onfufilled?: Fulfilled<
-      InvokeResult<
-        Invoke<TManifest, TInvocableKey, TFuncSelector>,
-        TManifest
-      >,
-      TResult1
-    >,
-    onrejected?: Rejected<TResult2>,
-  ): Promise<TResult1 | TResult2> {
-    return this.invoker(this.payload, this.init).then(onfufilled).catch(
-      onrejected,
-    );
-  }
-}
 type InvocationObj<TManifest extends AppManifest> = {
   [app in AppsOf<TManifest>]: {
     [type in AllTypesOf<TManifest, app>]:

--- a/routes/live/previews/[...block].tsx
+++ b/routes/live/previews/[...block].tsx
@@ -97,11 +97,11 @@ export const render = async (
     DecoState<unknown, DecoSiteState>
   >,
 ) => {
-  const { state: { resolve } } = ctx;
+  const { state: { resolve, monitoring } } = ctx;
   const url = new URL(previewUrl);
   const block = addLocal(url.pathname.replace(/^\/live\/previews\//, ""));
 
-  const end = ctx.state?.t.start("load-data");
+  let timing = monitoring?.timings?.start("load-data");
   const [params, pathname] = paramsFromUrl(url);
   const newUrl = new URL(req.url);
   if (pathname) {
@@ -123,7 +123,12 @@ export const render = async (
       request: newReq,
     },
   );
-  end?.();
+  timing?.end();
 
-  return await ctx.render(page);
+  timing = monitoring?.timings?.start("render-to-string");
+  try {
+    return await ctx.render(page);
+  } finally {
+    timing?.end();
+  }
 };

--- a/runtime/caches/common.ts
+++ b/runtime/caches/common.ts
@@ -1,7 +1,7 @@
 import { ValueType } from "../../deps.ts";
+import { tracer } from "../../observability/otel/config.ts";
 import { meter } from "../../observability/otel/metrics.ts";
 import { sha1 } from "../utils.ts";
-import { tracer } from "../../observability/otel/config.ts";
 
 export const assertNoOptions = (
   { ignoreMethod, ignoreSearch, ignoreVary }: CacheQueryOptions = {},

--- a/runtime/fetch/mod.ts
+++ b/runtime/fetch/mod.ts
@@ -1,10 +1,10 @@
-import { DISABLE_LOADER_CACHE } from "../../blocks/loader.ts";
+import { ENABLE_LOADER_CACHE } from "../../blocks/loader.ts";
 import { createFetch as withCache } from "./fetchCache.ts";
 import { createFetch as withLogs } from "./fetchLog.ts";
 
 export const fetch = [
   withLogs,
-  DISABLE_LOADER_CACHE ? withCache : undefined,
+  ENABLE_LOADER_CACHE ? undefined : withCache,
 ].filter(Boolean).reduceRight((acc, curr) => curr!(acc), globalThis.fetch);
 
 export type { DecoRequestInit as RequestInit } from "./fetchCache.ts";

--- a/runtime/fetch/mod.ts
+++ b/runtime/fetch/mod.ts
@@ -1,9 +1,10 @@
+import { DISABLE_LOADER_CACHE } from "../../blocks/loader.ts";
 import { createFetch as withCache } from "./fetchCache.ts";
 import { createFetch as withLogs } from "./fetchLog.ts";
 
 export const fetch = [
   withLogs,
-  withCache,
-].reduceRight((acc, curr) => curr(acc), globalThis.fetch);
+  DISABLE_LOADER_CACHE ? withCache : undefined,
+].filter(Boolean).reduceRight((acc, curr) => curr!(acc), globalThis.fetch);
 
 export type { DecoRequestInit as RequestInit } from "./fetchCache.ts";

--- a/utils/log.ts
+++ b/utils/log.ts
@@ -1,22 +1,5 @@
+import { Timing } from "deco/utils/timings.ts";
 import { blue, bold, cyan, gray, green, red, yellow } from "std/fmt/colors.ts";
-import { context } from "../live.ts";
-
-export const formatHeaders = (h: Headers) => {
-  const headersAsObject: Record<string, string> = {};
-  for (const [key, value] of h.entries()) {
-    headersAsObject[key] = value;
-  }
-
-  return `${cyan(bold("Incoming Headers:"))} ${
-    JSON.stringify(headersAsObject)
-  }\n`;
-};
-
-export const formatIncomingRequest = (request: Request, site: string) => {
-  return `${cyan(bold("Site: "))}${site} - ${
-    cyan(bold("URL:"))
-  } ${request.url}\n${formatHeaders(request.headers)}`;
-};
 
 export const formatOutgoingFetch = (
   request: Request,
@@ -34,32 +17,73 @@ export const formatOutgoingFetch = (
   } | ${gray(request.url)}`;
 };
 
-export const formatLog = (opts: {
+interface LogOptions {
   status: number;
   begin: number;
   url: URL;
-  pageId?: number;
-}) => {
-  const statusFormatter = opts.status < 300
-    ? green
-    : opts.status < 400
-    ? blue
-    : opts.status < 500
-    ? yellow
-    : red;
-  const duration = (performance.now() - opts.begin).toFixed(0);
+  timings?: readonly Timing[];
+}
 
-  if (context.isDeploy) {
-    return `[${
-      statusFormatter(`${opts.status}`)
-    }]: ${duration}ms ${opts.url.pathname} ${opts.pageId ? opts.pageId : ""}`;
+const formatStatus = (status: number) =>
+  (status < 300 ? green : status < 400 ? blue : status < 500 ? yellow : red)(
+    `${status}`,
+  );
+
+const formatLatency = (latency: number) => `${latency.toFixed(0)}ms`.padEnd(6);
+
+const progress = (
+  start: number,
+  end: number,
+  totalStart: number,
+  totalEnd: number,
+) => {
+  const length = 20;
+  const duration = totalEnd - totalStart;
+  const charStart = Math.ceil(length * (start - totalStart) / duration);
+  const charEnd = Math.ceil(length * (end - totalStart) / duration);
+
+  const bar: string[] = [];
+  for (let it = 0; it < length; it++) {
+    if (it < charStart) bar.push(" ");
+    else if (it < charEnd) bar.push("=");
+    else bar.push(" ");
   }
 
-  return `[${statusFormatter(`${opts.status}`)}]: ${duration}ms ${
-    cyan(opts.url.pathname)
-  } ${
-    opts.pageId
-      ? green(`https://deco.cx/live/${context.siteId}/pages/${opts.pageId}`)
-      : ""
-  }`;
+  return `[${bar.join("")}]`;
+};
+
+export const formatLog = (opts: LogOptions) => {
+  const end = performance.now();
+  const s = formatStatus(opts.status);
+  const l = formatLatency(end - opts.begin);
+  const p = cyan(opts.url.pathname);
+
+  const summary = `[${s}] ${l} ${p}`;
+
+  if (opts.timings === undefined) {
+    return summary;
+  }
+
+  const totalServerTiming = {
+    start: opts.begin,
+    end,
+    name: opts.url.pathname,
+    desc: opts.status.toString(),
+  };
+
+  const timings = [totalServerTiming, ...opts.timings]
+    .map((t) => {
+      if (!t.end) return;
+
+      const duration = t.end - t.start;
+      const l = formatLatency(duration);
+      const n = gray(t.name);
+      const d = (t.desc?.toUpperCase() ?? "").padEnd(6);
+
+      return `${progress(t.start, t.end, opts.begin, end)} ${l} ${d} ${n} `;
+    })
+    .filter(Boolean)
+    .join("\n");
+
+  return `${summary}\n${timings}`;
 };


### PR DESCRIPTION
# Purpose of this PR

This pull request introduces enhancements to loaders by incorporating stale caching and improved visibility. 

# Motivation

The architecture of Deco.cx relies on the assumption that utilizing stale caching for third-party datasources yields optimal performance and facilitates customization. In practical terms, our custom `fetch` function ensures that all requests are routed through a stale caching CDN layer. For example, when a user writes `fetch('https://example.com')`, Deco.cx's framework actually fetches the proxied URL: `fetch('https://decocache.com?src=https://example.com')`. While this approach initially worked well for integrations on `decohub`, challenges arose as some services offered their own client packages that did not support a custom fetch. Additionally, instrumenting these fetches for effective tracing in our admin UI proved to be a hurdle.

To address these issues, we are shifting away from a custom `fetch` approach and pivoting towards enhancing our loader API to support caching and tracing.

# Opting into the New Features

To adopt the updated API, set the following environment variable:

```sh
source ENABLE_LOADER_CACHE=true
```

And that's it! You are now leveraging the new traced loaders.

## Stale Caching Mode

By default, stale caching is inactive in loaders. To activate stale caching mode, modify your loader's code as follows:

```ts
// ... loader code

export const cache = 'stale-while-revalidate'
```

The `cache` variable can be set to either `stale-while-revalidate` or `no-store`, with the default being `no-store`.

Now, your loader is stale cached! To confirm, open a page where your loader is used and add a `?__d` query string to the URL. You should observe the tracing information in the terminal, including cache states such as `HIT`, `MISS`, `STALE`, and `BYPASS`.

- `HIT`: Cache considered fresh. We use 60 seconds as the standard max-age for caching
- `STALE`: Cache not fresh, but stale content served (background validation triggered).
- `MISS`: Loader is cacheable, but data not in the cache.
- `BYPASS`: Loader not cacheable, possibly due to using `export const cache = 'no-store'` mode, missing environment variable, or no caching layer available.

## Varying the Cache

Some loaders may need to vary based on properties available only in the request object, such as query strings. To achieve this, use the new `cacheKey` function:

```ts
export const cacheKey = (req: Request, ctx: AppContext): string => '';
```

Simply export this function in your loader file. An example can be found [here](https://github.com/deco-cx/apps/blob/333c1d4c74493b18762cc3c1abd1f0d929431dc5/vtex/loaders/intelligentSearch/productDetailsPage.ts#L130).