### PR TITLE
Do not catch invoke err on invoke resolver (instead catch on API handler)

### DIFF
--- a/blocks/app.ts
+++ b/blocks/app.ts
@@ -166,14 +166,14 @@ export const mergeRuntimes = <
   return {
     manifest: mergeManifests(currentManifest, manifest),
     resolvables: {
-      ...currentResolvables,
       ...resolvables,
+      ...currentResolvables,
     },
     resolvers: {
-      ...currentResolvers,
       ...resolvers,
+      ...currentResolvers,
     },
-    sourceMap: { ...currentSourceMap ?? {}, ...sourceMap ?? {} },
+    sourceMap: { ...sourceMap ?? {}, ...currentSourceMap ?? {} },
   };
 };
 

--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -38,7 +38,7 @@ export const isWrappedError = (
   return (err as WrappedError)?.__isErr;
 };
 
-const isInvokeCtx = <TContext extends ResolverMiddlewareContext<any>>(
+export const isInvokeCtx = <TContext extends ResolverMiddlewareContext<any>>(
   ctx: TContext | TContext & { isInvoke: true },
 ): ctx is TContext & { isInvoke: true } => {
   return (ctx as TContext & { isInvoke: true })?.isInvoke;

--- a/engine/manifest/defaults.ts
+++ b/engine/manifest/defaults.ts
@@ -1,3 +1,4 @@
+import { isInvokeCtx } from "../../blocks/loader.ts";
 import PreviewNotAvailable from "../../components/PreviewNotAvailable.tsx";
 import { DotNestedKeys, pickPaths } from "../../utils/object.ts";
 import { ResolveOptions } from "../core/mod.ts";
@@ -162,8 +163,9 @@ export default {
   },
   invoke: async function invoke(
     { props, block }: BlockInvocation,
-    { resolvables, resolvers, resolve },
+    ctx,
   ) {
+    const { resolvables, resolvers, resolve } = ctx;
     try {
       const invokeBlock = `${INVOKE_PREFIX_KEY}${block}`;
       const _invokeResolver = resolvers[invokeBlock];
@@ -189,7 +191,7 @@ export default {
         propsAreResolved: true,
       });
     } catch (err) {
-      if (!(err instanceof HttpError)) {
+      if (!(err instanceof HttpError) && !isInvokeCtx(ctx)) {
         throw new HttpError(
           new Response(
             err ? err : JSON.stringify({

--- a/routes/live/invoke/[...key].ts
+++ b/routes/live/invoke/[...key].ts
@@ -2,8 +2,7 @@ import { HandlerContext } from "$fresh/server.ts";
 import { DecoSiteState, DecoState } from "../../../types.ts";
 import { bodyFromUrl } from "../../../utils/http.ts";
 import { invokeToHttpResponse } from "../../../utils/invoke.ts";
-import { InvokeFunction, payloadToResolvable } from "./index.ts";
-
+import { InvokeFunction, payloadToResolvable, wrapInvokeErr } from "./index.ts";
 export const handler = async (
   req: Request,
   ctx: HandlerContext<
@@ -24,7 +23,7 @@ export const handler = async (
       (url.searchParams.getAll("select") ?? []) as InvokeFunction["select"],
   };
 
-  const resp = await resolve(payloadToResolvable(invokeFunc));
+  const resp = await resolve(payloadToResolvable(invokeFunc)).catch(wrapInvokeErr);
 
   return invokeToHttpResponse(req, resp);
 };


### PR DESCRIPTION
This PR does mainly two things:

1 - Avoid catching errors on invoke resolver

Why? because sometimes you're invoking a function inline (e.g from another function action/loader) and the response should't be an HTTPError, instead the invoke response should be kept. On the other hand the invoke HTTP API handler should always return an HTTP error. so it will be fine to move to there.

2 - Avoid overriding resolvers with app dependencies

This is specially useful when you're in a migration process and you have two apps with the same name (we have this in our admin) and some of the apps defines the same action/loader. This is making the "main app" (the app that depends on others) overrides the "dependants" apps actions/loaders