### PR TITLE
fix: section export default return type

### DIFF
--- a/blocks/section.ts
+++ b/blocks/section.ts
@@ -89,7 +89,7 @@ export const createSectionBlock = (
   type,
   introspect: {
     funcNames: ["loader", "action", "default"],
-    includeReturn: true,
+    includeReturn: ["default"],
   },
   adapt: <TConfig = any, TProps = any>(
     mod: SectionModule<TConfig, TProps>,


### PR DESCRIPTION
revert from this https://github.com/deco-cx/deco/commit/2f8658c9bbe7f3fb04267cd74b9c88b0f4f9a31f to this https://github.com/deco-cx/deco/commit/223b2a27d68f559c6cf53f7a77992ba18231fe52.

This fixes the section return type match with the page [SEO property](https://github.com/deco-cx/apps/blob/main/website/pages/Page.tsx#L45).