### PR TITLE
fix: Islands and Async Rendering

### DIFF
--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -75,6 +75,23 @@ export const wrapCaughtErrors = async <
         if (prop === "__isErr") {
           return true;
         }
+
+        /**
+         * This proxy may be used inside islands.
+         * Islands props are serialized by fresh's serializer.
+         * This code makes it behave well with fresh's serializer
+         */
+        if (prop === "peek") {
+          return undefined;
+        }
+        if (prop === "toJSON") {
+          return () => null;
+        }
+
+        /**
+         * No special case found, throw and hope to be catch by the
+         * section's ErrorFallback
+         */
         throw err;
       },
     });

--- a/blocks/section.ts
+++ b/blocks/section.ts
@@ -90,6 +90,18 @@ const wrapCaughtErrors = async <TProps>(
             if (prop === "__isErr") {
               return true;
             }
+
+            /**
+             * This proxy may be used inside islands.
+             * Islands props are serialized by fresh's serializer.
+             * This code makes it behave well with fresh's serializer
+             */
+            if (prop === "peek") {
+              return undefined;
+            }
+            if (prop === "toJSON") {
+              return () => null;
+            }
             throw err;
           },
         }),


### PR DESCRIPTION
This PR makes async rendering work with islands.

The issue was that Async Rendering creates a Proxy object. When this object was passed to Islands directly, Fresh's serializer tried to JSON.stringify this proxy object, that throw resulting in an error being shown to the final user. The fix was to enable JSON.stringify for this Proxy object so that the ErrorFallbacks catch these errors correctly