### PR TITLE
feat(daemon): allow git fetch as a raw subcommand

### DIFF
--- a/daemon/git.ts
+++ b/daemon/git.ts
@@ -368,6 +368,7 @@ const ALLOWED_SUBCOMMANDS = new Set([
   "ls-tree",
   "cat-file",
   "revert",
+  "fetch",
 ]);
 
 /**


### PR DESCRIPTION
## Summary

- Adds `"fetch"` to `ALLOWED_SUBCOMMANDS` in `daemon/git.ts` so that `git fetch origin` can be executed via the `/git/raw` endpoint.

## Test plan

- [ ] Call `/git/raw` with args `["fetch", "origin"]` and confirm it executes successfully.
- [ ] Confirm blocked flags like `--force` still get rejected when used with `fetch`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows running git fetch via the `/git/raw` endpoint by adding `fetch` to `ALLOWED_SUBCOMMANDS`. This enables `git fetch origin` while existing blocked flags (e.g., `--force`) remain enforced.

<sup>Written for commit 65ee3a46db97a31c0a604216b3c841e339a2612d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `/git/raw` endpoint now supports the `fetch` subcommand for git operations, enabling previously unavailable functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->