### PR TITLE
[chore]: Improve reload to be long polling

### DIFF
--- a/engine/decofile/fetcher.ts
+++ b/engine/decofile/fetcher.ts
@@ -148,6 +148,11 @@ export const fromJSON = (
     state: () => Promise.resolve(state),
     onChange: (cb) => {
       cbs.push(cb);
+      return {
+        [Symbol.dispose]: () => {
+          cbs.splice(cbs.indexOf(cb), 1);
+        },
+      };
     },
     notify: () => {
       return Promise.all(cbs.map((cb) => cb())).then(() => {});
@@ -232,6 +237,10 @@ export const fromEndpoint = (endpoint: string): DecofileProvider => {
     state: (options) => decofileProviderPromise.then((r) => r.state(options)),
     onChange: (cb) => {
       decofileProviderPromise.then((r) => r.onChange(cb));
+      return {
+        [Symbol.dispose]: () => {
+        },
+      };
     },
     revision: () => decofileProviderPromise.then((r) => r.revision()),
     dispose: () => {

--- a/engine/decofile/fsFolder.ts
+++ b/engine/decofile/fsFolder.ts
@@ -199,6 +199,11 @@ export const newFsFolderProviderFromPath = (
     },
     onChange: (cb: OnChangeCallback) => {
       onChangeCbs.push(cb);
+      return {
+        [Symbol.dispose]: () => {
+          onChangeCbs.splice(onChangeCbs.indexOf(cb), 1);
+        },
+      };
     },
     revision: () => decofile.then((r) => r.revision),
   };

--- a/engine/decofile/realtime.ts
+++ b/engine/decofile/realtime.ts
@@ -155,6 +155,11 @@ export const newRealtime = (
   return {
     onChange: (cb: OnChangeCallback) => {
       onChangeCbs.push(cb);
+      return {
+        [Symbol.dispose]: () => {
+          onChangeCbs.splice(onChangeCbs.indexOf(cb), 1);
+        },
+      };
     },
     notify() {
       return notify();

--- a/runtime/routes/reload.ts
+++ b/runtime/routes/reload.ts
@@ -1,16 +1,21 @@
 import { createHandler } from "../middleware.ts";
 
-export const handler = createHandler((
+export const handler = createHandler(async (
   { var: state, req },
 ) => {
+  const isUpToDate = Promise.withResolvers<void>();
   const delay = req.query("delay");
   const delayMs = delay ? parseInt(delay) : 5000;
 
   let currentInterval = 1000; // Start with 1 second
   let elapsed = 0;
+  using _ = state.release.onChange(() => {
+    isUpToDate.resolve(); // force resolve
+  });
 
   const scheduleNext = () => {
     if (elapsed >= delayMs) {
+      isUpToDate.resolve(); // force resolve
       return; // Stop when we've reached the delay
     }
 
@@ -25,8 +30,9 @@ export const handler = createHandler((
 
   scheduleNext(); // Start the exponential retry process
 
+  await isUpToDate.promise;
   return new Response(
-    JSON.stringify({ scheduled: true }),
+    JSON.stringify({ elapsed }),
     {
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event listeners now support proper resource cleanup via disposal mechanism.
  * Reload endpoint now uses exponential backoff scheduling for better retry behavior.

* **Bug Fixes**
  * Reduced unnecessary change notifications by tracking prior state and only notifying on actual changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->