### PR TITLE
feat: allow ignore querystring from useSection href prop

### DIFF
--- a/hooks/mod.ts
+++ b/hooks/mod.ts
@@ -1,4 +1,7 @@
 export { useDevice } from "./useDevice.ts";
 export { usePartialSection } from "./usePartialSection.ts";
 export { useScript, useScriptAsDataURI } from "./useScript.ts";
-export { useSection } from "./useSection.ts";
+export {
+  addBlockedQS as unstable_blockUseSectionHrefQueryStrings,
+  useSection,
+} from "./useSection.ts";

--- a/hooks/useSection.ts
+++ b/hooks/useSection.ts
@@ -32,6 +32,10 @@ const BLOCKED_QS = new Set<string>([
   "ck_subscriber_id",
 ]);
 
+export const addBlockedQS = (queryStrings: string[]) => {
+  queryStrings.forEach((qs) => BLOCKED_QS.add(qs));
+};
+
 /** Returns new props object with prop __cb with `pathname?querystring` from href */
 const createStableHref = (href: string): string => {
   const hrefUrl = new URL(href!, "http://localhost:8000");
@@ -67,10 +71,11 @@ export const useSection = <P>(
   const { request, renderSalt, context: { state: { pathTemplate } } } = ctx;
 
   const hrefParam = href ?? request.url;
+  const stableHrefPathQs = createStableHref(hrefParam);
   const cbString = [
     revisionId,
     vary,
-    createStableHref(hrefParam),
+    stableHrefPathQs,
     ctx?.deploymentId,
   ].join("|");
   hasher.hash(cbString);
@@ -79,7 +84,7 @@ export const useSection = <P>(
 
   const params = new URLSearchParams([
     ["props", JSON.stringify(props)],
-    ["href", hrefParam],
+    ["href", new URL(stableHrefPathQs, hrefParam).href],
     ["pathTemplate", pathTemplate],
     ["renderSalt", `${renderSalt ?? crypto.randomUUID()}`],
     ["__cb", `${cb}`],


### PR DESCRIPTION
# Description
The idea of this is allow websites that uses useSection to ignore some querystrings from useSection cache key, resulting in a stable cache key with better cache hit ratio.

## Consideration
This api `unstable_blockUseSectionHrefQueryStrings` can be used in two ways:
1. hardcoded blocked strings
```ts
// apps/site.ts
import { unstable_blockUseSectionHrefQueryStrings } from "deco/hooks"
unstable_blockUseSectionHrefQueryStrings(["utm_source", "gclid"])
```

2. editable by CMS
```ts
// apps/site.ts
import { unstable_blockUseSectionHrefQueryStrings } from "deco/hooks"

interface SiteProps {
  // ... other Props
  blockedQs: string[]
}

export default function App({blockedQs}: Props) {
  // ... some code
  unstable_blockUseSectionHrefQueryStrings(blockedQs);
  // ... some code
}
```
