### PR TITLE
feat(hooks): add useSetEarlyHints

### DIFF
--- a/hooks/mod.ts
+++ b/hooks/mod.ts
@@ -8,3 +8,4 @@ export {
   addBlockedQS as unstable_blockUseSectionHrefQueryStrings,
   useSection,
 } from "./useSection.ts";
+export { useSetEarlyHints } from "./useSetEarlyHints.ts";

--- a/hooks/useSetEarlyHints.ts
+++ b/hooks/useSetEarlyHints.ts
@@ -1,0 +1,14 @@
+import { useContext } from "preact/hooks";
+
+import { SectionContext } from "../components/section.tsx";
+
+/**
+ * Hook to access set early hints information.
+ *
+ * @throws {Error}  - Throws an error if used on the browser or when context is missing.
+ */
+export const useSetEarlyHints = (): (hint: string) => void => {
+  const ctx = useContext(SectionContext);
+  return (hint: string) =>
+    ctx?.context.state.response.headers.append("link", hint);
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds support for sending Early Hints (HTTP 103) link headers, proactively hinting critical resources to the browser and potentially improving initial load performance on supported clients.
  - Backward compatible and non-intrusive: no UI changes; activates only when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->