### PR TITLE
feat: support per-tenant Valkey credentials via LOADER_CACHE_REDIS_USERNAME

### DIFF
--- a/runtime/caches/redis.ts
+++ b/runtime/caches/redis.ts
@@ -42,6 +42,7 @@ const SENTINEL_URLS = Deno.env.get("LOADER_CACHE_REDIS_SENTINEL_URLS");
 const SENTINEL_NAME = Deno.env.get("LOADER_CACHE_REDIS_SENTINEL_NAME") ??
   "mymaster";
 const SENTINEL_PASSWORD = Deno.env.get("LOADER_CACHE_REDIS_SENTINEL_PASSWORD");
+const REDIS_USERNAME = Deno.env.get("LOADER_CACHE_REDIS_USERNAME");
 const REDIS_PASSWORD = Deno.env.get("LOADER_CACHE_REDIS_PASSWORD");
 const REDIS_READ_URL = Deno.env.get("LOADER_CACHE_REDIS_READ_URL");
 
@@ -235,12 +236,14 @@ function createRedisClient(): Redis {
       sentinels: parseSentinels(SENTINEL_URLS),
       name: SENTINEL_NAME,
       ...(SENTINEL_PASSWORD && { sentinelPassword: SENTINEL_PASSWORD }),
+      ...(REDIS_USERNAME && { username: REDIS_USERNAME }),
       ...(REDIS_PASSWORD && { password: REDIS_PASSWORD }),
     });
   }
 
   return new Redis(Deno.env.get("LOADER_CACHE_REDIS_URL")!, {
     ...sharedOptions,
+    ...(REDIS_USERNAME && { username: REDIS_USERNAME }),
     ...(REDIS_PASSWORD && { password: REDIS_PASSWORD }),
   });
 }
@@ -248,6 +251,7 @@ function createRedisClient(): Redis {
 function createReadRedisClient(): Redis {
   return new Redis(REDIS_READ_URL!, {
     ...sharedOptions,
+    ...(REDIS_USERNAME && { username: REDIS_USERNAME }),
     ...(REDIS_PASSWORD && { password: REDIS_PASSWORD }),
   });
 }


### PR DESCRIPTION
## Summary

- Reads `LOADER_CACHE_REDIS_USERNAME` and passes it as the ioredis `username` option for ACL-based authentication
- Applied to all three client constructors: Sentinel, direct URL, and read replica
- Completely backwards compatible: if the env var is absent, behavior is identical to today

## How it works

When the deco operator provisions a site namespace, it creates a `valkey-acl` Secret injected into the pod with:
- `LOADER_CACHE_REDIS_USERNAME` = site name (e.g. `minha-loja`)
- `LOADER_CACHE_REDIS_PASSWORD` = random per-site password

The Valkey ACL for that user is restricted to `~minha-loja:*` and `~lock:minha-loja:*` — matching exactly the key prefixes already generated by `utils.ts` via `DECO_SITE_NAME`.

## ⚠️ Merge only after operator validation

This PR should be merged and deployed **only after**:
1. decocms/operator#3 is deployed and validated
2. Valkey auth is enabled in production
3. ACL provisioning is confirmed working end-to-end

Merging before that is safe (env var absent = no-op), but sites won't actually use per-tenant credentials until the operator is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-tenant Valkey ACL authentication via `LOADER_CACHE_REDIS_USERNAME`. If the env var is missing, behavior is unchanged.

- **New Features**
  - Sets `username` on `ioredis` for Sentinel, direct, and read-replica clients.

- **Migration**
  - Merge after `decocms/operator#3` is deployed, Valkey auth is enabled, and ACL provisioning is validated.
  - Safe to merge earlier; without the env var this is a no-op.

<sup>Written for commit de8d68053b009ce32e3523b84ef7e68c3b6d0033. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Redis username-based authentication configuration for enhanced connection security across all connection types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->