### PR TITLE
fix(daemon): call setupGithubTokenNetrc before publish to renew token

### DIFF
--- a/daemon/git.ts
+++ b/daemon/git.ts
@@ -216,6 +216,7 @@ export const publish = ({ build }: Options): Handler => {
     const author = body.author || { name: "decobot", email: "capy@deco.cx" };
     const message = body.message || `New release by ${author.name}`;
 
+    await setupGithubTokenNetrc();
     await git.fetch(["-p"]).submoduleUpdate(["--depth", "1"]);
 
     await resetToMergeBase();


### PR DESCRIPTION
##
Fixes a case when app is from private registry and use short lived token, need to refresh netrc token before git operations at publish