### PR TITLE
Improves loaders cache

### DIFF
--- a/runtime/caches/lrucache.ts
+++ b/runtime/caches/lrucache.ts
@@ -11,15 +11,14 @@ const CACHE_MAX_SIZE = parseInt(
   Deno.env.get("CACHE_MAX_SIZE") ?? Deno.env.get("MAX_CACHE_SIZE") ??
     "1073741824",
 ); // 1 GB max size of cache
-const CACHE_TTL_AUTOPURGE = Deno.env.get("CACHE_TTL_AUTOPURGE") !== "false"; // automatically delete expired items
-const CACHE_ALLOW_STALE = Deno.env.get("CACHE_ALLOW_STALE") !== "false"; // automatically allow stale
+const CACHE_TTL_AUTOPURGE = Deno.env.get("CACHE_TTL_AUTOPURGE") === "true"; // creates a cron for each element in the cache to automatically delete expired items
 const CACHE_TTL_RESOLUTION = parseInt(
-  Deno.env.get("CACHE_TTL_RESOLUTION") ?? "30000",
-); // check for expired items every 30 seconds
+  Deno.env.get("CACHE_TTL_RESOLUTION") ?? "1000",
+); // updates the lru cache timer every 1 second
 // Additional time-to-live increment in milliseconds to extend the cache expiration beyond the response's Expires header.
 // If not set, the cache will use only the expiration timestamp from response headers
 const STALE_TTL_PERIOD = parseInt(
-  Deno.env.get("STALE_TTL_PERIOD") ?? "0",
+  Deno.env.get("STALE_TTL_PERIOD") ?? "30000",
 );
 
 const cacheOptions = (cache: Cache) => (
@@ -27,8 +26,7 @@ const cacheOptions = (cache: Cache) => (
     maxSize: CACHE_MAX_SIZE,
     ttlAutopurge: CACHE_TTL_AUTOPURGE,
     ttlResolution: CACHE_TTL_RESOLUTION,
-    allowStale: CACHE_ALLOW_STALE,
-    dispose: async (_value: Uint8Array, key: string) => {
+    dispose: async (_value: boolean, key: string) => {
       await cache.delete(key);
     },
   }
@@ -56,7 +54,6 @@ function createLruCacheStorage(cacheStorageInner: CacheStorage): CacheStorage {
           assertNoOptions(options);
           const cacheKey = await requestURLSHA1(request);
           if (fileCache.has(cacheKey)) {
-            fileCache.get(cacheKey);
             const result = cacheInner.match(cacheKey);
             return result;
           }
@@ -88,7 +85,7 @@ function createLruCacheStorage(cacheStorageInner: CacheStorage): CacheStorage {
           if (!length || length == "0") {
             return;
           }
-          fileCache.set(cacheKey, new Uint8Array(), {
+          fileCache.set(cacheKey, true, {
             size: parseInt(length),
             ttl,
           });


### PR DESCRIPTION
This PR aims to improve the loader's cache engine, the LRUCache lib is only used to managed the LRU heuristic, the actual values for the cached items lives at inner cache engines (file system for instance). Some important chages are:
- Removes the default auto purge for the LRUCache, the auto purge creates a timer based on the item's ttl to purge it asap. As we store a lot of items (10000) with recurrent updates this could mean wast of resources. This timer consumes memory and cpu, the lib recomendation is to not use it
- Removes the option to allow stale as option to instantiate the LRUCache, this is only useful if we use the LRU to store values, we dont even use real values but only placeholder. So totally unnecessary
- Reduce the ttl resolution, ttl resolution is a LRUCache's smart way to avoid overhead checking "what time is it?" everytime an operation is done, the lib caches the "what time is it?" question for the duration of the ttl resolution. A bigger value would imply in a inconsistent cache
- Adds stale-while-revalidate as default option, with 30s of stale value
- Removes a memory bloat as it was unnecessary to have values stored at LRUCache it is better to use the smaller structure as possible, so I decide to use boolean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected TTL autopurge behavior to strictly apply when configured.

* **Changes**
  * Cache expiration checks now occur more frequently, ensuring fresher content delivery.
  * Stale cache retention extended by 30 seconds beyond the original expiration time.
  * Removed configuration option for stale cache allowance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->