### PR TITLE
Fixing OTEL error

### DIFF
--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -139,7 +139,7 @@ export const wrapCaughtErrors = async <
 const stats = {
   cache: meter.createCounter("loader_cache", {
     unit: "1",
-    valueType: ValueType.INT,
+    valueType: ValueType.DOUBLE,
   }),
   latency: meter.createHistogram("resolver_latency", {
     description: "resolver latency",

--- a/observability/http.ts
+++ b/observability/http.ts
@@ -4,7 +4,7 @@ import { meter } from "./otel/metrics.ts";
 const httpDuration = meter.createHistogram("http_request_duration", {
   description: "http request duration",
   unit: "ms",
-  valueType: ValueType.INT,
+  valueType: ValueType.DOUBLE,
 });
 /**
  * @returns a end function that when gets called observe the duration of the operation.

--- a/observability/otel/instrumentation/deno-runtime.ts
+++ b/observability/otel/instrumentation/deno-runtime.ts
@@ -41,21 +41,21 @@ export class DenoRuntimeInstrumentation extends InstrumentationBase {
     this.metrics ??= {
       openResources: this.meter
         .createObservableUpDownCounter("deno.open_resources", {
-          valueType: ValueType.INT,
+          valueType: ValueType.DOUBLE,
           description: "Number of open resources of a particular type.",
         }),
       memoryUsage: this.meter
         .createObservableGauge("deno.memory_usage", {
-          valueType: ValueType.INT,
+          valueType: ValueType.DOUBLE,
         }),
       dispatchedCtr: this.meter
         .createObservableCounter("deno.ops_dispatched", {
-          valueType: ValueType.INT,
+          valueType: ValueType.DOUBLE,
           description: "Total number of Deno op invocations.",
         }),
       inflightCtr: this.meter
         .createObservableUpDownCounter("deno.ops_inflight", {
-          valueType: ValueType.INT,
+          valueType: ValueType.DOUBLE,
           description: "Number of currently-inflight Deno ops.",
         }),
     };

--- a/runtime/caches/common.ts
+++ b/runtime/caches/common.ts
@@ -10,7 +10,7 @@ export interface CacheMetrics {
 }
 const cacheHit = meter.createCounter("cache_hit", {
   unit: "1",
-  valueType: ValueType.INT,
+  valueType: ValueType.DOUBLE,
 });
 
 const getCacheStatus = (

--- a/runtime/middlewares/liveness.ts
+++ b/runtime/middlewares/liveness.ts
@@ -35,7 +35,7 @@ const DRY_RUN = Deno.env.get("PROBE_DRY_RUN") === "true";
 
 const probe = meter.createCounter("probe_failed", {
   unit: "1",
-  valueType: ValueType.INT,
+  valueType: ValueType.DOUBLE,
 });
 
 export function getProbeThresholdAsNum(


### PR DESCRIPTION
```
Error: Only valueType: DOUBLE is supported
    at Meter.createObservableUpDownCounter (ext:deno_telemetry/telemetry.ts:403:13)
    at DenoRuntimeInstrumentation.enable (https://jsr.io/@deco/deco/1.132.0/observability/otel/instrumentation/deno-runtime.ts:43:10)
    at enableInstrumentations (file:///app/src/../deno_dir/npm/registry.npmjs.org/@opentelemetry/instrumentation/0.52.1/build/src/autoLoaderUtils.js:42:29)
    at registerInstrumentations (file:///app/src/../deno_dir/npm/registry.npmjs.org/@opentelemetry/instrumentation/0.52.1/build/src/autoLoader.js:34:50)
    at https://jsr.io/@deco/deco/1.132.0/observability/otel/config.ts:80:1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated metric value types from integer to double precision across observability metrics, including loader cache, HTTP request duration, Deno runtime resources, cache hits, and liveness probes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->