### PR TITLE
Fix url pattern match

### DIFF
--- a/runtime/features/render.tsx
+++ b/runtime/features/render.tsx
@@ -50,10 +50,10 @@ export const render = async <TAppManifest extends AppManifest = AppManifest>(
 
   const url = new URL(href, req.url);
   const request = new Request(url, req);
-  const urlPathTemplate = new URL(pathTemplate, "http://localhost:8000");
+  const urlPathTemplate = new URLPattern(pathTemplate, "http://localhost:8000");
   const params = new URLPattern({
     pathname: urlPathTemplate.pathname,
-    ...(urlPathTemplate.search ? { search: urlPathTemplate.search } : {}),
+    search: urlPathTemplate.search,
   }).exec(url);
 
   const resolvables = await state.resolve({

--- a/runtime/features/render.tsx
+++ b/runtime/features/render.tsx
@@ -53,7 +53,7 @@ export const render = async <TAppManifest extends AppManifest = AppManifest>(
   const urlPathTemplate = new URLPattern(pathTemplate, "http://localhost:8000");
   const params = new URLPattern({
     pathname: urlPathTemplate.pathname,
-    search: urlPathTemplate.search,
+    search: urlPathTemplate.search || "*",
   }).exec(url);
 
   const resolvables = await state.resolve({


### PR DESCRIPTION
this PR is ralated to #898 

this changes adds a wildcard fallback to searchparams once the current version on production of deno has a bug that turn a undefined search as a empty string, this is already fixed on newer versions of deno

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL path parsing consistency by aligning the mechanism with standard URLPattern behavior for more reliable query parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->