### PR TITLE
add revert as allowed subcommand

### DIFF
--- a/daemon/git.ts
+++ b/daemon/git.ts
@@ -367,6 +367,7 @@ const ALLOWED_SUBCOMMANDS = new Set([
   "ls-files",
   "ls-tree",
   "cat-file",
+  "revert",
 ]);
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow running `git revert` via the daemon by adding it to the allowed subcommands. This enables commit reverts in restricted Git environments without expanding other command access.

<sup>Written for commit c1ead6565ada5b18e68f1f04844380a0f7be93d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Git revert command support through the raw Git API endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->