### PR TITLE
Fix typos, improve comments, and rename variables for clarity

### DIFF
--- a/blocks/action.ts
+++ b/blocks/action.ts
@@ -28,6 +28,6 @@ const actionBlock: Block<ActionModule> = {
 };
 
 /**
- * Actions are arbitrary functions that always run in a request context, it execute mutations.
+ * Actions are arbitrary functions that always run in a request context, it executes mutations.
  */
 export default actionBlock;

--- a/blocks/appsUtil.ts
+++ b/blocks/appsUtil.ts
@@ -16,9 +16,9 @@ import type { AppManifest } from "../types.ts";
 import { usePreviewFunc } from "./utils.tsx";
 
 const resolverIsBlock = (blk: Block) => (resolver: string) => {
-  const splitted = resolver.split("/");
+  const segments = resolver.split("/");
   // check if there's any segment on the same name of the block
-  return splitted.some((segment) => segment === blk.type); //FIXME (mcandeia) this is not a straightforward solution
+  return segments.some((segment) => segment === blk.type); //FIXME (mcandeia) this is not a straightforward solution
 };
 
 const asManifest = <TManifest extends AppManifest>(

--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -111,7 +111,7 @@ export const wrapCaughtErrors = async <
         }
 
         /**
-         * No special case found, throw and hope to be catch by the
+         * No special case found, throw and hope to be caught by the
          * section's ErrorFallback
          */
         throw err;
