### PR TITLE
Enhance Metadata Generation with "Used By" Tracking

### DIFF
--- a/engine/decofile/fsFolder.ts
+++ b/engine/decofile/fsFolder.ts
@@ -79,35 +79,45 @@ const inferMetadata = (
  * @param currentPath - The current path of the object being processed.
  * @param isRoot - Indicates whether the current object is the root object.
  */
+/**
+ * Recursively maps block references in an object and updates the `usedBy` property of the corresponding blocks.
+ *
+ * @param obj - The object to inspect for block references.
+ * @param blockMetadata - A map of block paths to block metadata.
+ * @param blockPathByName - A map of block names to their corresponding file paths.
+ * @param currentPath - The path of the current block being processed.
+ * @param isRoot - Indicates whether the current object is the root object.
+ */
 const mapBlockReferences = (
   obj: unknown,
-  blocks: Map<string, Metadata>,
+  blockMetadata: Map<string, Metadata>,
+  blockPathByName: Map<string, string>,
   currentPath: string,
-  isRoot = true,
+  isRoot = true
 ): void => {
-  if (typeof obj !== "object" || obj === null) return;
+  if (typeof obj !== 'object' || obj === null) return;
 
   if (Array.isArray(obj)) {
-    obj.forEach((item) => mapBlockReferences(item, blocks, currentPath, false));
-  } else {
-    for (const [key, value] of Object.entries(obj)) {
-      if (key === "__resolveType" && typeof value === "string" && !isRoot) {
-        const blockName = value.split("/").pop();
-        if (blockName) {
-          const blockPath = Array.from(blocks.keys()).find((path) =>
-            decodeURIComponent(path.split("/").pop() ?? "") ===
-              `${blockName}.json`
-          );
-          if (blockPath && blockPath !== currentPath) {
-            const block = blocks.get(blockPath);
-            if (block && !block.usedBy.includes(currentPath)) {
-              block.usedBy.push(currentPath);
-            }
+    for (const item of obj) {
+      mapBlockReferences(item, blockMetadata, blockPathByName, currentPath, false);
+    }
+    return;
+  }
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === '__resolveType' && !isRoot) {
+      const blockName = value.split('/').pop();
+      if (blockName) {
+        const referencedBlockPath = blockPathByName.get(blockName);
+        if (referencedBlockPath && referencedBlockPath !== currentPath) {
+          const blockMeta = blockMetadata.get(referencedBlockPath);
+          if (blockMeta && !blockMeta.usedBy.includes(currentPath)) {
+            blockMeta.usedBy.push(currentPath);
           }
         }
-      } else if (typeof value === "object" && value !== null) {
-        mapBlockReferences(value, blocks, currentPath, false);
       }
+    } else if (typeof value === 'object' && value !== null) {
+      mapBlockReferences(value, blockMetadata, blockPathByName, currentPath, false);
     }
   }
 };
@@ -116,7 +126,7 @@ const mapBlockReferences = (
 export const genMetadata = async () => {
   try {
     const knownBlockTypes = new Set(getBlocks().map((x) => x.type));
-    const paths: string[] = [];
+    const blockPaths: string[] = [];
 
     const walker = walk(join(DECO_FOLDER, BLOCKS_FOLDER), {
       includeDirs: false,
@@ -125,11 +135,11 @@ export const genMetadata = async () => {
     });
 
     for await (const entry of walker) {
-      paths.push(entry.path);
+      blockPaths.push(entry.path);
     }
 
-    const entries = await Promise.all(
-      paths.map(async (path) =>
+    const blockEntries = await Promise.all(
+      blockPaths.map(async (path) =>
         [
           `/${path.replaceAll("\\", "/")}`,
           JSON.parse(await Deno.readTextFile(path)),
@@ -137,22 +147,27 @@ export const genMetadata = async () => {
       ),
     );
 
-    const metadata = new Map(
-      entries.map(([path, content]) => [
-        path,
-        inferMetadata(content, knownBlockTypes),
-      ]).filter(([, meta]) => meta !== null) as [string, Metadata][],
-    );
+    const blockMetadata: Map<string, Metadata> = new Map();
+    const blockPathByName = new Map<string, string>();
 
-    for (const [path, content] of entries) {
-      mapBlockReferences(content, metadata, path);
+    for (const [path, content] of blockEntries) {
+      const meta = inferMetadata(content, knownBlockTypes);
+      if (meta !== null) {
+        blockMetadata.set(path, meta);
+        const blockName = parseBlockId(basename(path));
+        blockPathByName.set(blockName, path);
+      }
     }
 
-    const pathname = join(Deno.cwd(), METADATA_PATH);
-    await ensureFile(pathname);
+    for (const [path, content] of blockEntries) {
+      mapBlockReferences(content, blockMetadata, blockPathByName, path);
+    }
+
+    const metadataPath = join(Deno.cwd(), METADATA_PATH);
+    await ensureFile(metadataPath);
     await Deno.writeTextFile(
-      pathname,
-      JSON.stringify(Object.fromEntries(metadata)),
+      metadataPath,
+      JSON.stringify(Object.fromEntries(blockMetadata)),
     );
   } catch (error) {
     console.error("Error while auto-generating blocks.json", error);

--- a/engine/decofile/fsFolder.ts
+++ b/engine/decofile/fsFolder.ts
@@ -39,7 +39,10 @@ const inferBlockType = (resolveType: string, knownBlockTypes: Set<string>) => {
   return blockType;
 };
 
-const inferMetadata = (content: unknown, knownBlockTypes: Set<string>): Metadata | null => {
+const inferMetadata = (
+  content: unknown,
+  knownBlockTypes: Set<string>,
+): Metadata | null => {
   try {
     const { __resolveType, name, path } = content as Record<string, string>;
     const blockType = inferBlockType(__resolveType, knownBlockTypes);
@@ -70,7 +73,7 @@ const inferMetadata = (content: unknown, knownBlockTypes: Set<string>): Metadata
 
 /**
  * Recursively maps block references in an object and updates the `usedBy` property of the corresponding blocks.
- * 
+ *
  * @param obj - The object to map block references in.
  * @param blocks - A map of block paths to block metadata.
  * @param currentPath - The current path of the object being processed.
@@ -80,19 +83,20 @@ const mapBlockReferences = (
   obj: unknown,
   blocks: Map<string, Metadata>,
   currentPath: string,
-  isRoot = true
+  isRoot = true,
 ): void => {
-  if (typeof obj !== 'object' || obj === null) return;
+  if (typeof obj !== "object" || obj === null) return;
 
   if (Array.isArray(obj)) {
-    obj.forEach(item => mapBlockReferences(item, blocks, currentPath, false));
+    obj.forEach((item) => mapBlockReferences(item, blocks, currentPath, false));
   } else {
     for (const [key, value] of Object.entries(obj)) {
-      if (key === '__resolveType' && typeof value === 'string' && !isRoot) {
-        const blockName = value.split('/').pop();
+      if (key === "__resolveType" && typeof value === "string" && !isRoot) {
+        const blockName = value.split("/").pop();
         if (blockName) {
-          const blockPath = Array.from(blocks.keys()).find(path => 
-            decodeURIComponent(path.split('/').pop() ?? '') === `${blockName}.json`
+          const blockPath = Array.from(blocks.keys()).find((path) =>
+            decodeURIComponent(path.split("/").pop() ?? "") ===
+              `${blockName}.json`
           );
           if (blockPath && blockPath !== currentPath) {
             const block = blocks.get(blockPath);
@@ -101,7 +105,7 @@ const mapBlockReferences = (
             }
           }
         }
-      } else if (typeof value === 'object' && value !== null) {
+      } else if (typeof value === "object" && value !== null) {
         mapBlockReferences(value, blocks, currentPath, false);
       }
     }
@@ -137,7 +141,7 @@ export const genMetadata = async () => {
       entries.map(([path, content]) => [
         path,
         inferMetadata(content, knownBlockTypes),
-      ]).filter(([, meta]) => meta !== null) as [string, Metadata][]
+      ]).filter(([, meta]) => meta !== null) as [string, Metadata][],
     );
 
     for (const [path, content] of entries) {
@@ -146,7 +150,10 @@ export const genMetadata = async () => {
 
     const pathname = join(Deno.cwd(), METADATA_PATH);
     await ensureFile(pathname);
-    await Deno.writeTextFile(pathname, JSON.stringify(Object.fromEntries(metadata)));
+    await Deno.writeTextFile(
+      pathname,
+      JSON.stringify(Object.fromEntries(metadata)),
+    );
   } catch (error) {
     console.error("Error while auto-generating blocks.json", error);
   }


### PR DESCRIPTION
## Description
This PR enhances the metadata generation process by introducing a `usedBy` field to track where each saved block is utilized across the project

### Key Changes:
`usedBy` Tracking: Added logic to identify and record references between saved blocks, updating the metadata with this information.

### Example (from `blocks.json`):

```json
{
  "/.deco/blocks/Footer.json": {
    "blockType": "sections",
    "__resolveType": "site/sections/Footer.tsx",
    "usedBy": [
      "/.deco/blocks/pages-test-3c04f2690620.json",
      "/.deco/blocks/pages-home-5afd25174424.json",
      "/.deco/blocks/pages-testing-a5c1b57018a9.json"
    ]
  }
}
```
