### PR TITLE
fix: autofind tracking branch

### DIFF
--- a/daemon/git.ts
+++ b/daemon/git.ts
@@ -6,7 +6,9 @@ const git = GIT.simpleGit(Deno.cwd(), {
 });
 
 const getMergeBase = async () => {
-  const { current, tracking } = await git.status();
+  const status = await git.status();
+  const current = status.current;
+  const tracking = status.tracking || "main";
 
   if (!current || !tracking) {
     throw new Error(`Missing local or upstream branches`);


### PR DESCRIPTION
When one creates a branch with `git checkout -b`, git returns the following

<img width="313" alt="Screenshot 2024-08-05 at 10 51 28" src="https://github.com/user-attachments/assets/24e27562-2821-4a6a-907c-f18d2fc20ecc">

This means tracking is null. In this case, let's take main as the default tracking branch. A future PR may add a better heuristics for finding the tracking branch