### PR TITLE
fix(parsePath): not throwing error when package

### DIFF
--- a/engine/schema/parser.ts
+++ b/engine/schema/parser.ts
@@ -300,6 +300,13 @@ export const parsePath = async (
     const resolved = await resolveFileExtension(path);
     if (resolved) {
       resolvedPath = resolved;
+    } else if (!path.match(/\.(ts|tsx|js|jsx|mjs|cjs|d\.ts|d\.mts|d\.cts)$/)) {
+      // If resolution failed and path has no extension, return undefined instead of throwing
+      console.warn(
+        `%cCould not resolve path ${path}, file not found`,
+        "color: gray",
+      );
+      return Promise.resolve(undefined);
     }
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path resolution to properly handle unresolvable file paths. The system now returns early with a diagnostic warning instead of attempting to process invalid references, reducing downstream errors and improving error visibility for debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->