### PR TITLE
fix: use deno user permissions for deno-dir

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -66,7 +66,7 @@ jobs:
           # maybe add deno lsp?
           RUN apk add git openssh
           RUN DENO_DIR=/daemon-deno-dir deno cache jsr:@deco/deco@$IMAGE_TAG_COMMIT/scripts/run
-          RUN mkdir -p /home/deno && chown -R deno:deno /home/deno && mkdir /app/deco && chown -R deno:deno /app && mkdir -p /deno-dir && chown -R deno:deno /deno-dir
+          RUN mkdir -p /home/deno && chown -R deno:deno /home/deno && mkdir /app/deco && chown -R deno:deno /app && mkdir -p /deno-dir && chown -R deno:deno /deno-dir && chown -R deno:deno /daemon-deno-dir
 
           # Prefer not to run as root.
           USER deno


### PR DESCRIPTION
I think this fixes 
<img width="1114" alt="Screenshot 2024-08-21 at 21 20 33" src="https://github.com/user-attachments/assets/bd15a47e-45df-4af0-ae59-0570a2b8f64e">
