### PR TITLE
Change flag default checking

### DIFF
--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -80,7 +80,7 @@ export const wrapCaughtErrors = async <
 };
 
 export const ENABLE_LOADER_CACHE =
-  Deno.env.get("ENABLE_LOADER_CACHE") !== undefined;
+  Deno.env.get("ENABLE_LOADER_CACHE") === "true";
 
 export const LOADER_CACHE_START_TRESHOLD =
   Deno.env.get("LOADER_CACHE_START_TRESHOLD") ?? 5;

--- a/utils/userAgent.ts
+++ b/utils/userAgent.ts
@@ -34,7 +34,7 @@ export const deviceOf = (request: Request) => {
 
 const UABotParser = new UAParser(Bots);
 
-const KNOWN_BOTS = ["Google-InspectionTool"]
+const KNOWN_BOTS = ["Google-InspectionTool"];
 
 export const isBot = (req: Request) => {
   const fromCloudFlare = req.headers.get("cf-verified-bot");
@@ -43,8 +43,8 @@ export const isBot = (req: Request) => {
     return true;
   }
 
-  if(KNOWN_BOTS.some(bot => req.headers.get("user-agent")?.includes(bot))) {
-    return true
+  if (KNOWN_BOTS.some((bot) => req.headers.get("user-agent")?.includes(bot))) {
+    return true;
   }
 
   const ua = req.headers.get("user-agent") || "";


### PR DESCRIPTION
It is easier to check if it is true rather than if it is just not undefined. Deno.env.get(ENABLE_LOADER_CACHE) !== undefined; receiving a false value would result in enabling the cache. This is not intuitive and may result in problems in the future.