### PR TITLE
feat: add shouldDecodeChunk to readFromStream

### DIFF
--- a/clients/withManifest.ts
+++ b/clients/withManifest.ts
@@ -43,6 +43,7 @@ export const isEventStreamResponse = (
 
 export async function* readFromStream<T>(
   response: Response,
+  shouldDecodeChunk?: boolean,
 ): AsyncIterableIterator<T> {
   if (!response.body) {
     return;
@@ -71,7 +72,8 @@ export async function* readFromStream<T>(
       }
 
       try {
-        yield JSON.parse(decodeURIComponent(data.replace("data:", "")));
+        const chunk = data.replace("data:", "");
+        yield JSON.parse(shouldDecodeChunk ? decodeURIComponent(chunk) : chunk);
       } catch (_err) {
         console.log("error parsing data", _err, data);
         continue;

--- a/clients/withManifest.ts
+++ b/clients/withManifest.ts
@@ -71,8 +71,6 @@ export async function* readFromStream<T>(
         continue;
       }
 
-      console.log(shouldDecodeChunk);
-
       try {
         const chunk = data.replace("data:", "");
         yield JSON.parse(shouldDecodeChunk ? decodeURIComponent(chunk) : chunk);

--- a/clients/withManifest.ts
+++ b/clients/withManifest.ts
@@ -43,7 +43,7 @@ export const isEventStreamResponse = (
 
 export async function* readFromStream<T>(
   response: Response,
-  shouldDecodeChunk?: boolean,
+  shouldDecodeChunk: boolean = true,
 ): AsyncIterableIterator<T> {
   if (!response.body) {
     return;
@@ -70,6 +70,8 @@ export async function* readFromStream<T>(
       if (!data.startsWith("data:")) {
         continue;
       }
+
+      console.log(shouldDecodeChunk);
 
       try {
         const chunk = data.replace("data:", "");


### PR DESCRIPTION
## Description
Introduces the `shouldDecodeChunk` parameter to `readFromStream` for conditional decoding of stream chunks. Default behavior remains unchanged unless shouldDecodeChunk is set to false.
- Default Behavior: If `shouldDecodeChunk` is `true` or not provided, the function behaves as before, decoding the chunk with `decodeURIComponent`.
- New Flexibility: If `shouldDecodeChunk` is `false`, the chunk will bypass decoding, allowing for direct JSON parsing.
