### PR TITLE
 feat: add configurable CACHE_TTL environment variable

### DIFF
--- a/runtime/caches/lrucache.ts
+++ b/runtime/caches/lrucache.ts
@@ -81,9 +81,7 @@ function createLruCacheStorage(cacheStorageInner: CacheStorage): CacheStorage {
           // - If STALE_TTL_PERIOD is configured, add it to the expiration time from the response headers
           //   This allows extending the cache lifetime beyond what the server specifies and serves stale content during this extra time
           // The staleness is detect at the loader level because it checks for the expires header, that remains untouched here, the idea is to serve stale content but with expired header
-          const ttl = !Number.isNaN(STALE_TTL_PERIOD)
-            ? (expirationTimestamp - Date.now()) + STALE_TTL_PERIOD
-            : expirationTimestamp - Date.now();
+          const ttl = (expirationTimestamp - Date.now()) + STALE_TTL_PERIOD;
 
           const cacheKey = await requestURLSHA1(request);
           const length = response.headers.get("Content-Length");


### PR DESCRIPTION
  ## Summary
  - Adds `LRU_CACHE_TTL ` environment variable support to allow manual configuration of cache time-to-live
  - When `LRU_CACHE_TTL ` is set, it takes precedence over the expiration timestamp from response headers
  - Provides more control over cache duration for different deployment scenarios

  ## Changes
  - Added `LRU_CACHE_TTL ` environment variable in `runtime/caches/lrucache.ts:19`
  - Updated cache put logic (lines 76-78) to check for `LRU_CACHE_TTL ` first before falling back to response header expiration
  - Added documentation comment explaining the variable's purpose


  ## Example Scenario

  Consider the following configuration:
  - `LRU_CACHE_TTL ` is set to 3600000 (1 hour)
  - Response from server has `Expires` header indicating 3 minutes from now

  ### Timeline:

  **T=0: Initial Request**
  - Resource is fetched from the server
  - LRU cache stores the entry with TTL of 1 hour (from `LRU_CACHE_TTL `)
  - CacheStorage API stores the response with expiration from headers (3 minutes)

  **T=2 minutes: Second Request (within 3 minutes)**
  - LRU cache check: ✓ Hit (58 minutes remaining)
  - CacheStorage API check: ✓ Fresh (1 minute remaining)
  - Result: Cached response served immediately, no network request

  **T=4 minutes: Third Request (after 3 minutes, within 1 hour)**
  - LRU cache check: ✓ Hit (56 minutes remaining)
  - CacheStorage API check: ✗ Expired (1 minute past expiration)
  - Result: Stale response served immediately to the user
  - Background revalidation: Fresh copy fetched from server and cache updated

  **T=65 minutes: Fourth Request (after 1 hour)**
  - LRU cache check: ✗ Miss (TTL expired)
  - CacheStorage API check: ✗ Miss
  - Result: Fresh fetch from server, cache repopulated

  This dual-layer approach allows you to:
  - Control memory retention independently via `LRU_CACHE_TTL ` (prevents premature eviction from LRU)
  - Respect server-provided expiration for freshness semantics

  This describes how the LRU cache's TTL acts as a retention policy while the CacheStorage API's expiration determines freshness,
   enabling the stale-while-revalidate pattern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable "stale TTL" increment to optionally extend how long cached items remain valid beyond response expiration times.
  * If set to a valid number, the increment is added to each response's TTL; if unset/invalid, caching follows response expiration as before.
  * Existing expiration-based staleness detection remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->