### PR TITLE
feat(loader): allow loader bypass cache and but allow sections being cached

### DIFF
--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -173,16 +173,30 @@ const wrapLoader = (
       const loader = ctx.resolverId || "unknown";
       const start = performance.now();
       let status: "bypass" | "miss" | "stale" | "hit" | undefined;
+
       const cacheKeyValue = cacheKey(props, req, ctx);
+      const isCacheKeyValueToBypass = cacheKeyValue === null;
+      const isCacheModeToBypass = mode === "no-store";
+      const shouldVary = isCacheModeToBypass ||
+        isCacheKeyValueToBypass;
+
+      const isCacheEngineDefined = isCache(maybeCache);
+      const bypassCache = !ENABLE_LOADER_CACHE ||
+        !isCacheEngineDefined ||
+        shouldVary;
       try {
         // Should skip cache
         if (
-          mode === "no-store" ||
-          !ENABLE_LOADER_CACHE ||
-          !isCache(maybeCache) ||
-          cacheKeyValue === null
+          bypassCache ||
+          // This code is unreachable, but the TS complains that cache is undefined because
+          // it doesn't get that isCache is inside of bypassCache variable
+          !isCache(maybeCache)
         ) {
-          if (ctx.vary) {
+          /**
+           * This vary should cache is used to vary sections content. Even if the loader results isn't being cached,
+           * the sections could be cached
+           */
+          if (ctx.vary && shouldVary) {
             ctx.vary.shouldCache = false;
           }
 

--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -175,15 +175,15 @@ const wrapLoader = (
       let status: "bypass" | "miss" | "stale" | "hit" | undefined;
 
       const cacheKeyValue = cacheKey(props, req, ctx);
-      const isCacheKeyValueToBypass = cacheKeyValue === null;
-      const isCacheModeToBypass = mode === "no-store";
-      const shouldVary = isCacheModeToBypass ||
-        isCacheKeyValueToBypass;
+      const isCacheKeyNull = cacheKeyValue === null;
+      const isCacheModeNoStore = mode === "no-store";
+      const preventVary = isCacheModeNoStore ||
+        isCacheKeyNull;
 
       const isCacheEngineDefined = isCache(maybeCache);
       const bypassCache = !ENABLE_LOADER_CACHE ||
         !isCacheEngineDefined ||
-        shouldVary;
+        preventVary;
       try {
         // Should skip cache
         if (
@@ -196,8 +196,10 @@ const wrapLoader = (
            * This vary should cache is used to vary sections content. Even if the loader results isn't being cached,
            * the sections could be cached
            */
-          if (ctx.vary && shouldVary) {
+          if (ctx.vary && preventVary) {
             ctx.vary.shouldCache = false;
+          } else if (!preventVary) {
+            ctx.vary?.push(loader, cacheKeyValue ?? "");
           }
 
           status = "bypass";


### PR DESCRIPTION
This pr enables sites that uses websites/sections/Rendering/Lazy.tsx to cache their responses even if ENABLE_LOADER_CACHE is false.