### PR TITLE
Adds environment name to otel and adds platform header to all responses

### DIFF
--- a/deco.ts
+++ b/deco.ts
@@ -90,6 +90,12 @@ const getHostingPlatform = (): WellKnownHostingPlatform => {
   }
 };
 
+export const platformId = {
+  "kubernetes": "deco-a3ViZXJuZXRlcw==",
+  "denodeploy": "deco-ZGVub2RlcGxveQ==",
+  "localhost": "deco-local",
+}
+
 // deno-lint-ignore no-explicit-any
 let defaultContext: Omit<DecoContext<any>, "schema"> = {
   deploymentId,

--- a/deco.ts
+++ b/deco.ts
@@ -90,12 +90,6 @@ const getHostingPlatform = (): WellKnownHostingPlatform => {
   }
 };
 
-export const platformId = {
-  "kubernetes": "deco-a3ViZXJuZXRlcw==",
-  "denodeploy": "deco-ZGVub2RlcGxveQ==",
-  "localhost": "deco-local",
-}
-
 // deno-lint-ignore no-explicit-any
 let defaultContext: Omit<DecoContext<any>, "schema"> = {
   deploymentId,

--- a/observability/otel/config.ts
+++ b/observability/otel/config.ts
@@ -45,6 +45,11 @@ export const resource = Resource.default().merge(
     "deco.apps.version": apps_ver,
     [SemanticResourceAttributes.CLOUD_REGION]: Deno.env.get("DENO_REGION") ??
       "unknown",
+    [SemanticResourceAttributes.DEPLOYMENT_ENVIRONMENT]: Deno.env.get(
+        "DECO_ENV_NAME",
+      )
+      ? `env-${Deno.env.get("DECO_ENV_NAME")}`
+      : "production",
   }),
 );
 

--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -1,7 +1,7 @@
 // deno-lint-ignore-file no-explicit-any
 import { HTTPException } from "@hono/hono/http-exception";
 import { DECO_MATCHER_HEADER_QS } from "../blocks/matcher.ts";
-import { Context } from "../deco.ts";
+import { context, Context, platformId } from "../deco.ts";
 import { Exception, getCookies, SpanStatusCode } from "../deps.ts";
 import { startObserve } from "../observability/http.ts";
 import { logger } from "../observability/mod.ts";
@@ -348,6 +348,8 @@ export const middlewareFor = <TAppManifest extends AppManifest = AppManifest>(
         return ctx.res = initialResponse;
       }
       const newHeaders = new Headers(initialResponse.headers);
+      platformId[context.platform] && newHeaders.set("x-deco-platform", platformId[context.platform]);
+
       if (
         (url.pathname.startsWith("/live/previews") &&
           url.searchParams.has("mode") &&

--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -1,7 +1,7 @@
 // deno-lint-ignore-file no-explicit-any
 import { HTTPException } from "@hono/hono/http-exception";
 import { DECO_MATCHER_HEADER_QS } from "../blocks/matcher.ts";
-import { context, Context, platformId } from "../deco.ts";
+import { context, Context } from "../deco.ts";
 import { Exception, getCookies, SpanStatusCode } from "../deps.ts";
 import { startObserve } from "../observability/http.ts";
 import { logger } from "../observability/mod.ts";
@@ -348,7 +348,7 @@ export const middlewareFor = <TAppManifest extends AppManifest = AppManifest>(
         return ctx.res = initialResponse;
       }
       const newHeaders = new Headers(initialResponse.headers);
-      platformId[context.platform] && newHeaders.set("x-deco-platform", platformId[context.platform]);
+      context.platform && newHeaders.set("x-deco-platform", context.platform);
 
       if (
         (url.pathname.startsWith("/live/previews") &&


### PR DESCRIPTION
This PR aims to improves informations on otel and response headers in 2 ways:
- First it will add an otel info to the logs: deployment.environment. That will be the env name with "env-" as prefix to avoid collision when the user decide to use "production" as an environment name, and "production" for the production deployment.
- Second it will add the header x-deco-platform to the fetch, this aims to increase our monitoring system when trying to understand the difference between the platforms. 

<img width="390" alt="image" src="https://github.com/user-attachments/assets/25198f7c-a0cc-43a2-9978-98617216f4c6" />
<img width="742" alt="image" src="https://github.com/user-attachments/assets/00654ad2-c52d-4576-a4ca-68398b9c5aee" />
<img width="745" alt="image" src="https://github.com/user-attachments/assets/be4f8700-8174-43b5-bebe-d2850ecc299f" />
