### PR TITLE
Feat: Simulate a bot request using query params

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: cache deno installation and deno.land dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: ${{ runner.os }}-deno-${{ hashFiles('**/*') }}
           restore-keys: ${{ runner.os }}-deno-

--- a/blocks/utils.tsx
+++ b/blocks/utils.tsx
@@ -28,6 +28,7 @@ import { type Device, deviceOf, isBot as isUABot } from "../utils/userAgent.ts";
 import type { HttpContext } from "./handler.ts";
 import type { Vary } from "../utils/vary.ts";
 import { Context } from "../mod.ts";
+import { simulateBot } from "../utils/http.ts";
 
 export interface GateKeeperAccess {
   defaultVisibility?: "private" | "public";
@@ -139,7 +140,7 @@ export const fnContextFromHttpContext = <TState = {}>(
       return device ??= deviceOf(ctx.request);
     },
     get isBot() {
-      return isBot ??= isUABot(ctx.request);
+      return isBot ??= isUABot(ctx.request) || simulateBot(ctx.request);
     },
   };
 };

--- a/utils/http.ts
+++ b/utils/http.ts
@@ -223,5 +223,5 @@ export const forceHttps = (req: Request) => {
 
 export const simulateBot = (req: Request) => {
   const url = new URL(req.url);
-  return url.searchParams.has("asBot");
+  return url.searchParams.has("__asBot");
 };

--- a/utils/http.ts
+++ b/utils/http.ts
@@ -220,3 +220,8 @@ export const forceHttps = (req: Request) => {
   }
   return httpsReq;
 };
+
+export const simulateBot = (req: Request) => {
+  const url = new URL(req.url);
+  return url.searchParams.has("asBot");
+};


### PR DESCRIPTION
This PR adds a way to simulate a request as a bot using query params, this is useful for debugging and SEO comparison as it disables async render and some other features.

Using `asBot` param on url `isBot` will always be `true`