### PR TITLE
fix client forApp to allow invokation proxy

### DIFF
--- a/clients/withManifest.ts
+++ b/clients/withManifest.ts
@@ -380,11 +380,17 @@ export const proxy = <TManifest extends AppManifest>(
   return proxyFor(invoke<TManifest>(fetcher) as typeof batchInvoke);
 };
 
+export type ExtendedForAppInvoke<TApp extends App> =
+  & ManifestInvoke<
+    ManifestOf<TApp>
+  >
+  & { invoke: InvocationProxyWithBatcher<ManifestOf<TApp>> };
+
 /**
  * Creates a proxy that lets you invoke functions based on the declared actions and loaders. (compatibility with old invoke)
  */
-export const forApp = <TApp extends App>(): ManifestInvoke<
-  ManifestOf<TApp>
+export const forApp = <TApp extends App>(): ExtendedForAppInvoke<
+  TApp
 > => {
   const { create } = withManifest<ManifestOf<TApp>>();
   return {


### PR DESCRIPTION
Current forApp type doesn't define invoke as a result of a proxy invoke.

A proxied invoke is a bigger type, since it is able to proxy the Manifest of an App.

By extending the forApp type of return, we allow the return type of proxied calls to be also applied.