### PR TITLE
feat: schema generation handle chose function return types as array

### DIFF
--- a/blocks/section.ts
+++ b/blocks/section.ts
@@ -105,7 +105,7 @@ export const createSectionBlock = (
   type: "sections" | "pages",
 ): Block<SectionModule> => ({
   type,
-  introspect: { funcNames: ["loader", "default"], includeReturn: true },
+  introspect: { funcNames: ["loader", "default"], includeReturn: ["default"] },
   adapt: <TConfig = any, TProps = any>(
     mod: SectionModule<TConfig, TProps>,
     resolver: string,

--- a/engine/block.ts
+++ b/engine/block.ts
@@ -36,7 +36,7 @@ export type ModuleOf<TBlock> = TBlock extends Block<
   : never;
 
 export interface IntrospectParams {
-  includeReturn?: boolean | ((ts: TsType) => TsType | undefined);
+  includeReturn?: boolean | string[] | ((ts: TsType) => TsType | undefined);
   funcNames?: string[];
 }
 

--- a/engine/schema/transform.ts
+++ b/engine/schema/transform.ts
@@ -1242,6 +1242,22 @@ const paramsOf = (
     return typeAnnotation!;
   });
 };
+
+const getReturnFnFunction = async (
+  funcNames: string[],
+  importMapResolver: ImportMapResolver,
+  mPath: string,
+  mProgram: ParsedSource,
+) => {
+  for (const name of funcNames) {
+    const fn = name === "default"
+      ? await findDefaultFuncExport(importMapResolver, mPath, mProgram)
+      : await findFuncExport(importMapResolver, name, mPath, mProgram);
+
+    if (fn) return returnOf(fn);
+  }
+};
+
 export const programToBlockRef = async (
   importMapResolver: ImportMapResolver,
   mPath: string,
@@ -1264,7 +1280,14 @@ export const programToBlockRef = async (
     }
 
     const includeReturn = introspect?.includeReturn;
-    const fnReturn = returnOf(fn);
+    const fnReturn = Array.isArray(includeReturn)
+      ? await getReturnFnFunction(
+        includeReturn,
+        importMapResolver,
+        mPath,
+        mProgram,
+      )
+      : returnOf(fn);
     const { path, parsedSource } = fn;
 
     const retn = typeof includeReturn === "function"


### PR DESCRIPTION
This fixes this problem:

scenario
```ts
// MyCustomSection.tsx
type MyCustomSection = JSX.Element;
interface Props {}
export function loader(p: Props) {}
export default function Section(): MyCustomSection {}
```

```ts
// some block that only receives section<MyCustomSection>;
import { Section } from "deco/blocks/section.ts";

interface Props {
  section: Section<MyCustomSection>
}
export default function Block(p: Props) {}
```

Before:
the schema of property section of Block will be an array with { title: "MyCustomSection" }

After:
the schema of property section of block will be an array with {title: "MyCustomSection"} and schema of props from `MyCustomSection.tsx`