### PR TITLE
add fallback for deco_site_name env var

### DIFF
--- a/daemon/daemon.ts
+++ b/daemon/daemon.ts
@@ -12,7 +12,8 @@ import { logs } from "./loggings/stream.ts";
 import { createRealtimeAPIs } from "./realtime/app.ts";
 import { createSSE } from "./sse/api.ts";
 
-export const DECO_SITE_NAME = Deno.env.get(ENV_SITE_NAME);
+export const DECO_SITE_NAME = Deno.env.get(ENV_SITE_NAME) ??
+  Deno.cwd().split("/").pop()?.split("\\").pop();
 export const DECO_ENV_NAME = Deno.env.get("DECO_ENV_NAME");
 export const DECO_HOST = Deno.env.get("DECO_HOST") === "true";
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved site naming configuration with automatic fallback to the current working directory when the environment variable is not set.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->