### PR TITLE
fix(runtime): block from path preview

### DIFF
--- a/runtime/features/preview.tsx
+++ b/runtime/features/preview.tsx
@@ -30,7 +30,9 @@ export const preview = async <TAppManifest extends AppManifest = AppManifest>(
 ) => {
   const { resolve } = ctx;
   const url = new URL(previewUrl);
-  const block = addLocal(url.pathname.replace(/^\/live\/previews\//, ""));
+  const block = addLocal(
+    decodeURIComponent(url.pathname.replace(/^\/live\/previews\//, "")),
+  );
 
   const [params, pathname] = paramsFromUrl(url);
   const newUrl = new URL(req.url);


### PR DESCRIPTION
Fix: allow accept encodedURI characters for block at /deco/previews routes.

Exemple: block id `Product List Loader` that's encoded is `Product%20List%20Loader`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly handles URL-encoded characters in preview paths, ensuring the intended content loads.
  * Resolves issues with previews when paths include spaces or special characters.
  * Improves reliability of preview resolution for encoded URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->