### PR TITLE
Simple default props version

### DIFF
--- a/engine/schema/schemeable.test.ts
+++ b/engine/schema/schemeable.test.ts
@@ -319,6 +319,7 @@ Deno.test("Simple interface generation", async () => {
   assertEquals(definitions[rands[0]], {
     allOf: undefined,
     title: "SimpleInterface",
+    default: undefined,
     type: "object",
     properties: {
       name: {
@@ -388,6 +389,7 @@ Deno.test("Non required fields generation", async () => {
   assertEquals(ref.$ref, `#/definitions/${rands[0]}`);
   assertEquals(definitions[rands[0]], {
     allOf: undefined,
+    default: undefined,
     type: "object",
     title: "NonRequiredFields",
     properties: {
@@ -462,6 +464,7 @@ Deno.test("Union types generation", async () => {
   assertEquals(ref.$ref, `#/definitions/${rands[0]}`);
   assertEquals(definitions[rands[0]], {
     allOf: undefined,
+    default: undefined,
     title: "UnionTypes",
     type: "object",
     properties: {
@@ -529,6 +532,7 @@ Deno.test("Array fields generation", async () => {
   assertEquals(ref.$ref, `#/definitions/${rands[0]}`);
   assertEquals(definitions[rands[0]], {
     allOf: undefined,
+    default: undefined,
     title: "ArrayFields",
     type: "object",
     properties: {
@@ -607,6 +611,7 @@ Deno.test("Type reference generation", async () => {
   assertEquals(ref.$ref, `#/definitions/${rands[0]}`);
   assertEquals(definitions[rands[0]], {
     allOf: undefined,
+    default: undefined,
     title: "InterfaceWithTypeRef",
     type: "object",
     properties: {
@@ -691,6 +696,7 @@ Deno.test("JSDoc tags injection", async () => {
   assertEquals(ref.$ref, `#/definitions/${rands[0]}`);
   assertEquals(definitions[rands[0]], {
     allOf: undefined,
+    default: undefined,
     title: "WithTags",
     type: "object",
     properties: {
@@ -842,6 +848,7 @@ Deno.test("Wellknown in types generation", async () => {
   assertEquals(definitions[rands[0]], {
     allOf: undefined,
     title: "WellKnown",
+    default: undefined,
     type: "object",
     properties: {
       array: {

--- a/engine/schema/schemeable.ts
+++ b/engine/schema/schemeable.ts
@@ -166,6 +166,7 @@ const schemeableToJSONSchemaFunc = (
         allOf: allOf && allOf.length > 0 ? allOf : undefined,
         properties,
         required,
+        default: schemeable.default,
         title: schemeable.title ?? schemeable.name,
       };
       return [


### PR DESCRIPTION
## Problem
Currently we you have default values set in your component you got an empty form in the admin but the component still being rendered with the data specified at code. This leads in bad experience because you can't do the mapping from the input text to the page data.

## Solution

From now on, you can specify default props (only simpler scenarios are covered) in your block (any block is supported) by just specifying it in the function parameter itself. Example:

```tsx
import { ImageWidget } from "apps/admin/widgets.ts";
import Image from "apps/website/components/Image.tsx";

interface Props {
  href?: string;
  image?: ImageWidget;
  alt?: string;
  width?: number;
  height?: number;
  text?: string;
}

function Footer({
  image =
    "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/4959/d7aa9290-074f-417c-99c3-5b0587c8c2ee",
  href = "https://deco.cx/",
  text = "Made with",
  alt = "Made with deco.cx",
  height = 20,
  width = 50,
}: Props) {
  return (
    <div class="py-8 lg:px-0 px-6 fixed bottom-0 w-full mx-auto">
      <a
        href={href}
        class="flex flex-row gap-1 items-center justify-center text-xs"
        target="_blank"
      >
        {text && <p>{text}</p>}
        {image && (
          <Image
            src={image || ""}
            alt={alt || ""}
            height={height || 20}
            width={width || 50}
          />
        )}
      </a>
    </div>
  );
}

export default Footer;

```

<img width="1443" alt="image" src="https://github.com/deco-cx/deco/assets/5839364/dec2094c-9e88-44ce-acbd-42aaa09b56b2">
