### PR TITLE
Add debug for /deco/render request

### DIFF
--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -103,7 +103,7 @@ async (ctx, next) => {
 const DEBUG_COOKIE = "deco_debug";
 const DEBUG_ENABLED = "enabled";
 
-const DEBUG_QS = "__d";
+export const DEBUG_QS = "__d";
 const addHours = function (date: Date, h: number) {
   date.setTime(date.getTime() + (h * 60 * 60 * 1000));
   return date;

--- a/utils/vary.ts
+++ b/utils/vary.ts
@@ -1,11 +1,22 @@
+import type { FieldResolver } from "../engine/core/resolver.ts";
+
+export interface DebugProperties {
+  resolver: FieldResolver;
+}
+
 export interface Vary {
   push: (...key: string[]) => void;
   build: () => string;
   shouldCache: boolean;
+  debug: {
+    push: <T extends DebugProperties>(debug: T) => void;
+    build: <T extends DebugProperties>() => T[];
+  };
 }
 
 export const vary = (): Vary => {
   const vary: string[] = [];
+  const debug: DebugProperties[] = [];
 
   return {
     push: (...key: string[]) => vary.push(...key),
@@ -13,5 +24,10 @@ export const vary = (): Vary => {
       return vary.sort().join();
     },
     shouldCache: true,
+    debug: {
+      push: <T extends DebugProperties>(_debug: T) =>
+        debug.push(_debug as DebugProperties),
+      build: <T extends DebugProperties>() => debug as T[],
+    },
   };
 };


### PR DESCRIPTION
## How it works
Add debug param for async render when `__d` is present on request querystring. The output data has this shape:

```ts
interface LoaderDebugData {
  resolver: FieldResolver;
  reason: {
    cache: LoaderCache;
    cacheKeyNull: boolean;
  }
}

interface DebugData {
 debugData: LoaderDebugData[]; // In future could have more properties here with other object type
}
```