### PR TITLE
fix: rebase

### DIFF
--- a/daemon/git.ts
+++ b/daemon/git.ts
@@ -8,10 +8,13 @@ import {
   simpleGit,
   type StatusResult,
 } from "simple-git";
+import { createLocker } from "./async.ts";
 import { logs } from "./loggings/stream.ts";
 
 const SOURCE_PATH = Deno.env.get("SOURCE_ASSET_PATH");
 const DEFAULT_TRACKING_BRANCH = Deno.env.get("DECO_TRACKING_BRANCH") ?? "main";
+
+export const lockerGitAPI = createLocker();
 
 const git = simpleGit(Deno.cwd(), {
   maxConcurrentProcesses: 1,
@@ -347,6 +350,7 @@ interface Options {
 export const createGitAPIS = (options: Options) => {
   const app = new Hono();
 
+  app.use(lockerGitAPI.wlock);
   app.get("/diff", diff);
   app.get("/status", status);
   app.get("/log", log);

--- a/daemon/git.ts
+++ b/daemon/git.ts
@@ -214,7 +214,7 @@ export const publish = ({ build }: Options): Handler => {
       .reset(["."])
       .reset([base])
       .add(["."])
-      .commit(message || "New release", {
+      .commit(message, {
         "--author": `${author.name} <${author.email}>`,
         "--no-verify": null,
       });

--- a/daemon/git.ts
+++ b/daemon/git.ts
@@ -202,7 +202,9 @@ export const publish = ({ build }: Options): Handler => {
   };
 
   return async (c) => {
-    const { message, author } = await c.req.json() as PublishAPI["body"];
+    const body = await c.req.json() as PublishAPI["body"];
+    const author = body.author || { name: "decobot", email: "capy@deco.cx" };
+    const message = body.message || `New release by ${author.name}`;
 
     await git.fetch(["-p"]);
 
@@ -212,7 +214,7 @@ export const publish = ({ build }: Options): Handler => {
       .reset(["."])
       .reset([base])
       .add(["."])
-      .commit(message, {
+      .commit(message || "New release", {
         "--author": `${author.name} <${author.email}>`,
         "--no-verify": null,
       });

--- a/daemon/realtime/app.ts
+++ b/daemon/realtime/app.ts
@@ -4,6 +4,7 @@ import { ensureFile } from "@std/fs";
 import { walk, WalkError } from "@std/fs/walk";
 import { join, SEPARATOR } from "@std/path";
 import fjp from "fast-json-patch";
+import { lockerGitAPI } from "../git.ts";
 import { BinaryIndexedTree } from "./crdt/bit.ts";
 import { apply } from "./crdt/text.ts";
 import {
@@ -68,7 +69,7 @@ export const createRealtimeAPIs = () => {
 
       const path = paths[0];
 
-      if (path.includes(".git")) {
+      if (path.includes(".git") || path.includes("node_modules")) {
         continue;
       }
 
@@ -80,6 +81,7 @@ export const createRealtimeAPIs = () => {
     }
   };
 
+  app.use(lockerGitAPI.rlock);
   app.use(inflight());
   app.get("/", (c) => {
     if (c.req.header("Upgrade") !== "websocket") {
@@ -238,7 +240,7 @@ export const createRealtimeAPIs = () => {
       for await (const entry of walker) {
         const key = toPosix(entry.path.replace(root, "/"));
 
-        if (key.includes(".git")) {
+        if (key.includes(".git") || key.includes("node_modules")) {
           continue;
         }
 

--- a/deno.json
+++ b/deno.json
@@ -50,7 +50,7 @@
   "imports": {
     "$fresh/": "https://denopkg.com/denoland/fresh@1.6.8/",
     "@cliffy/prompt": "jsr:@cliffy/prompt@^1.0.0-rc.5",
-    "@core/asyncutil": "jsr:@core/asyncutil@^1.0.0",
+    "@core/asyncutil": "jsr:@core/asyncutil@^1.0.2",
     "@deco/durable": "jsr:@deco/durable@^0.5.3",
     "@deco/warp": "jsr:@deco/warp@^0.3.4",
     "@hono/hono": "jsr:@hono/hono@^4.5.4",
@@ -65,6 +65,7 @@
     "@std/fs": "jsr:@std/fs@^0.229.1",
     "@std/http": "jsr:@std/http@^1.0.0",
     "@std/io": "jsr:@std/io@^0.224.4",
+    "@std/jsonc": "jsr:@std/jsonc@^1.0.0",
     "@std/log": "jsr:@std/log@^0.224.5",
     "@std/media-types": "jsr:@std/media-types@^1.0.0-rc.1",
     "@std/path": "jsr:@std/path@^0.225.2",

--- a/deno.json
+++ b/deno.json
@@ -65,7 +65,6 @@
     "@std/fs": "jsr:@std/fs@^0.229.1",
     "@std/http": "jsr:@std/http@^1.0.0",
     "@std/io": "jsr:@std/io@^0.224.4",
-    "@std/jsonc": "jsr:@std/jsonc@^1.0.0",
     "@std/log": "jsr:@std/log@^0.224.5",
     "@std/media-types": "jsr:@std/media-types@^1.0.0-rc.1",
     "@std/path": "jsr:@std/path@^0.225.2",

--- a/engine/decofile/fsFolder.ts
+++ b/engine/decofile/fsFolder.ts
@@ -1,3 +1,4 @@
+import { Mutex } from "@core/asyncutil/mutex";
 import { debounce } from "@std/async/debounce";
 import { ensureFile } from "@std/fs";
 import { walk } from "@std/fs/walk";
@@ -13,7 +14,6 @@ import type {
   ReadOptions,
 } from "./provider.ts";
 import type { VersionedDecofile } from "./realtime.ts";
-import { Mutex } from "@core/asyncutil/mutex";
 
 export const parseBlockId = (filename: string) =>
   decodeURIComponent(filename.slice(0, filename.length - ".json".length));

--- a/engine/decofile/fsFolder.ts
+++ b/engine/decofile/fsFolder.ts
@@ -5,7 +5,6 @@ import { basename, join } from "@std/path";
 import getBlocks from "../../blocks/index.ts";
 import { Context } from "../../live.ts";
 import { exists } from "../../utils/filesystem.ts";
-import { Mutex } from "../../utils/sync.ts";
 import { BLOCKS_FOLDER, DECO_FOLDER, METADATA_PATH } from "./constants.ts";
 import type {
   Decofile,
@@ -14,6 +13,7 @@ import type {
   ReadOptions,
 } from "./provider.ts";
 import type { VersionedDecofile } from "./realtime.ts";
+import { Mutex } from "@core/asyncutil/mutex";
 
 export const parseBlockId = (filename: string) =>
   decodeURIComponent(filename.slice(0, filename.length - ".json".length));
@@ -123,7 +123,7 @@ export const newFsFolderProviderFromPath = (
       const watcher = Deno.watchFs(fullPath);
       let filesChangedBatch: string[] = [];
       const updateState = debounce(async () => {
-        using _ = await limiter.acquire();
+        using _lock = await limiter.acquire();
 
         // for each filesChangedBatch read them all
         // and update the state

--- a/utils/sync.ts
+++ b/utils/sync.ts
@@ -3,44 +3,6 @@ import { isAwaitable, type PromiseOrValue } from "../engine/core/utils.ts";
 export interface SyncOnce<T> {
   do: (cb: () => PromiseOrValue<T>) => PromiseOrValue<T>;
 }
-export class Mutex {
-  public locked: boolean;
-  public queue: Array<ReturnType<typeof Promise.withResolvers<void>>>;
-  constructor() {
-    this.locked = false;
-    this.queue = [];
-  }
-
-  acquire(): Promise<Disposable> {
-    const disposable = {
-      [Symbol.dispose]: () => {
-        return this.release();
-      },
-    };
-    if (!this.locked) {
-      this.locked = true;
-      return Promise.resolve(disposable);
-    }
-    const promise = Promise.withResolvers<void>();
-    this.queue.push(promise);
-    return promise.promise.then(() => {
-      return disposable;
-    });
-  }
-
-  freeOrNext(): boolean {
-    return !this.locked || this.queue.length === 0;
-  }
-
-  release() {
-    if (this.queue.length > 0) {
-      const next = this.queue.shift();
-      next?.resolve();
-    } else {
-      this.locked = false;
-    }
-  }
-}
 
 /**
  * Run the function only once.


### PR DESCRIPTION
Uses read-write lock to make sure there's one single git operation happening on the server.

When I'll use any git api, I do lock.wlock, to acquire a write lock. This makes sure one single request is being performed by the whole daemon set apis

When I'll use any other daemon apis, I do lock.rlock, to make sure many concurrent daemon apis can be used.

Also, I acquire the read lock for generating the manifest and metadata