### PR TITLE
feat(daemon): add POST /git/checkout endpoint for switching to existing branches

### DIFF
--- a/daemon/git.ts
+++ b/daemon/git.ts
@@ -324,6 +324,15 @@ export interface CheckoutBranchAPI {
   };
 }
 
+export interface CheckoutExistingBranchAPI {
+  body: {
+    branchName: string;
+  };
+  response: {
+    branch: string;
+  };
+}
+
 // ─── /git/raw ─────────────────────────────────────────────────────────────────
 
 export interface GitRawAPI {
@@ -858,6 +867,28 @@ export const checkoutBranch: Handler = async (c) => {
   return Response.json({ branch: branchName });
 };
 
+export const checkoutExistingBranch: Handler = async (c) => {
+  const { branchName } =
+    (await c.req.json()) as CheckoutExistingBranchAPI["body"];
+
+  if (!branchName || !/^[a-zA-Z0-9_\-./]+$/.test(branchName)) {
+    return new Response("Invalid branch name", { status: 400 });
+  }
+
+  const branches = await git.branch(["-a"]);
+  const exists = Object.keys(branches.branches).some(
+    (b) => b === branchName || b === `remotes/origin/${branchName}`,
+  );
+
+  if (!exists) {
+    return new Response(`Branch "${branchName}" not found`, { status: 404 });
+  }
+
+  await git.checkout(branchName);
+
+  return Response.json({ branch: branchName });
+};
+
 export const createGitAPIS = (options: Options) => {
   const app = new Hono();
 
@@ -869,6 +900,7 @@ export const createGitAPIS = (options: Options) => {
   app.post("/discard", discard);
   app.post("/rebase", rebase);
   app.post("/checkout-branch", checkoutBranch);
+  app.post("/checkout", checkoutExistingBranch);
   app.post("/raw", gitRaw);
 
   return app;


### PR DESCRIPTION
## Summary

- Splits branch checkout into two explicit APIs to make intent clear and failure modes predictable:
  - `POST /checkout-branch` — creates **and** switches to a new branch (`git checkout -b`). Fails if the branch already exists.
  - `POST /checkout` — switches to an **existing** branch (`git checkout`). Returns `404` if the branch is not found locally or in `origin`.
- Adds `CheckoutExistingBranchAPI` interface for the new endpoint.

## Test plan

- [ ] `POST /checkout` with an existing local branch name → switches branch, returns `{ branch }`
- [ ] `POST /checkout` with a remote-only branch name → switches branch, returns `{ branch }`
- [ ] `POST /checkout` with a non-existent branch name → returns `404`
- [ ] `POST /checkout-branch` with a new branch name → creates and switches, returns `{ branch }`
- [ ] `POST /checkout-branch` with an already-existing branch name → returns an error from git

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add POST /git/checkout to switch to an existing branch (local or origin). This makes branch switching explicit and returns clear errors.

- New Features
  - POST /git/checkout: switches to an existing branch; returns 404 if not found.
  - POST /git/checkout-branch: create-and-switch; errors if the branch already exists.
  - Validates branch names; adds CheckoutExistingBranchAPI; returns { branch } on success.

<sup>Written for commit e870afec20a0213968eecd8679ecb39ffd34d0ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to checkout existing branches, supporting both local and remote branches with branch name validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->