### PR TITLE
fix: try json when no content length is supplied

### DIFF
--- a/runtime/routes/invoke.ts
+++ b/runtime/routes/invoke.ts
@@ -38,11 +38,11 @@ function getParsingStrategy(req: Request): keyof typeof propsParsers | null {
   const contentType = req.headers.get("content-type");
   const contentLength = req.headers.get("content-length");
 
-  if (contentLength === "0" || !contentLength) {
+  if (contentLength === "0") {
     return null;
   }
 
-  if (!contentType) {
+  if (!contentLength || !contentType) {
     return "try-json";
   }
 


### PR DESCRIPTION
1:1 old behavior