### PR TITLE
Fix(flags): False positive when variant rule is an async function

### DIFF
--- a/blocks/flag.ts
+++ b/blocks/flag.ts
@@ -5,6 +5,7 @@ import JsonViewer from "../components/JsonViewer.tsx";
 import type { Block, BlockModule, InstanceOf } from "../engine/block.ts";
 import { isDeferred } from "../engine/core/resolver.ts";
 import { type Device, deviceOf } from "../utils/userAgent.ts";
+import { isAwaitable } from "../utils/mod.ts";
 export type Flag = InstanceOf<typeof flagBlock, "#/root/flags">;
 
 export interface FlagObj<TVariant = unknown> {
@@ -64,7 +65,7 @@ const flagBlock: Block<BlockModule<FlagFunc>> = {
   >(func: {
     default: FlagFunc<TConfig>;
   }) =>
-  ($live: TConfig, { request }: HttpContext) => {
+  async ($live: TConfig, { request }: HttpContext) => {
     const flag = func.default($live);
     let device: Device | null = null;
     const ctx = {
@@ -75,12 +76,27 @@ const flagBlock: Block<BlockModule<FlagFunc>> = {
       },
     };
     if (isMultivariate(flag)) {
-      const value = ((flag?.variants ?? []).find((variant) =>
-        typeof variant?.rule === "function" && variant?.rule(ctx)
-      ) as Variant<unknown>)?.value ??
-        ((flag?.variants ?? [])[flag?.variants?.length - 1] as Variant<unknown>)
-          ?.value;
-      return isDeferred(value) ? value() : value;
+      let match: Variant<unknown> | null = null;
+
+      for (const variant of flag.variants || []) {
+        let ruleResult = typeof variant?.rule === "function"
+          ? variant?.rule(ctx)
+          : null;
+        // the rule can sometimes be a promise and we need to await it to check if it's truthy or not
+        if (isAwaitable(ruleResult)) {
+          ruleResult = await ruleResult;
+        }
+        if (ruleResult) {
+          match = variant;
+          break;
+        }
+      }
+
+      if (!match) {
+        match = flag.variants[flag.variants.length - 1];
+      }
+
+      return isDeferred(match?.value) ? match?.value() : match?.value;
     }
     const matchValue = typeof flag?.matcher === "function"
       ? flag.matcher(ctx)

--- a/blocks/flag.ts
+++ b/blocks/flag.ts
@@ -84,7 +84,12 @@ const flagBlock: Block<BlockModule<FlagFunc>> = {
           : null;
         // the rule can sometimes be a promise and we need to await it to check if it's truthy or not
         if (isAwaitable(ruleResult)) {
-          ruleResult = await ruleResult;
+          try {
+            ruleResult = await ruleResult;
+          } catch (_) {
+            // if the rule throws an error, we don't match this variant
+            ruleResult = false;
+          }
         }
         if (ruleResult) {
           match = variant;


### PR DESCRIPTION
There are scenarios where we have a multivariant (e.g Pages with variants) and `variant.rule` can return a Promise<boolean> even if the matcher module returns a synchronous function, this occurs when I have a matcher in my project and an (asynchronous) middleware in my app `site.ts `, making `variant.rule` asynchronous as well. It doesn't impact matchers that are from other apps like `website` app that have a lot of matchers, but only the local ones

Illustration of my problem.
```
- Page "Home" 
   |- variants.0.home => Promise<boolean> -> when resolved it returns "false"
   \- variants.1.home => boolean -> always "true"

// looping through the flags.variants
index 0 -> variants.rule(ctx) -> Promise<false> -> true // because Promise is a truly value
early return with wrong variant match
```
The `variant.rule` check is always true since Promise<boolean> is a truly value, even if the final value of the promise is false.

This PR makes it possible for us to detect asynchronous functions in the flags block, where the problem was occurring, and if necessary we make sure the promise is resolved so that we can check if the `variant.rule` returns `true`
```
- Page "Home" 
   |- variants.0.home => Promise<boolean> -> when resolved it returns "false"
   \- variants.1.home => boolean -> always "true"

// looping through the flags.variants
index 0 -> variants.rule(ctx) -> Promise<false> -> await for the result -> don't match
index 1 -> variants.rule(ctx) -> return as it's returning "true"
return with the correct match
```

