### PR TITLE
fix(daemon): prevent throw error on publish trying to setup github token for sites without github_app_key env var

### DIFF
--- a/daemon/git.ts
+++ b/daemon/git.ts
@@ -216,7 +216,10 @@ export const publish = ({ build }: Options): Handler => {
     const author = body.author || { name: "decobot", email: "capy@deco.cx" };
     const message = body.message || `New release by ${author.name}`;
 
-    await setupGithubTokenNetrc();
+    if (GITHUB_APP_KEY) {
+      await setupGithubTokenNetrc();
+    }
+
     await git.fetch(["-p"]).submoduleUpdate(["--depth", "1"]);
 
     await resetToMergeBase();


### PR DESCRIPTION
Related to #945 