@@ -205,7 +205,7 @@ const wrapLoader = (
         if (
           bypassCache ||
           // This code is unreachable, but the TS complains that cache is undefined because
-          // it doesn't get that isCache is inside of bypassCache variable
+          // it doesn't get that isCache is inside the bypassCache variable
           !isCache(maybeCache)
         ) {
           const shouldNotCache = isCacheNoStore || isCacheKeyNull;

--- a/blocks/matcher.ts
+++ b/blocks/matcher.ts
@@ -149,7 +149,7 @@ const matcherBlock: Block<
       let isSegment = true;
 
       // from last to first and stop in the first resolvable
-      // the rational behind is: whenever you enter in a resolvable it means that it can be referenced by other resolvables and this value should not change.
+      // the rationale behind is: whenever you enter a resolvable it means that it can be referenced by other resolvables and this value should not change.
       for (let i = httpCtx.resolveChain.length - 1; i >= 0; i--) {
         const { type, value } = httpCtx.resolveChain[i];
         if (type === "prop" || type === "resolvable") {

--- a/clients/proxy.ts
+++ b/clients/proxy.ts
@@ -50,7 +50,7 @@ export class InvokeAwaiter<
   }
 
   then<TResult1, TResult2 = TResult1>(
-    onfufilled?: Fulfilled<
+    onfulfilled?: Fulfilled<
       InvokeResult<
         Invoke<TManifest, TInvocableKey, TFuncSelector>,
         TManifest
@@ -59,7 +59,7 @@ export class InvokeAwaiter<
     >,
     onrejected?: Rejected<TResult2>,
   ): Promise<TResult1 | TResult2> {
-    return this.invoker(this.payload, this.init).then(onfufilled).catch(
+    return this.invoker(this.payload, this.init).then(onfulfilled).catch(
       onrejected,
     );
   }

--- a/components/section.tsx
+++ b/components/section.tsx
@@ -182,7 +182,7 @@ export function withSection<TProps, TLoaderProps = TProps>(
         // if this is the case, so we can use the renderSaltFromState - which means that we are in a partial rendering phase
         const renderSalt = parentRenderSalt === undefined
           ? renderSaltFromState ?? `${renderCount}`
-          : `${parentRenderSalt ?? ""}${renderCount}`; // the render salt is used to prevent duplicate ids in the same page, it starts with parent renderSalt and appends how many time this function is called.
+          : `${parentRenderSalt ?? ""}${renderCount}`; // the render salt is used to prevent duplicate ids in the same page, it starts with parent renderSalt and appends how many times this function is called.
         const id = `${idPrefix}-${renderSalt}`; // all children of the same parent will have the same renderSalt, but different renderCount
         renderCount = ++renderCount % MAX_RENDER_COUNT;
 

--- a/daemon/git.ts
+++ b/daemon/git.ts
@@ -314,7 +314,7 @@ const resolveConflictsRecursively = async (wip: number = 50) => {
 
 /**
  * Rebases with -XTheirs strategy. If conflicts are found, it will try to resolve them automatically.
- * Conflicts happen when someone deletes a file and you modify it, or when you modify a file and someone else modifies it.
+ * Conflicts happen when someone deletes a file, and you modify it, or when you modify a file and someone else modifies it.
  * In this case, the strategy is to keep the changes the current branch has.
  */
 export const rebase: Handler = async () => {
@@ -364,7 +364,7 @@ export const ensureGit = async (
       return;
     }
     const lockIndexPath = join(Deno.cwd(), ".git/index.lock");
-    // index.lock should not exists as it means that another git process is running or it is unterminated (non-atomic operations.)
+    // index.lock should not exist as it means that another git process is running, or it is unterminated (non-atomic operations.)
     const hasGitIndexLock = await Deno.stat(lockIndexPath)
       .then(() => true)
       .catch((e) => e instanceof Deno.errors.NotFound ? false : true);

--- a/engine/core/mod.ts
+++ b/engine/core/mod.ts
@@ -57,7 +57,7 @@ export const resolverIdFromResolveChain = (chain: FieldResolver[]) => {
   let uniqueId = "";
 
   // from last to first and stop in the first resolvable
-  // the rational behind is: whenever you enter in a resolvable it means that it can be referenced by other resolvables and this value should not change.
+  // the rationale behind is: whenever you enter a resolvable it means that it can be referenced by other resolvables and this value should not change.
   for (let i = chain.length - 1; i >= 0; i--) {
     const { type, value } = chain[i];
     if (type === "prop" || type === "resolvable") {

--- a/engine/core/resolver.ts
+++ b/engine/core/resolver.ts
@@ -293,7 +293,7 @@ export const withResolveChainOfType = <
 export const RESOLVE_SHORTCIRCUIT = "resolved";
 
 /**
- * wraps an arbitrary data as a resolved object skiping the config resolution algorithm.
+ * wraps an arbitrary data as a resolved object skipping the config resolution algorithm.
  */
 export const asResolved = <T>(data: T, deferred?: boolean): T => {
   return {

--- a/engine/core/utils.ts
+++ b/engine/core/utils.ts
@@ -55,7 +55,7 @@ export const isPrimitive = <T>(v: T): boolean => {
 
 export interface SingleFlight<T> {
   /**
-   * Do separates executions between "keys"
+   * Do separate executions between "keys"
    */
   do: (key: string, f: () => Promise<T>) => Promise<T>;
   /**

--- a/engine/decofile/provider.ts
+++ b/engine/decofile/provider.ts
@@ -86,7 +86,7 @@ export const compose = (...providers: DecofileProvider[]): DecofileProvider => {
 
 const DECOFILE_RELEASE_ENV_VAR = "DECO_RELEASE";
 
-// if decofile does not exists but blocks exists so it should be lazy
+// if decofile does not exist but blocks exist so it should be lazy
 const BLOCKS_FOLDER = join(Deno.cwd(), ".deco", "blocks");
 const blocksFolderExistsPromise = exists(BLOCKS_FOLDER, {
   isDirectory: true,

--- a/engine/importmap/jsr.ts
+++ b/engine/importmap/jsr.ts
@@ -34,7 +34,7 @@ const fetchMetaExports = (
     `https://jsr.io/${packg}/${version}_meta.json`,
   ).then(
     (meta) => meta.json() as Promise<PackageMeta>,
-    // there are other fields that dosn't need to be cached as they are very large.
+    // there are other fields that doesn't need to be cached as they are very large.
   ).then(({ exports }) => {
     return { exports };
   });

--- a/engine/manifest/manifestBuilder.ts
+++ b/engine/manifest/manifestBuilder.ts
@@ -93,7 +93,7 @@ export interface ManifestBuilder<TManifest extends AppManifest = AppManifest> {
   build(): string;
 }
 // function type any of root if not output
-// if output gen output and add anyOf function type
+// if output, gen output and add anyOf function type
 export interface ExportDefault {
   variable: Variable;
 }

--- a/engine/schema/builder.ts
+++ b/engine/schema/builder.ts
@@ -75,7 +75,7 @@ const withNotResolveType = (
 /**
  * Used as a schema for the return value of the given function.
  * E.g, let's say you have a function that returns a boolean, and this function is referenced by `deco-sites/std/myBooleanFunction.ts`
- * Say this function receives a input named `BooleanFunctionProps` that takes any arbitrary data.
+ * Say this function receives an input named `BooleanFunctionProps` that takes any arbitrary data.
  * This function takes the mentioned parameters (functionRef and inputSchema) and builds a JSONSchema that uses the input as `allOf` property ("extends")
  * and a required property `__resolveType` pointing to the mentioned function.
  *
@@ -130,7 +130,7 @@ export interface SchemaBuilder {
   build(): Schemas;
   /**
    * Add a new block schema to the schema.
-   * @param blockSchema is the refernece to the configuration input and the blockfunction output
+   * @param blockSchema is the reference to the configuration input and the blockfunction output
    */
   withBlockSchema(blockSchema: BlockModule | EntrypointModule): SchemaBuilder;
 }

--- a/engine/schema/comments.ts
+++ b/engine/schema/comments.ts
@@ -79,7 +79,7 @@ const isSpannableArray = (child: any): child is Spannable[] => {
  * As comments are treat as a separate array of strings containing only the information of which character it starts and ends (spannable).
  * This code distribute it based on the span attribute of the comments, matching with the body span attribute.
  *
- * So it basically starts with all comments of the module, and then distribute it into body items, it recursively do the same thing inside a body item declaration if it is a TsInterface declaration,
+ * So it basically starts with all comments of the module, and then distribute it into body items, it recursively does the same thing inside a body item declaration if it is a TsInterface declaration,
  * so that we have the comments assigned to the properties as well.
  */
 const assignCommentsForSpannable = (_rootSpan: any) => {

--- a/engine/schema/lazy.ts
+++ b/engine/schema/lazy.ts
@@ -46,8 +46,8 @@ const indexedBlocks = (
 /**
  * This function basically incorporate saved blocks in the schema so the user can select it through the UI as part of the schema.
  * So it is divided in two phases
- * 1. The first phase is responsible for incorporating on the root block types its saved definitions. For instance, handlers, sections and pages has no differentiation between its returns. So I don't need to group it individually they can be group alltogether
- * 2. The second phase is for loaders that needs to be referenced based on its return type. So instead of putting in the loaders root type it should be put on its return type definition, e.g whereas a Product[] fit, a saved loader that returns a Product[] also fit.
+ * 1. The first phase is responsible for incorporating on the root block types its saved definitions. For instance, handlers, sections and pages has no differentiation between its returns. So I don't need to group it individually they can be grouped altogether
+ * 2. The second phase is for loaders that needs to be referenced based on its return type. So instead of putting in the loaders root type it should be put on its return type definition, e.g. whereas a Product[] fit, a saved loader that returns a Product[] also fit.
  */
 const incorporateSavedBlocksIntoSchema = <
   TAppManifest extends AppManifest = AppManifest,
@@ -92,7 +92,7 @@ const incorporateSavedBlocksIntoSchema = <
     const first = anyOf && (anyOf[0] as JSONSchema7).$ref;
     if (first === "#/definitions/Resolvable") { // means that this block can be swapped out to a saved block
       anyOf?.splice(0, 1); // remove resolvable
-      definitions[ref] = { ...val, anyOf: [...val?.anyOf ?? []] }; // create a any of value instead of the value itself
+      definitions[ref] = { ...val, anyOf: [...val?.anyOf ?? []] }; // create an any of value instead of the value itself
       const availableFunctions = (anyOf?.map((func) =>
         getResolveType(func)
       ) ?? []).filter(notUndefined).reduce((acc, f) => {

--- a/engine/schema/transform.ts
+++ b/engine/schema/transform.ts
@@ -536,11 +536,11 @@ const wellKnownTypeReferenceToSchemeable = async <
       if (literal.type !== "StringLiteral") {
         return undefined;
       }
-      const splitted = literal.value.split("/");
+      const split = literal.value.split("/");
       return {
         file: ctx.path,
         type: "inline",
-        name: splitted[splitted.length - 1],
+        name: split[split.length - 1],
         value: {
           $ref: literal.value,
         },

--- a/engine/schema/utils.ts
+++ b/engine/schema/utils.ts
@@ -1,5 +1,5 @@
 /**
- * Some attriibutes are not string in JSON Schema. Because of that, we need to parse some to boolean or number.
+ * Some attributes are not string in JSON Schema. Because of that, we need to parse some to boolean or number.
  * For instance, maxLength and maxItems have to be parsed to number. readOnly should be a boolean etc
  */
 export const parseJSDocAttribute = (key: string, value: string) => {

--- a/observability/otel/config.ts
+++ b/observability/otel/config.ts
@@ -74,7 +74,7 @@ const trackCfHeaders = [
 
 registerInstrumentations({
   instrumentations: [
-    // @ts-ignore: no idea why this is failing but it should work
+    // @ts-ignore: no idea why this is failing, but it should work
     new FetchInstrumentation(
       {
         applyCustomAttributesOnSpan: (
@@ -134,7 +134,7 @@ const provider = new NodeTracerProvider({
 
 if (OTEL_IS_ENABLED) {
   const traceExporter = new OTLPTraceExporter();
-  // @ts-ignore: no idea why this is failing but it should work
+  // @ts-ignore: no idea why this is failing, but it should work
   provider.addSpanProcessor(new BatchSpanProcessor(traceExporter));
 
   provider.register();

--- a/observability/otel/instrumentation/deno-runtime.ts
+++ b/observability/otel/instrumentation/deno-runtime.ts
@@ -1,5 +1,5 @@
 /**
- * Heavily inspired from unlicense code: https://github.com/cloudydeno/deno-observability/blob/main/instrumentation/deno-runtime.ts
+ * Heavily inspired from unlicensed code: https://github.com/cloudydeno/deno-observability/blob/main/instrumentation/deno-runtime.ts
  */
 import {
   type Attributes,

--- a/observability/otel/logger.ts
+++ b/observability/otel/logger.ts
@@ -89,7 +89,7 @@ export class OpenTelemetryHandler extends log.BaseHandler {
       : new OTLPLogExporter(options.httpExporterOptions);
 
     const processor = new BatchLogRecordProcessor(
-      // @ts-ignore: no idea why this is failing but it should work
+      // @ts-ignore: no idea why this is failing, but it should work
       exporter,
       options.processorConfig,
     );

--- a/observability/otel/metrics.ts
+++ b/observability/otel/metrics.ts
@@ -22,10 +22,10 @@ const headersStringToObject = (headersString: string | undefined | null) => {
   if (!headersString) {
     return {};
   }
-  const splittedByComma = headersString.split(",").map((keyVal) =>
+  const splitByComma = headersString.split(",").map((keyVal) =>
     keyVal.split("=") as [string, string]
   );
-  return Object.fromEntries(splittedByComma);
+  return Object.fromEntries(splitByComma);
 };
 
 // Add views with different boundaries for each unit.

--- a/runtime/errors.ts
+++ b/runtime/errors.ts
@@ -1,5 +1,5 @@
 /**
- * Escape hatch to allow throwing an http error
+ * Escape hatch to allow throwing a http error
  */
 export class HttpError extends Error {
   public status: number;

--- a/runtime/features/meta.ts
+++ b/runtime/features/meta.ts
@@ -68,7 +68,7 @@ const waitForChanges = async (ifNoneMatch: string, signal: AbortSignal) => {
     if (etag !== ifNoneMatch) {
       const info = await sf.do(context.instance.id, async () => {
         const { manifest } = await context.runtime!;
-        const manfiestBlocks = toManifestBlocks(
+        const manifestBlocks = toManifestBlocks(
           manifest,
         );
         const schema = await lazySchema.value;
@@ -79,7 +79,7 @@ const waitForChanges = async (ifNoneMatch: string, signal: AbortSignal) => {
           version: denoJSON.version,
           namespace: context.namespace!,
           site: context.site!,
-          manifest: manfiestBlocks,
+          manifest: manifestBlocks,
           schema,
           platform: context.platform,
         };

--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -193,7 +193,7 @@ const SERVER_TIMING_SEPARATOR: string = ",";
 const SERVER_TIMING_MAX_LEN: number = 2_000;
 /**
  * @description return server-timing string equal or less than size parameter.
- * if timings.length > size then return the timing until the well formed timing that's smaller than size.
+ * if timings.length > size then return the timing until the well-formed timing that's smaller than size.
  */
 const reduceServerTimingsTo = (timings: string, size: number): string => {
   if (timings.length <= size) return timings;

--- a/types.ts
+++ b/types.ts
@@ -96,7 +96,7 @@ export interface StatefulContext<T> {
 export interface Route {
   pathTemplate: string;
   /**
-   * @description if true so the path will be checked agaisnt the coming from request instead of using urlpattern.
+   * @description if true so the path will be checked against the coming from request instead of using urlpattern.
    */
   isHref?: boolean;
   // FIXME this should be placed at nested level 3 of the object to avoid being resolved before the routeSelection is executed.

--- a/utils/dataURI.ts
+++ b/utils/dataURI.ts
@@ -1,5 +1,5 @@
 // Avoid throwing DOM Exception:
-// The string to be encoded contains characters outside of the Latin1 range.
+// The string to be encoded contains characters outside the Latin1 range.
 const btoaSafe = (x: string) =>
   btoa(`decodeURIComponent(escape(${unescape(encodeURIComponent(x))}))`);
 

--- a/utils/patched_fetch.ts
+++ b/utils/patched_fetch.ts
@@ -1,6 +1,6 @@
 import { RequestContext } from "../deco.ts";
 
-// Monkey patch fetch so we can have global cancelation token
+// Monkey patch fetch so we can have global cancellation token
 const fetcher = globalThis.fetch;
 
 type RequestInitWithSignal = (RequestInit | globalThis.RequestInit) & {

--- a/utils/promise.ts
+++ b/utils/promise.ts
@@ -1,5 +1,5 @@
 /**
- * Promise.prototype.then onfufilled callback type.
+ * Promise.prototype.then onfulfilled callback type.
  */
 export type Fulfilled<R, T> = ((result: R) => T | PromiseLike<T>) | null;
 


### PR DESCRIPTION
This PR corrects typos and grammar issues in comments and variable names. Additionally, some variables were renamed within their scope to improve readability and clarity.

If you have any questions, feel free to reach out!

Cheers,
Arthur

P.S. Special shoutout to Rafael—the best designer I know! 😎😎