### PR TITLE
[ Erros/Feat ] Redirects

### DIFF
--- a/engine/errors.ts
+++ b/engine/errors.ts
@@ -21,7 +21,12 @@ export const shortcircuit = (resp: Response) => {
  * Redirect using the specified @param url.
  */
 export const redirect = (url: string | URL, status?: number) => {
-  shortcircuit(Response.redirect(url, status));
+  shortcircuit(
+    new Response(null, {
+      status: status ?? 307,
+      headers: { location: url.toString() },
+    }),
+  );
 };
 
 /**


### PR DESCRIPTION
Now you can only use "/test" to redirect. Before this pr you needed to send the complete url. 

before:
```js
redirect(`${url.origin}/test`) 
redirect(new URL(`${url.origin}/test`)
```
after:
```js
redirect(/test) 
redirect(`${url.origin}/test`)
redirect(new URL(`${url.origin}/test`)
```