### PR TITLE
feat(render): add observability headers for lazy sections and pages

### DIFF
--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -354,6 +354,16 @@ export const middlewareFor = <TAppManifest extends AppManifest = AppManifest>(
       }
       const newHeaders = new Headers(initialResponse.headers);
       context.platform && newHeaders.set("x-deco-platform", context.platform);
+      
+      // Add route template for debugging/observability
+      if (ctx?.var?.pathTemplate) {
+        newHeaders.set("x-deco-route", ctx.var.pathTemplate);
+      }
+      
+      // Add matched page block name for debugging/observability
+      if (ctx?.var?.matchedPageBlock) {
+        newHeaders.set("x-deco-page", ctx.var.matchedPageBlock);
+      }
 
       if (
         (url.pathname.startsWith("/live/previews") &&

--- a/runtime/routes/render.tsx
+++ b/runtime/routes/render.tsx
@@ -80,7 +80,7 @@ export const handler = createHandler(async (
   const opts = fromRequest(req);
   const isDebugRequest = opts.searchParams.has(DEBUG_QS);
 
-  const { page, shouldCache } = await state.deco.render(req, opts, state);
+  const { page, shouldCache, sectionName } = await state.deco.render(req, opts, state);
 
   if (isDebugRequest) {
     return Response.json({ debugData: state.vary.debug.build() });
@@ -96,6 +96,11 @@ export const handler = createHandler(async (
       } satisfies PageParams<PageData>,
     },
   });
+
+  // Add section name header for debugging/observability
+  if (sectionName) {
+    response.headers.set("x-deco-section", sectionName);
+  }
 
   // this is a hack to make sure we cache only sections that does not vary based on the loader content.
   // so we can calculate cacheBust per page but decide to cache sections individually based on vary.


### PR DESCRIPTION
- Add x-deco-section header with component type and title
- Add x-deco-route header with matched route template
- Add x-deco-page header with matched page block name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal observability and debugging capabilities by adding route and page tracking headers to response metadata.
  * Improved section identification and tracking for better diagnostic information during request processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->