### PR TITLE
Remove warning when file not found

### DIFF
--- a/runtime/caches/fileSystem.ts
+++ b/runtime/caches/fileSystem.ts
@@ -145,11 +145,7 @@ function createFileSystemCache(): CacheStorage {
     } catch (err) {
       // Error code different for file/dir not found
       // The file won't be found in cases where it's not cached
-      if (err.code === "ENOENT") {
-        logger.warning(
-          `file not found when reading from file system, path: ${FILE_SYSTEM_CACHE_DIRECTORY}/${key}`,
-        );
-      } else {
+      if (err.code !== "ENOENT") {
         logger.error(`error when reading from file system, ${err}`);
       }
       return null;


### PR DESCRIPTION
This warning gets spammed all over HyperDx, and this information is basically representing a miss, which is already contained in the cache hit metric.

<img width="1252" alt="Screenshot 2024-04-26 at 08 46 57" src="https://github.com/deco-cx/deco/assets/53613091/624d30fa-ada0-47b1-a512-110a2e261602">
