### PR TITLE
fix: windows path checking

### DIFF
--- a/dev/deno.ts
+++ b/dev/deno.ts
@@ -6,7 +6,7 @@ import {
   initLoader,
   parsePath,
 } from "@deco/deco/engine";
-import { join, toFileUrl } from "@std/path";
+import { join, SEPARATOR, toFileUrl } from "@std/path";
 
 const visit = (
   program: ParsedSource,
@@ -67,7 +67,7 @@ const importsFrom = async (path: string): Promise<string[]> => {
   return [...imports.values()];
 };
 
-const localAppsFolder = `${Deno.cwd()}/apps`;
+const localAppsFolder = `${Deno.cwd().replaceAll(SEPARATOR, "/")}/apps`;
 
 const skipPath = (path: string) => {
   if (path.endsWith(".tsx")) {

--- a/dev/tailwind.ts
+++ b/dev/tailwind.ts
@@ -1,6 +1,6 @@
 import { cyan } from "@std/fmt/colors";
 import { walk } from "@std/fs";
-import { join, toFileUrl } from "@std/path";
+import { join, SEPARATOR, toFileUrl } from "@std/path";
 import autoprefixer from "npm:autoprefixer@10.4.14";
 import cssnano from "npm:cssnano@6.0.1";
 import postcss, { type AcceptedPlugin } from "npm:postcss@8.4.27";
@@ -87,7 +87,8 @@ const withReleaseContent = async (config: Config) => {
       includeFiles: true,
     })
   ) {
-    if (entry.path.endsWith(".tsx") || entry.path.includes("/apps/")) {
+    const path = entry.path.replaceAll(SEPARATOR, "/");
+    if (path.endsWith(".tsx") || path.includes("/apps/")) {
       roots.add(toFileUrl(entry.path).href);
     }
   }


### PR DESCRIPTION
This PR fixes some path checking on recursive importing that are related to local apps.

Before this fix, when running on windows a lot of classes were removed because the `resolveRecursively` was skipping the local app path since `path.includes(localAppsFolder)` was comparing different type of separators and the import wasn't occurring

![image](https://github.com/user-attachments/assets/7c145912-0fc5-4597-ac56-12d58a3e37d8)
