### PR TITLE
fix resolved

### DIFF
--- a/engine/core/hints.ts
+++ b/engine/core/hints.ts
@@ -43,7 +43,7 @@ export const traverseAny = <T>(
   value: unknown,
 ): HintNode<T> | null => {
   if (isResolved(value)) {
-    return {};
+    return null;
   }
   const node = isResolvable(value) ? {} : null;
   if (Array.isArray(value)) {

--- a/engine/core/hints.ts
+++ b/engine/core/hints.ts
@@ -43,7 +43,7 @@ export const traverseAny = <T>(
   value: unknown,
 ): HintNode<T> | null => {
   if (isResolved(value)) {
-    return null;
+    return {};
   }
   const node = isResolvable(value) ? {} : null;
   if (Array.isArray(value)) {

--- a/runtime/fresh/routes/render.tsx
+++ b/runtime/fresh/routes/render.tsx
@@ -170,7 +170,7 @@ export const handler = async (
 
   return ctx.state.resolve(
     { page, __resolveType: "render" },
-    undefined,
+    { propsAreResolved: true },
     original,
   ) as unknown as Promise<Response>;
 };


### PR DESCRIPTION
If we have a `asResolved` object, but we pass this to  `ctx.state.resolve({})`, we get the data as the response. However, this breaks async rendering since we need these asResovled to keep as Resolved after calling ctx.state.resolve.

This bug can be seen in our searchbar, where the loader is loaded asResovled, but after the section re-renders, we get the data, instead of the asResovled loader