### PR TITLE
fix: useSection hook cache key

### DIFF
--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -174,6 +174,10 @@ const wrapLoader = (
       let status: "bypass" | "miss" | "stale" | "hit" | undefined;
       const cacheKeyValue = cacheKey(props, req, ctx);
       try {
+        if (cacheKeyValue) {
+          ctx.vary?.push(loader, cacheKeyValue);
+        }
+
         // Should skip cache
         if (
           mode === "no-store" ||
@@ -187,7 +191,6 @@ const wrapLoader = (
           return await handler(props, req, ctx);
         }
 
-        ctx.vary && ctx.vary.push(loader, cacheKeyValue);
         if (countCache === null) {
           countCache = new weakcache.WeakLRUCache({
             cacheSize: LOADER_CACHE_SIZE,


### PR DESCRIPTION
This PR fixes the vary so the __cb cache key takes into account the loader cache key even if the loader cache is not enabled