### PR TITLE
fix(loader): prevent sections not being cached when ENABLE_LOADER_CACHE is false

### DIFF
--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -180,12 +180,12 @@ const wrapLoader = (
       const isCacheModeToBypass = mode === "no-store";
 
       const bypassCache = isCacheModeToBypass ||
-        !isCacheEngineDefined ||
         isCacheKeyValueToBypass;
       try {
         // Should skip cache
         if (
           !ENABLE_LOADER_CACHE ||
+          !isCacheEngineDefined ||
           bypassCache ||
           // This code is unreachable, but the TS complains that cache is undefined because
           // it doesn't get that isCache is inside of bypassCache variable

--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -173,10 +173,15 @@ const wrapLoader = (
       const loader = ctx.resolverId || "unknown";
       const start = performance.now();
       let status: "bypass" | "miss" | "stale" | "hit" | undefined;
+
       const cacheKeyValue = cacheKey(props, req, ctx);
-      const bypassCache = mode === "no-store" ||
-        !isCache(maybeCache) ||
-        cacheKeyValue === null;
+      const isCacheKeyValueToBypass = cacheKeyValue === null;
+      const isCacheEngineDefined = isCache(maybeCache);
+      const isCacheModeToBypass = mode === "no-store";
+
+      const bypassCache = isCacheModeToBypass ||
+        !isCacheEngineDefined ||
+        isCacheKeyValueToBypass;
       try {
         // Should skip cache
         if (

--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -176,16 +176,17 @@ const wrapLoader = (
 
       const cacheKeyValue = cacheKey(props, req, ctx);
       const isCacheKeyValueToBypass = cacheKeyValue === null;
-      const isCacheEngineDefined = isCache(maybeCache);
       const isCacheModeToBypass = mode === "no-store";
-
-      const bypassCache = isCacheModeToBypass ||
+      const shouldVary = isCacheModeToBypass ||
         isCacheKeyValueToBypass;
+
+      const isCacheEngineDefined = isCache(maybeCache);
+      const bypassCache = !ENABLE_LOADER_CACHE ||
+        !isCacheEngineDefined ||
+        shouldVary;
       try {
         // Should skip cache
         if (
-          !ENABLE_LOADER_CACHE ||
-          !isCacheEngineDefined ||
           bypassCache ||
           // This code is unreachable, but the TS complains that cache is undefined because
           // it doesn't get that isCache is inside of bypassCache variable
@@ -195,7 +196,7 @@ const wrapLoader = (
            * This vary should cache is used to vary sections content. Even if the loader results isn't being cached,
            * the sections could be cached
            */
-          if (ctx.vary && bypassCache) {
+          if (ctx.vary && shouldVary) {
             ctx.vary.shouldCache = false;
           }
 

--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -174,15 +174,20 @@ const wrapLoader = (
       const start = performance.now();
       let status: "bypass" | "miss" | "stale" | "hit" | undefined;
       const cacheKeyValue = cacheKey(props, req, ctx);
+      const bypassCache = mode === "no-store" ||
+        !isCache(maybeCache) ||
+        cacheKeyValue === null;
       try {
         // Should skip cache
         if (
-          mode === "no-store" ||
           !ENABLE_LOADER_CACHE ||
-          !isCache(maybeCache) ||
-          cacheKeyValue === null
+          bypassCache
         ) {
-          if (ctx.vary) {
+          /**
+           * This vary should cache is used to vary sections content. Even if the loader results isn't being cached,
+           * the sections could be cached
+           */
+          if (ctx.vary && bypassCache) {
             ctx.vary.shouldCache = false;
           }
 

--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -181,7 +181,10 @@ const wrapLoader = (
         // Should skip cache
         if (
           !ENABLE_LOADER_CACHE ||
-          bypassCache
+          bypassCache ||
+          // This code is unreachable, but the TS complains that cache is undefined because
+          // it doesn't get that isCache is inside of bypassCache variable
+          !isCache(maybeCache)
         ) {
           /**
            * This vary should cache is used to vary sections content. Even if the loader results isn't being cached,


### PR DESCRIPTION
This pr enables sites that uses websites/sections/Rendering/Lazy.tsx to cache their responses even if ENABLE_LOADER_CACHE is false.