### PR TITLE
fix: createStableHref to remove properly the blocked querystrings

### DIFF
--- a/hooks/useSection.ts
+++ b/hooks/useSection.ts
@@ -39,7 +39,8 @@ export const addBlockedQS = (queryStrings: string[]): void => {
 /** Returns new props object with prop __cb with `pathname?querystring` from href */
 const createStableHref = (href: string): string => {
   const hrefUrl = new URL(href!, "http://localhost:8000");
-  hrefUrl.searchParams.forEach((_: string, qsName: string) => {
+  const qsList = [...hrefUrl.searchParams.keys()];
+  qsList.forEach((qsName: string) => {
     if (BLOCKED_QS.has(qsName)) hrefUrl.searchParams.delete(qsName);
   });
   hrefUrl.searchParams.sort();


### PR DESCRIPTION
For this context
BLOCKED_QS =['ranSiteID', 'utm_term', 'utm_medium', 'ranMID']
href: http://localhost:8000/?ranMID=value0&ranSiteID=value&utm_medium=aff&utm_term=term

before: createStableHref(href) http://localhost:8000/?ranSiteID=value&utm_term=term
after: createStableHref(href) // http://localhost:8000/