### PR TITLE
[WIP] Make preview SSR only

### DIFF
--- a/runtime/routes/blockPreview.tsx
+++ b/runtime/routes/blockPreview.tsx
@@ -99,7 +99,12 @@ export const render = async (
     return await ctx.render({
       page: {
         Component: Preview,
-        props: { url: ctx.var.url, params: ctx.req.param(), data: page },
+        props: {
+          url: ctx.var.url,
+          params: ctx.req.param(),
+          data: page,
+          options: { serverSideOnly: true },
+        },
       },
     });
   } finally {

--- a/runtime/routes/previews.tsx
+++ b/runtime/routes/previews.tsx
@@ -47,7 +47,7 @@ export const handler = createHandler((ctx) => {
   return ctx.render({
     page: {
       Component: Preview,
-      props: {},
+      props: { options: { serverSideOnly: true } },
     },
   });
 });


### PR DESCRIPTION
Block previews are susceptible to high memory usage and may generate excessive requests, especially when dealing with non-cacheable js resources (particularly on localhost calls).

To mitigate these issues, we avoid hydration. Consequently, the server responds with a concise HTML snippet, and the client refrains from using JavaScript to render the section. Nevertheless, we still display apps global sections and <Head> elements, ensuring that the theme and any other inserted HTML elements are visible in the preview.

This is a minor step towards resolving the block gallery issue. There are still several aspects that require further attention and improvement.