### PR TITLE
[FEAT]: create server only access control for loaders and actions

### DIFF
--- a/blocks/action.ts
+++ b/blocks/action.ts
@@ -21,8 +21,10 @@ const actionBlock: Block<ActionModule> = {
     TProps = any,
   >(
     mod: ActionModule<TProps>,
+    key: string,
   ) => [
-    applyProps(gateKeeper(mod)),
+    gateKeeper(mod.defaultVisibility, key),
+    applyProps(mod),
   ],
   defaultPreview: (result) => {
     return {

--- a/blocks/action.ts
+++ b/blocks/action.ts
@@ -2,7 +2,7 @@
 import {
   applyProps,
   type FnProps,
-  GateKeeperAccess,
+  type GateKeeperAccess,
 } from "../blocks/utils.tsx";
 import JsonViewer from "../components/JsonViewer.tsx";
 import type { Block, BlockModule, InstanceOf } from "../engine/block.ts";

--- a/blocks/action.ts
+++ b/blocks/action.ts
@@ -1,14 +1,19 @@
 // deno-lint-ignore-file no-explicit-any
-import { applyProps, type FnProps } from "../blocks/utils.tsx";
+import {
+  applyProps,
+  type FnProps,
+  GateKeeperAccess,
+} from "../blocks/utils.tsx";
 import JsonViewer from "../components/JsonViewer.tsx";
 import type { Block, BlockModule, InstanceOf } from "../engine/block.ts";
+import { gateKeeper } from "./utils.tsx";
 
 export type Action = InstanceOf<typeof actionBlock, "#/root/actions">;
 
-export type ActionModule<
+export interface ActionModule<
   TProps = any,
   TResp = any,
-> = BlockModule<FnProps<TProps, TResp>>;
+> extends BlockModule<FnProps<TProps, TResp>>, GateKeeperAccess {}
 
 const actionBlock: Block<ActionModule> = {
   type: "actions",
@@ -17,7 +22,7 @@ const actionBlock: Block<ActionModule> = {
   >(
     mod: ActionModule<TProps>,
   ) => [
-    applyProps(mod),
+    applyProps(gateKeeper(mod)),
   ],
   defaultPreview: (result) => {
     return {

--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -334,13 +334,12 @@ const wrapLoader = (
 const loaderBlock: Block<LoaderModule> = {
   type: "loaders",
   introspect: { includeReturn: true },
-  adapt: <TProps = any>(mod: LoaderModule<TProps>) => [
+  adapt: <TProps = any>(mod: LoaderModule<TProps>, key: string) => [
+    gateKeeper(mod.defaultVisibility, key),
     wrapCaughtErrors,
     (props: TProps, ctx: HttpContext<{ global: any } & RequestState>) =>
       applyProps(
-        gateKeeper(
-          wrapLoader(mod, ctx.resolveChain, ctx.context.state.release),
-        ),
+        wrapLoader(mod, ctx.resolveChain, ctx.context.state.release),
       )(
         props,
         ctx,

--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -19,6 +19,8 @@ import {
   applyProps,
   type FnContext,
   type FnProps,
+  gateKeeper,
+  type GateKeeperAccess,
   type RequestState,
   type SingleFlightKeyFunc,
 } from "./utils.tsx";
@@ -28,7 +30,7 @@ export type Loader = InstanceOf<typeof loaderBlock, "#/root/loaders">;
 export interface LoaderModule<
   TProps = any,
   TState = any,
-> extends BlockModule<FnProps<TProps>> {
+> extends BlockModule<FnProps<TProps>>, GateKeeperAccess {
   /**
    * Specifies caching behavior for the loader and its dependencies.
    *
@@ -335,7 +337,11 @@ const loaderBlock: Block<LoaderModule> = {
   adapt: <TProps = any>(mod: LoaderModule<TProps>) => [
     wrapCaughtErrors,
     (props: TProps, ctx: HttpContext<{ global: any } & RequestState>) =>
-      applyProps(wrapLoader(mod, ctx.resolveChain, ctx.context.state.release))(
+      applyProps(
+        gateKeeper(
+          wrapLoader(mod, ctx.resolveChain, ctx.context.state.release),
+        ),
+      )(
         props,
         ctx,
       ),

--- a/blocks/utils.tsx
+++ b/blocks/utils.tsx
@@ -27,10 +27,9 @@ import type { InvocationProxy } from "../utils/invoke.types.ts";
 import { type Device, deviceOf, isBot as isUABot } from "../utils/userAgent.ts";
 import type { HttpContext } from "./handler.ts";
 import type { Vary } from "../utils/vary.ts";
-import { ActionModule } from "./action.ts";
 
 export interface GateKeeperAccess {
-  visibility?: "server" | "public";
+  defaultVisibility?: "private" | "public";
 }
 
 export type SingleFlightKeyFunc<TConfig = any, TCtx = any> = (
@@ -258,7 +257,7 @@ export const buildImportMap = (manifest: AppManifest): ImportMap => {
 export const gateKeeper = (
   {
     default: handler,
-    visibility = "public",
+    defaultVisibility = "public",
     ...rest
   }: BlockModule & GateKeeperAccess,
 ) => {
@@ -269,7 +268,7 @@ export const gateKeeper = (
       req: Request,
       ctx: FnContext<unknown, any>,
     ): Promise<ReturnType<typeof handler>> => {
-      if (visibility === "server" && !ctx.isInvoke) {
+      if (defaultVisibility === "private" && !ctx.isInvoke) {
         return new Response(null, {
           status: 403,
         });

--- a/deco.ts
+++ b/deco.ts
@@ -6,6 +6,8 @@ import type { ReleaseResolver } from "./engine/core/mod.ts";
 import type { DecofileProvider } from "./engine/decofile/provider.ts";
 import type { AppManifest } from "./types.ts";
 import { randId } from "./utils/rand.ts";
+import { BlockKeys } from "./mod.ts";
+import { GateKeeperAccess } from "./blocks/utils.tsx";
 
 export interface DecoRuntimeState<
   TAppManifest extends AppManifest = AppManifest,
@@ -55,6 +57,12 @@ export interface DecoContext<TAppManifest extends AppManifest = AppManifest> {
   runtime?: Promise<DecoRuntimeState<TAppManifest>>;
   instance: InstanceInfo;
   request?: RequestContext;
+
+  visibilityOverrides?: Record<
+    BlockKeys<TAppManifest> extends undefined ? string
+      : BlockKeys<TAppManifest>,
+    GateKeeperAccess["defaultVisibility"]
+  >;
 }
 
 export interface RequestContextBinder {
@@ -107,7 +115,7 @@ export const Context = {
   // Function to retrieve the active context
   active: <T extends AppManifest = AppManifest>(): DecoContext<T> => {
     // Retrieve the context associated with the async ID
-    return asyncLocalStorage.getStore() ?? defaultContext;
+    return asyncLocalStorage.getStore() as DecoContext<T> ?? defaultContext;
   },
   bind: <R, TArgs extends unknown[]>(
     ctx: DecoContext,

--- a/engine/block.ts
+++ b/engine/block.ts
@@ -117,7 +117,7 @@ export type InstanceOf<
 export type BlockTypes<TManifest extends AppManifest = AppManifest> =
   keyof Omit<
     TManifest,
-    "config" | "baseUrl"
+    "config" | "baseUrl" | "name"
   >;
 
 export type BlockKeys<TManifest extends AppManifest = AppManifest> = {

--- a/engine/manifest/manifest.ts
+++ b/engine/manifest/manifest.ts
@@ -409,6 +409,7 @@ export const newContext = <
   instanceId: string | undefined = undefined,
   site: string | undefined = undefined,
   namespace: string = "site",
+  visibilityOverrides?: DecoContext<T>["visibilityOverrides"],
 ): Promise<DecoContext<T>> => {
   const currentContext = Context.active<T>();
   const ctx: DecoContext<T> = {
@@ -419,6 +420,7 @@ export const newContext = <
       id: instanceId ?? randId(),
       startedAt: new Date(),
     },
+    visibilityOverrides,
   };
 
   return fulfillContext(ctx, m, currentImportMap, release);

--- a/runtime/fresh/plugin.tsx
+++ b/runtime/fresh/plugin.tsx
@@ -1,6 +1,6 @@
 // TODO make fresh plugin use @deco/deco from JSR. so that we can use the same code for both
 
-import type { AppManifest, SiteInfo } from "@deco/deco";
+import type { AppManifest, DecoContext, SiteInfo } from "@deco/deco";
 import { Deco, type PageData, type PageParams } from "@deco/deco";
 import { framework as htmxFramework } from "@deco/deco/htmx";
 import type { ComponentType } from "preact";
@@ -51,6 +51,7 @@ export interface InitOptions<TManifest extends AppManifest = AppManifest> {
   site?: SiteInfo;
   deco?: Deco<TManifest>;
   middlewares?: PluginMiddleware[];
+  visibilityOverrides?: DecoContext<TManifest>["visibilityOverrides"];
 }
 
 export type Options<TManifest extends AppManifest = AppManifest> =
@@ -89,6 +90,7 @@ export default function decoPlugin<TManifest extends AppManifest = AppManifest>(
     site: opt?.site?.name,
     namespace: opt?.site?.namespace,
     bindings: { framework: opt?.htmx ? htmxFramework : framework },
+    visibilityOverrides: opt.visibilityOverrides,
   });
 
   const catchAll: PluginRoute = {

--- a/runtime/mod.ts
+++ b/runtime/mod.ts
@@ -57,6 +57,8 @@ export interface DecoOptions<TAppManifest extends AppManifest = AppManifest> {
   manifest?: TAppManifest;
   decofile?: DecofileProvider;
   bindings?: Bindings<TAppManifest>;
+
+  visibilityOverrides?: DecoContext<TAppManifest>["visibilityOverrides"];
 }
 
 const NOOP_CALL = () => {};
@@ -86,6 +88,7 @@ export class Deco<TAppManifest extends AppManifest = AppManifest> {
         crypto.randomUUID(),
         site,
         opts?.namespace,
+        opts?.visibilityOverrides,
       )
     );
     Context.setDefault(decoContext);


### PR DESCRIPTION
This PR adds the capability of export a access control const `defaultVisibility` that determines if a loader or a action is server only acessible or public accssible. 

A server only accessible loader/action its only callable by ctx.invoke, this prevent exposing private endpoints on webisite calls on client. 

Exemple:

```ts
export const defaultVisibility = 'private'
```

![image](https://github.com/user-attachments/assets/35ef0d9d-3f69-472b-962c-63a063af363b)

```ts
export const defaultVisibility = 'public'
```
![image](https://github.com/user-attachments/assets/ad850f2a-85d3-484d-ac05-7b5d337ed265)

