### PR TITLE
Fix shortcircuit return type

### DIFF
--- a/blocks/matcher.ts
+++ b/blocks/matcher.ts
@@ -154,7 +154,9 @@ const matcherBlock: Block<
         hasher.hash(uniqueId);
         const cookieName = `${DECO_MATCHER_PREFIX}${hasher.result()}`;
         hasher.reset();
-        const isMatchFromCookie = cookieValue.boolean(getCookies(ctx.request.headers)[cookieName]);
+        const isMatchFromCookie = cookieValue.boolean(
+          getCookies(ctx.request.headers)[cookieName],
+        );
         result ??= isMatchFromCookie ?? matcherFunc(ctx);
         if (result !== isMatchFromCookie) {
           const date = new Date();
@@ -164,7 +166,7 @@ const matcherBlock: Block<
             value: cookieValue.build(uniqueId, result),
             path: "/",
             sameSite: "Lax",
-            expires: date
+            expires: date,
           });
           respHeaders.append("vary", "cookie");
         }

--- a/runtime/errors.ts
+++ b/runtime/errors.ts
@@ -62,7 +62,7 @@ export const badRequest: ResponseErrorBuilder = status(400);
  * Stop any config resolution and throw an exception that should be returned to the main handler.
  * @param resp
  */
-export const shortcircuit = (resp: Response): HttpError => {
+export const shortcircuit = (resp: Response): never => {
   throw new HttpError(resp);
 };
 


### PR DESCRIPTION
Return type of shortcircuit was defined as HTTPError, `export const shortcircuit = (resp: Response): HTTPError`. This return type defines that the function return something and that we should expect HTTPError as a type.

Moreover, is correct to define never as the expected behavior.

```
export const shortcircuit = (resp: Response): never => {
  throw new HttpError(resp);
};
```