### PR TITLE
Add new line on output stream after each object.

### DIFF
--- a/utils/invoke.ts
+++ b/utils/invoke.ts
@@ -38,7 +38,7 @@ export const invokeToHttpResponse = (
 
       try {
         for await (const content of invokeResponse) {
-          await writer.write(encoder.encode(JSON.stringify(content)));
+          await writer.write(encoder.encode(JSON.stringify(content) + "\n"));
         }
       } finally {
         try {


### PR DESCRIPTION
Output streaming on loaders doesn't not add new lines after each object. This breaks expected behavior on client, where each object is separated by new line.