### PR TITLE
Fix upload file

### DIFF
--- a/runtime/routes/invoke.ts
+++ b/runtime/routes/invoke.ts
@@ -42,6 +42,10 @@ function getParsingStrategy(req: Request): keyof typeof propsParsers | null {
     return null;
   }
 
+  if (contentType?.startsWith("multipart/form-data")) {
+    return "form-data";
+  }
+
   if (!contentLength || !contentType) {
     return "try-json";
   }
@@ -50,9 +54,6 @@ function getParsingStrategy(req: Request): keyof typeof propsParsers | null {
     return "json";
   }
 
-  if (contentType.startsWith("multipart/form-data")) {
-    return "form-data";
-  }
 
   return null;
 }


### PR DESCRIPTION
It was not possible to upload files, as we were not receiving "content-length" in the request header, so the `getParsingStrategy()` method was not returning the correct strategy.