### PR TITLE
Adding return types to avoid compilation errors

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Publish package
-        run: npx jsr publish --allow-slow-types
+        run: npx jsr publish
 
       - name: Publish script package
         run: cd scripts/ && npx jsr publish

--- a/blocks/page.tsx
+++ b/blocks/page.tsx
@@ -1,12 +1,18 @@
 /** @jsxRuntime automatic */
 /** @jsxImportSource preact */
 
-import type { InstanceOf } from "../engine/block.ts";
-import { createSectionBlock } from "./section.ts";
+import type { Block, InstanceOf, ResolverLike } from "../engine/block.ts";
+import { createSectionBlock, type SectionModule } from "./section.ts";
 
 export type Page = InstanceOf<typeof page, "#/root/pages">;
 
-const page = createSectionBlock(
+const page: Block<
+  SectionModule<any, any, any, any>,
+  ResolverLike<any>,
+  string,
+  any,
+  any
+> = createSectionBlock(
   (component, ComponentFunc) => (props, { resolveChain }) => ({
     Component: (p) => <ComponentFunc {...p} />,
     props,

--- a/blocks/utils.tsx
+++ b/blocks/utils.tsx
@@ -164,7 +164,7 @@ export const applyProps = <
 (
   $live: TProps,
   ctx: HttpContext<{ global: any } & RequestState>,
-) => { // by default use global state
+): PromiseOrValue<TResp> => { // by default use global state
   return func.default(
     $live,
     ctx.request,

--- a/clients/proxy.ts
+++ b/clients/proxy.ts
@@ -45,7 +45,7 @@ export class InvokeAwaiter<
   ) {
   }
 
-  public get() {
+  public get(): Invoke<TManifest, TInvocableKey, TFuncSelector> {
     return this.payload;
   }
 

--- a/clients/withManifest.ts
+++ b/clients/withManifest.ts
@@ -315,7 +315,7 @@ export const create = <TManifest extends AppManifest>() =>
 ): Promise<InvokeResult<TPayload, TManifest>> =>
   invokeKey(key, props, init) as Promise<InvokeResult<TPayload, TManifest>>;
 
-interface ManifestInvoke<TManifest extends AppManifest> {
+export interface ManifestInvoke<TManifest extends AppManifest> {
   invoke: ReturnType<typeof invoke<TManifest>>;
   create: ReturnType<typeof create<TManifest>>;
 }
@@ -368,14 +368,10 @@ export const proxy = <TManifest extends AppManifest>(
   return proxyFor(invoke<TManifest>(fetcher) as typeof batchInvoke);
 };
 
-interface forAppType<TApp extends App> {
-  create: ReturnType<typeof create<ManifestOf<TApp>>>;
-  invoke: InvocationProxyWithBatcher<ManifestOf<TApp>>;
-}
 /**
  * Creates a proxy that lets you invoke functions based on the declared actions and loaders. (compatibility with old invoke)
  */
-export const forApp = <TApp extends App>(): forAppType<TApp> => {
+export const forApp = <TApp extends App>(): ManifestInvoke<ManifestOf<TApp>> => {
   const { create } = withManifest<ManifestOf<TApp>>();
   return {
     create: create,

--- a/clients/withManifest.ts
+++ b/clients/withManifest.ts
@@ -315,15 +315,23 @@ export const create = <TManifest extends AppManifest>() =>
 ): Promise<InvokeResult<TPayload, TManifest>> =>
   invokeKey(key, props, init) as Promise<InvokeResult<TPayload, TManifest>>;
 
+interface WithManifestReturn<TManifest extends AppManifest> {
+  invoke: ReturnType<typeof invoke<TManifest>>;
+  create: ReturnType<typeof create<TManifest>>;
+}
+
 /**
  * Creates a set of strongly-typed utilities to be used across the repositories where pointing to an existing function is supported.
  */
-export const withManifest = <TManifest extends AppManifest>() => {
+export const withManifest = <
+  TManifest extends AppManifest,
+>(): WithManifestReturn<TManifest> => {
   return {
     /**
      * Invokes the target function using the invoke api.
      */
     invoke: invoke<TManifest>(),
+
     /**
      * Creates an invoker function. Usage:
      *
@@ -360,10 +368,14 @@ export const proxy = <TManifest extends AppManifest>(
   return proxyFor(invoke<TManifest>(fetcher) as typeof batchInvoke);
 };
 
+interface forAppType<TApp extends App> {
+  create: ReturnType<typeof create<ManifestOf<TApp>>>;
+  invoke: InvocationProxyWithBatcher<ManifestOf<TApp>>;
+}
 /**
  * Creates a proxy that lets you invoke functions based on the declared actions and loaders. (compatibility with old invoke)
  */
-export const forApp = <TApp extends App>() => {
+export const forApp = <TApp extends App>(): forAppType<TApp> => {
   const { create } = withManifest<ManifestOf<TApp>>();
   return {
     create: create,

--- a/clients/withManifest.ts
+++ b/clients/withManifest.ts
@@ -315,7 +315,7 @@ export const create = <TManifest extends AppManifest>() =>
 ): Promise<InvokeResult<TPayload, TManifest>> =>
   invokeKey(key, props, init) as Promise<InvokeResult<TPayload, TManifest>>;
 
-interface WithManifestReturn<TManifest extends AppManifest> {
+interface ManifestInvoke<TManifest extends AppManifest> {
   invoke: ReturnType<typeof invoke<TManifest>>;
   create: ReturnType<typeof create<TManifest>>;
 }
@@ -325,7 +325,7 @@ interface WithManifestReturn<TManifest extends AppManifest> {
  */
 export const withManifest = <
   TManifest extends AppManifest,
->(): WithManifestReturn<TManifest> => {
+>(): ManifestInvoke<TManifest> => {
   return {
     /**
      * Invokes the target function using the invoke api.

--- a/components/JsonViewer.tsx
+++ b/components/JsonViewer.tsx
@@ -2,6 +2,7 @@
 /** @jsxImportSource preact */
 
 import { useFramework } from "../runtime/handler.tsx";
+import type { JSX } from "preact";
 
 export interface Props {
   body: string;
@@ -43,7 +44,7 @@ const snippet = (json: string) => {
   );
 };
 
-export default function JsonViewer(p: Props) {
+export default function JsonViewer(p: Props): JSX.Element {
   const { Head } = useFramework();
   return (
     <>

--- a/deco.ts
+++ b/deco.ts
@@ -57,6 +57,13 @@ export interface DecoContext<TAppManifest extends AppManifest = AppManifest> {
   request?: RequestContext;
 }
 
+export interface ContextResponse {
+  active: () => RequestContext | undefined; 
+  bind: <R, TArgs extends unknown[]>(request: RequestContext, 
+    f: (...args: TArgs) => R) => (...args: TArgs) => R; readonly signal: AbortSignal | undefined; 
+    readonly framework: "fresh" | "htmx"; 
+}
+
 const deploymentId = Deno.env.get("DENO_DEPLOYMENT_ID");
 const isDeploy = Boolean(deploymentId);
 
@@ -109,8 +116,8 @@ export const Context = {
   },
 };
 
-export const RequestContext = {
-  active: () => Context.active().request,
+export const RequestContext: ContextResponse = {
+  active: (): RequestContext | undefined => Context.active().request,
   bind: <R, TArgs extends unknown[]>(
     request: RequestContext,
     f: (...args: TArgs) => R,

--- a/deco.ts
+++ b/deco.ts
@@ -109,7 +109,6 @@ export const Context = {
   },
 };
 
-
 export const RequestContext = {
   active: () => Context.active().request,
   bind: <R, TArgs extends unknown[]>(

--- a/deco.ts
+++ b/deco.ts
@@ -109,6 +109,7 @@ export const Context = {
   },
 };
 
+
 export const RequestContext = {
   active: () => Context.active().request,
   bind: <R, TArgs extends unknown[]>(

--- a/deco.ts
+++ b/deco.ts
@@ -58,10 +58,13 @@ export interface DecoContext<TAppManifest extends AppManifest = AppManifest> {
 }
 
 export interface ContextResponse {
-  active: () => RequestContext | undefined; 
-  bind: <R, TArgs extends unknown[]>(request: RequestContext, 
-    f: (...args: TArgs) => R) => (...args: TArgs) => R; readonly signal: AbortSignal | undefined; 
-    readonly framework: "fresh" | "htmx"; 
+  active: () => RequestContext | undefined;
+  bind: <R, TArgs extends unknown[]>(
+    request: RequestContext,
+    f: (...args: TArgs) => R,
+  ) => (...args: TArgs) => R;
+  readonly signal: AbortSignal | undefined;
+  readonly framework: "fresh" | "htmx";
 }
 
 const deploymentId = Deno.env.get("DENO_DEPLOYMENT_ID");

--- a/deco.ts
+++ b/deco.ts
@@ -57,7 +57,7 @@ export interface DecoContext<TAppManifest extends AppManifest = AppManifest> {
   request?: RequestContext;
 }
 
-export interface ContextResponse {
+export interface RequestContextBinder {
   active: () => RequestContext | undefined;
   bind: <R, TArgs extends unknown[]>(
     request: RequestContext,
@@ -119,7 +119,7 @@ export const Context = {
   },
 };
 
-export const RequestContext: ContextResponse = {
+export const RequestContext: RequestContextBinder = {
   active: (): RequestContext | undefined => Context.active().request,
   bind: <R, TArgs extends unknown[]>(
     request: RequestContext,

--- a/deno.json
+++ b/deno.json
@@ -23,7 +23,7 @@
     "component": "deno eval 'import \"deco/scripts/component.ts\"'",
     "order_imports": "deno eval 'import \"deco/scripts/order_imports.ts\"'",
     "release": "deno run -A ./scripts/release.ts",
-    "check": "deno fmt && deno check live.ts && deno test -A . && deno bench -A .",
+    "check": "deno fmt && deno check live.ts && deno  --unstable-http test -A . && deno bench -A .",
     "cache_clean": "rm deno.lock; deno cache -r live.ts",
     "info_json": "deno info --json live.ts > deps.json",
     "detective": "deno run -A https://deno.land/x/detective/detective.ts deps.json",

--- a/deps.ts
+++ b/deps.ts
@@ -19,8 +19,9 @@ export {
   SpanKind,
   SpanStatusCode,
   trace,
-  ValueType,
+  ValueType
 } from "npm:@opentelemetry/api@1.9.0";
+export type { Meter } from "npm:@opentelemetry/api@1.9.0";
 export type {
   Attributes,
   BatchObservableResult,

--- a/deps.ts
+++ b/deps.ts
@@ -19,7 +19,7 @@ export {
   SpanKind,
   SpanStatusCode,
   trace,
-  ValueType
+  ValueType,
 } from "npm:@opentelemetry/api@1.9.0";
 export type { Meter } from "npm:@opentelemetry/api@1.9.0";
 export type {

--- a/engine/core/resolver.ts
+++ b/engine/core/resolver.ts
@@ -107,7 +107,7 @@ const SCORE_BY_RESOLVE_TYPES = new Map(
 );
 
 export const FieldResolver = {
-  minify: (chain: FieldResolver[]) => {
+  minify: (chain: FieldResolver[]): (string | number | undefined)[] => {
     const minified = [];
 
     for (const c of chain) {
@@ -117,7 +117,7 @@ export const FieldResolver = {
 
     return minified;
   },
-  unwind: (minified: string[]) => {
+  unwind: (minified: string[]): FieldResolver[] => {
     const unwinded: FieldResolver[] = [];
 
     for (let it = 0; it < minified.length; it += 2) {

--- a/engine/core/resolver.ts
+++ b/engine/core/resolver.ts
@@ -107,11 +107,11 @@ const SCORE_BY_RESOLVE_TYPES = new Map(
 );
 
 export const FieldResolver = {
-  minify: (chain: FieldResolver[]): (string | number | undefined)[] => {
+  minify: (chain: FieldResolver[]): (string | number)[] => {
     const minified = [];
 
     for (const c of chain) {
-      minified.push(SCORE_BY_RESOLVE_TYPES.get(c.type));
+      minified.push(SCORE_BY_RESOLVE_TYPES.get(c.type)!);
       minified.push(c.value);
     }
 

--- a/hooks/useDevice.ts
+++ b/hooks/useDevice.ts
@@ -1,7 +1,7 @@
 import { useContext } from "preact/hooks";
 import { SectionContext } from "../components/section.tsx";
 
-export const useDevice = () => {
+export const useDevice = (): string => {
   const ctx = useContext(SectionContext);
 
   if (typeof document !== "undefined") {

--- a/hooks/usePartialSection.ts
+++ b/hooks/usePartialSection.ts
@@ -7,7 +7,14 @@ interface Options<P> extends SO<P> {
   mode?: "replace" | "append" | "prepend";
 }
 
-export const usePartialSection = <P>(props: Options<P> = {}) => ({
+interface PartialSectionReturnType {
+  [CLIENT_NAV_ATTR]: boolean;
+  [PARTIAL_ATTR]: string;
+}
+
+export const usePartialSection = <P>(
+  props: Options<P> = {},
+): PartialSectionReturnType => ({
   [CLIENT_NAV_ATTR]: true,
   [PARTIAL_ATTR]: `${useSection(props)}&fresh-partial=true&partialMode=${
     props.mode || "replace"

--- a/hooks/usePartialSection.ts
+++ b/hooks/usePartialSection.ts
@@ -7,14 +7,14 @@ interface Options<P> extends SO<P> {
   mode?: "replace" | "append" | "prepend";
 }
 
-interface PartialSectionReturnType {
-  [CLIENT_NAV_ATTR]: boolean;
-  [PARTIAL_ATTR]: string;
+interface PartialSectionAttrs {
+  "f-client-nav": boolean;
+  "f-partial": string;
 }
 
 export const usePartialSection = <P>(
   props: Options<P> = {},
-): PartialSectionReturnType => ({
+): PartialSectionAttrs => ({
   [CLIENT_NAV_ATTR]: true,
   [PARTIAL_ATTR]: `${useSection(props)}&fresh-partial=true&partialMode=${
     props.mode || "replace"

--- a/hooks/useScript.ts
+++ b/hooks/useScript.ts
@@ -62,7 +62,7 @@ const minify = async (js: string) => {
 export function useScript<T extends (...args: any[]) => any>(
   fn: T,
   ...params: Parameters<T>
-) {
+): string {
   const javascript = fn.toString();
   const cached = cache.get(javascript) || minify(javascript);
 
@@ -86,6 +86,6 @@ export function useScript<T extends (...args: any[]) => any>(
 export function useScriptAsDataURI<T extends (...args: any[]) => any>(
   fn: T,
   ...params: Parameters<T>
-) {
+): string {
   return `data:text/javascript,${encodeURIComponent(useScript(fn, ...params))}`;
 }

--- a/hooks/useSection.ts
+++ b/hooks/useSection.ts
@@ -17,7 +17,7 @@ export type Options<P> = {
 
 export const useSection = <P>(
   { props = {}, href }: Pick<Options<P>, "href" | "props"> = {},
-) => {
+): string => {
   const ctx = useContext(SectionContext);
   const revisionId = ctx?.revision;
   const vary = ctx?.context.state.vary.build();

--- a/observability/otel/metrics.ts
+++ b/observability/otel/metrics.ts
@@ -1,3 +1,4 @@
+import type { Meter } from "npm:@opentelemetry/api@1.9.0";
 import {
   ExplicitBucketHistogramAggregation,
   MeterProvider,
@@ -50,4 +51,4 @@ if (OTEL_IS_ENABLED) {
   );
 }
 
-export const meter = meterProvider.getMeter("deco");
+export const meter: Meter = meterProvider.getMeter("deco");

--- a/observability/otel/metrics.ts
+++ b/observability/otel/metrics.ts
@@ -1,6 +1,5 @@
 import {
   ExplicitBucketHistogramAggregation,
-  type Meter,
   MeterProvider,
   OTLPMetricExporter,
   PeriodicExportingMetricReader,
@@ -22,6 +21,7 @@ const headersStringToObject = (headersString: string | undefined | null) => {
 const msBoundaries = [10, 100, 500, 1000, 5000, 10000, 15000];
 const sBoundaries = [1, 5, 10, 50];
 
+type IMeter = ReturnType<MeterProvider["getMeter"]>;
 const meterProvider: MeterProvider = new MeterProvider({
   resource,
   views: [
@@ -51,4 +51,4 @@ if (OTEL_IS_ENABLED) {
   );
 }
 
-export const meter: Meter = meterProvider.getMeter("deco");
+export const meter: IMeter = meterProvider.getMeter("deco");

--- a/observability/otel/metrics.ts
+++ b/observability/otel/metrics.ts
@@ -1,4 +1,3 @@
-import type { Meter } from "npm:@opentelemetry/api@1.9.0";
 import {
   ExplicitBucketHistogramAggregation,
   MeterProvider,
@@ -51,4 +50,4 @@ if (OTEL_IS_ENABLED) {
   );
 }
 
-export const meter: Meter = meterProvider.getMeter("deco");
+export const meter = meterProvider.getMeter("deco");

--- a/observability/otel/metrics.ts
+++ b/observability/otel/metrics.ts
@@ -4,6 +4,7 @@ import {
   OTLPMetricExporter,
   PeriodicExportingMetricReader,
   View,
+  type Meter
 } from "../../deps.ts";
 import { OTEL_IS_ENABLED, resource } from "./config.ts";
 // a=b,c=d => {a:b, c:d}
@@ -50,4 +51,4 @@ if (OTEL_IS_ENABLED) {
   );
 }
 
-export const meter = meterProvider.getMeter("deco");
+export const meter: Meter = meterProvider.getMeter("deco");

--- a/observability/otel/metrics.ts
+++ b/observability/otel/metrics.ts
@@ -1,10 +1,10 @@
 import {
   ExplicitBucketHistogramAggregation,
+  type Meter,
   MeterProvider,
   OTLPMetricExporter,
   PeriodicExportingMetricReader,
   View,
-  type Meter
 } from "../../deps.ts";
 import { OTEL_IS_ENABLED, resource } from "./config.ts";
 // a=b,c=d => {a:b, c:d}

--- a/runtime/caches/mod.ts
+++ b/runtime/caches/mod.ts
@@ -4,12 +4,13 @@ import {
   caches as cachesFileSystem,
   isFileSystemAvailable,
 } from "./fileSystem.ts";
-// TODO(mcandeia) s3 and redis is not being used and together they are 30% of the bundle size of deco, so we should remove them for now and add it dinamically later.
+// TODO(mcandeia) s3 and redis are not being used and together they are 30% of the bundle size of deco,
+// so we should remove them for now and add it dinamically later.
 // import { caches as redisCache, redis } from "./redis.ts";
 // import { caches as cachesS3, isS3Available } from "./s3.ts";
 import { createTieredCache } from "./tiered.ts";
 
-export const ENABLE_LOADER_CACHE =
+export const ENABLE_LOADER_CACHE: boolean =
   Deno.env.get("ENABLE_LOADER_CACHE") === "true";
 const DEFAULT_CACHE_ENGINE = "CACHE_API";
 const WEB_CACHE_ENGINES: CacheEngine[] = Deno.env.has("WEB_CACHE_ENGINE")

--- a/runtime/errors.ts
+++ b/runtime/errors.ts
@@ -62,14 +62,14 @@ export const badRequest: ResponseErrorBuilder = status(400);
  * Stop any config resolution and throw an exception that should be returned to the main handler.
  * @param resp
  */
-export const shortcircuit = (resp: Response) => {
+export const shortcircuit = (resp: Response): HttpError => {
   throw new HttpError(resp);
 };
 
 /**
  * Redirect using the specified @param url.
  */
-export const redirect = (url: string | URL, status?: number) => {
+export const redirect = (url: string | URL, status?: number): void => {
   shortcircuit(
     new Response(null, {
       status: status ?? 307,

--- a/runtime/features/invoke.ts
+++ b/runtime/features/invoke.ts
@@ -57,7 +57,7 @@ export const payloadToResolvable = (
 export const batchInvoke = (
   payload: InvokePayload<any>,
   state: State<any>,
-) => {
+): Promise<any> => {
   return state.resolve(
     payloadToResolvable(payload),
     {
@@ -71,7 +71,7 @@ export const invoke = async (
   props: InvokeFunction["props"],
   select: InvokeFunction["select"],
   state: State<any>,
-) => {
+): Promise<any> => {
   const invokeFunc = {
     key,
     props,

--- a/runtime/features/styles.css.ts
+++ b/runtime/features/styles.css.ts
@@ -233,7 +233,7 @@ const _isDev = Deno.env.get("DECO_PREVIEW") ||
   !Deno.env.has("DENO_DEPLOYMENT_ID");
 // FIXME @author Marcos V. Candeia since we don't have a build step on HTMX sites so mode should always defaults to dev.
 const mode = "dev"; //isDev ? "dev" : "prod";
-const getCSSEager = () =>
+const getCSSEager = (): Promise<string> =>
   Deno.readTextFile(TO).catch(() =>
     `Missing TailwindCSS file in production. Make sure you are building the file on the CI`
   );
@@ -273,7 +273,7 @@ const withReleaseContent = async (config: Config) => {
 };
 
 let css: string | null = null;
-const getCSSLazy = async (config: Config) => {
+const getCSSLazy = async (config: Config): Promise<string> => {
   return css ??= await bundle({
     from: TAILWIND_FILE,
     mode,
@@ -287,5 +287,5 @@ addEventListener("hmr", () => {
 });
 
 let tailwindConfig: null | Config = null;
-export const styles = async () =>
+export const styles = async (): Promise<string> =>
   await getCSS(tailwindConfig ??= await loadTailwindConfig(Deno.cwd()));

--- a/runtime/fetch/mod.ts
+++ b/runtime/fetch/mod.ts
@@ -2,7 +2,6 @@ import { ENABLE_LOADER_CACHE } from "../caches/mod.ts";
 import { createFetch as withCache } from "./fetchCache.ts";
 import { createFetch as withLogs } from "./fetchLog.ts";
 
-
 export const fetch = [
   withLogs,
   ENABLE_LOADER_CACHE ? undefined : withCache,

--- a/runtime/fetch/mod.ts
+++ b/runtime/fetch/mod.ts
@@ -2,6 +2,19 @@ import { ENABLE_LOADER_CACHE } from "../caches/mod.ts";
 import { createFetch as withCache } from "./fetchCache.ts";
 import { createFetch as withLogs } from "./fetchLog.ts";
 
+// Getting this error: error: TS2694 [ERROR]: Namespace 'Deno' has no exported member 'HttpClient'.
+// client: Deno.HttpClient;
+
+// interface ReturnFetch {
+//   (input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+//   (
+//     input: Request | URL | string,
+//     init?: RequestInit & {
+//       client: Deno.HttpClient;
+//     },
+//   ): Promise<Response>;
+// }
+
 export const fetch = [
   withLogs,
   ENABLE_LOADER_CACHE ? undefined : withCache,

--- a/runtime/fetch/mod.ts
+++ b/runtime/fetch/mod.ts
@@ -2,18 +2,6 @@ import { ENABLE_LOADER_CACHE } from "../caches/mod.ts";
 import { createFetch as withCache } from "./fetchCache.ts";
 import { createFetch as withLogs } from "./fetchLog.ts";
 
-// Getting this error: error: TS2694 [ERROR]: Namespace 'Deno' has no exported member 'HttpClient'.
-// client: Deno.HttpClient;
-
-// interface ReturnFetch {
-//   (input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
-//   (
-//     input: Request | URL | string,
-//     init?: RequestInit & {
-//       client: Deno.HttpClient;
-//     },
-//   ): Promise<Response>;
-// }
 
 export const fetch = [
   withLogs,

--- a/runtime/fetch/mod.ts
+++ b/runtime/fetch/mod.ts
@@ -2,7 +2,18 @@ import { ENABLE_LOADER_CACHE } from "../caches/mod.ts";
 import { createFetch as withCache } from "./fetchCache.ts";
 import { createFetch as withLogs } from "./fetchLog.ts";
 
-export const fetch = [
+interface FechInfo {
+  (input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+  (
+    input: Request | URL | string,
+    init?: RequestInit & {
+      // @ts-ignore: deno namespace is not working
+      client: Deno.HttpClient;
+    },
+  ): Promise<Response>;
+}
+
+export const fetch: FechInfo = [
   withLogs,
   ENABLE_LOADER_CACHE ? undefined : withCache,
 ].filter(Boolean).reduceRight((acc, curr) => curr!(acc), globalThis.fetch);

--- a/runtime/handler.tsx
+++ b/runtime/handler.tsx
@@ -99,7 +99,7 @@ export const FrameworkContext = createContext<Framework | undefined>(
   undefined,
 );
 
-export const useFramework = () => {
+export const useFramework = (): Framework => {
   return useContext(FrameworkContext)!;
 };
 

--- a/runtime/htmx/Bindings.tsx
+++ b/runtime/htmx/Bindings.tsx
@@ -5,7 +5,7 @@ import type { ComponentChildren } from "preact";
 import type { Framework } from "../../components/section.tsx";
 import { useSection } from "../../hooks/useSection.ts";
 
-export const Head = (_: { children: ComponentChildren }) => {
+export const Head = (_: { children: ComponentChildren }): null => {
   return null;
 };
 const bindings = {

--- a/runtime/mod.ts
+++ b/runtime/mod.ts
@@ -154,7 +154,7 @@ export class Deco<TAppManifest extends AppManifest = AppManifest> {
 
   batchInvoke(
     ...args: Parameters<typeof batchInvoke>
-  ) {
+  ): Promise<unknown> {
     return batchInvoke(...args);
   }
 

--- a/runtime/mod.ts
+++ b/runtime/mod.ts
@@ -126,7 +126,7 @@ export class Deco<TAppManifest extends AppManifest = AppManifest> {
     previewUrl: string,
     props: unknown,
     ctx?: State<TAppManifest>,
-  ): Promise<PreactComponent<any>> {
+  ): Promise<PreactComponent<unknown>> {
     return preview(
       req,
       previewUrl,
@@ -148,13 +148,13 @@ export class Deco<TAppManifest extends AppManifest = AppManifest> {
     );
   }
 
-  invoke(...args: Parameters<typeof invoke>): Promise<any> {
+  invoke(...args: Parameters<typeof invoke>): Promise<unknown> {
     return invoke(...args);
   }
 
   batchInvoke(
     ...args: Parameters<typeof batchInvoke>
-  ): Promise<any> {
+  ) {
     return batchInvoke(...args);
   }
 

--- a/runtime/mod.ts
+++ b/runtime/mod.ts
@@ -11,7 +11,7 @@ import {
 import { siteNameFromEnv } from "../engine/manifest/manifest.ts";
 import { randomSiteName } from "../engine/manifest/utils.ts";
 import { Context } from "../live.ts";
-import { newContext, type Resolvable } from "../mod.ts";
+import { newContext, type PreactComponent, type Resolvable } from "../mod.ts";
 import { observe } from "../observability/observe.ts";
 import { tracer } from "../observability/otel/config.ts";
 import {
@@ -23,11 +23,20 @@ import { defaultHeaders, forceHttps } from "../utils/http.ts";
 import { buildInvokeFunc } from "../utils/invoke.server.ts";
 import { createServerTimings } from "../utils/timings.ts";
 import { batchInvoke, invoke } from "./features/invoke.ts";
-import { type GetMetaOpts, meta } from "./features/meta.ts";
+import {
+  type GetMetaOpts,
+  meta,
+  type VersionedMetaInfo,
+} from "./features/meta.ts";
 import { preview } from "./features/preview.tsx";
-import { type Options, render } from "./features/render.tsx";
+import {
+  type Options,
+  render,
+  type RenderResponse,
+} from "./features/render.tsx";
 import { styles } from "./features/styles.css.ts";
 import { type Bindings, handlerFor } from "./handler.tsx";
+import type { ContextRenderer } from "deco/runtime/deps.ts";
 
 export interface PageParams<TData = any> {
   data: TData;
@@ -84,14 +93,19 @@ export class Deco<TAppManifest extends AppManifest = AppManifest> {
     );
   }
 
-  meta(opts?: GetMetaOpts) {
+  meta(opts?: GetMetaOpts): Promise<VersionedMetaInfo | undefined> {
     return meta(this.ctx, opts);
   }
 
-  get handler() {
+  get handler(): (
+    req: Request,
+    bindings?:
+      | { RENDER_FN?: ContextRenderer | undefined; GLOBALS?: unknown }
+      | undefined,
+  ) => Response | Promise<Response> {
     return this._handler ??= handlerFor(this);
   }
-  get fetch() {
+  get fetch(): (req: Request) => Response | Promise<Response> {
     return (req: Request) => this.handler(req);
   }
 
@@ -103,7 +117,7 @@ export class Deco<TAppManifest extends AppManifest = AppManifest> {
     return resolver.resolve(resolvable, ctx ?? {});
   }
 
-  styles(...args: Parameters<typeof styles>) {
+  styles(...args: Parameters<typeof styles>): Promise<string> {
     return styles(...args);
   }
 
@@ -112,7 +126,7 @@ export class Deco<TAppManifest extends AppManifest = AppManifest> {
     previewUrl: string,
     props: unknown,
     ctx?: State<TAppManifest>,
-  ) {
+  ): Promise<PreactComponent<any>> {
     return preview(
       req,
       previewUrl,
@@ -121,7 +135,11 @@ export class Deco<TAppManifest extends AppManifest = AppManifest> {
     );
   }
 
-  async render(req: Request, opts: Options, state?: State<TAppManifest>) {
+  async render(
+    req: Request,
+    opts: Options,
+    state?: State<TAppManifest>,
+  ): Promise<RenderResponse> {
     return render(
       req,
       opts,
@@ -130,13 +148,13 @@ export class Deco<TAppManifest extends AppManifest = AppManifest> {
     );
   }
 
-  invoke(...args: Parameters<typeof invoke>) {
+  invoke(...args: Parameters<typeof invoke>): Promise<any> {
     return invoke(...args);
   }
 
   batchInvoke(
     ...args: Parameters<typeof batchInvoke>
-  ) {
+  ): Promise<any> {
     return batchInvoke(...args);
   }
 

--- a/runtime/routes/entrypoint.tsx
+++ b/runtime/routes/entrypoint.tsx
@@ -23,7 +23,7 @@ const ctx = createContext<PageContext | undefined>(undefined);
 
 const routerCtx = createContext<RouterContext | undefined>(undefined);
 
-export const usePageContext = () => {
+export const usePageContext = (): PageContext | undefined => {
   const pageCtx = useContext(ctx);
   if (pageCtx === undefined) {
     console.warn(
@@ -33,7 +33,7 @@ export const usePageContext = () => {
   return pageCtx;
 };
 
-export const useRouterContext = () => {
+export const useRouterContext = (): RouterContext | undefined => {
   const routerCtxImpl = useContext(routerCtx);
   if (routerCtxImpl === undefined) {
     console.warn(

--- a/utils/object.ts
+++ b/utils/object.ts
@@ -139,7 +139,7 @@ export const buildObj = (
 
 export const identity = <T>(value: T): T => value;
 
-export const tryOrDefault = <R>(fn: () => R, defaultValue: R) => {
+export const tryOrDefault = <R>(fn: () => R, defaultValue: R): any => {
   try {
     return fn();
   } catch {

--- a/utils/object.ts
+++ b/utils/object.ts
@@ -139,7 +139,7 @@ export const buildObj = (
 
 export const identity = <T>(value: T): T => value;
 
-export const tryOrDefault = <R>(fn: () => R, defaultValue: R): any => {
+export const tryOrDefault = <R>(fn: () => R, defaultValue: R): R => {
   try {
     return fn();
   } catch {

--- a/utils/timings.ts
+++ b/utils/timings.ts
@@ -5,7 +5,7 @@ export interface Timing {
   end?: number;
 }
 
-export interface ServerTimingsReturn {
+export interface ServerTimingsBuilder {
   get: () => readonly Timing[];
   start: (
     name: string,
@@ -19,7 +19,7 @@ export interface ServerTimingsReturn {
   printTimings: () => string;
 }
 
-export function createServerTimings(): ServerTimingsReturn {
+export function createServerTimings(): ServerTimingsBuilder {
   const timings: Timing[] = [];
 
   const start = (name: string, desc?: string, start?: number) => {

--- a/utils/timings.ts
+++ b/utils/timings.ts
@@ -5,10 +5,18 @@ export interface Timing {
   end?: number;
 }
 
-export interface ServerTimingsReturn { 
-  get: () => readonly Timing[]; 
-  start: (name: string, desc?: string, start?: number) => { end: () => void; 
-  setDesc: (desc: string | undefined) => void; name: () => string; }; printTimings: () => string; 
+export interface ServerTimingsReturn {
+  get: () => readonly Timing[];
+  start: (
+    name: string,
+    desc?: string,
+    start?: number,
+  ) => {
+    end: () => void;
+    setDesc: (desc: string | undefined) => void;
+    name: () => string;
+  };
+  printTimings: () => string;
 }
 
 export function createServerTimings(): ServerTimingsReturn {

--- a/utils/timings.ts
+++ b/utils/timings.ts
@@ -5,7 +5,13 @@ export interface Timing {
   end?: number;
 }
 
-export function createServerTimings() {
+export interface ServerTimingsReturn { 
+  get: () => readonly Timing[]; 
+  start: (name: string, desc?: string, start?: number) => { end: () => void; 
+  setDesc: (desc: string | undefined) => void; name: () => string; }; printTimings: () => string; 
+}
+
+export function createServerTimings(): ServerTimingsReturn {
   const timings: Timing[] = [];
 
   const start = (name: string, desc?: string, start?: number) => {


### PR DESCRIPTION
Issue #790 

In order to deal with the slow types errors,attempted to address them by adding explicit type annotations into the files where the problem occurs. 

I tried this approach and resolved 38 out of 41 issues. However, three errors persist. We can solve that in another PR.