### PR TITLE
remove 6 seconds async render trigger

### DIFF
--- a/runtime/htmx/Bindings.tsx
+++ b/runtime/htmx/Bindings.tsx
@@ -30,7 +30,7 @@ const bindings: Framework = {
     return (
       <div
         hx-get={useSection({ props })}
-        hx-trigger="load once delay:6s, intersect once threshold:0.0"
+        hx-trigger="intersect once threshold:0.0"
         hx-target="closest section"
         hx-swap="outerHTML transition:true"
       >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated loading fallback component to remove automatic trigger after page load delay, now relying solely on visibility-based triggering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->