### PR TITLE
fix(daemon): bump simple-git and enable allowUnsafeEditor

### DIFF
--- a/daemon/git.ts
+++ b/daemon/git.ts
@@ -57,6 +57,9 @@ export const lockerGitAPI = createLocker();
 
 export const git = simpleGit(Deno.cwd(), {
   config: ["core.editor=true"], // disable interactive editor
+  unsafe: {
+    allowUnsafeEditor: true,
+  },
   maxConcurrentProcesses: 1,
   trimmed: true,
   progress: ({ method, stage, progress }) =>

--- a/deno.json
+++ b/deno.json
@@ -96,7 +96,7 @@
     "partytown/": "https://deno.land/x/partytown@0.3.0/",
     "preact": "npm:preact@10.23.1",
     "preact-render-to-string": "npm:preact-render-to-string@6.4.0",
-    "simple-git": "npm:simple-git@^3.25.0",
+    "simple-git": "npm:simple-git@^3.36.0",
     "std/": "https://deno.land/std@0.203.0/"
   },
   "compilerOptions": {


### PR DESCRIPTION
## Summary

- Bumps simple-git from ^3.25.0 to ^3.36.0 in deno.json
- Adds unsafe: { allowUnsafeEditor: true } to the simpleGit() options in daemon/git.ts

## Context

simple-git >= 3.27 introduced a security plugin that blocks setting core.editor via the config option unless allowUnsafeEditor is explicitly enabled. The daemon sets core.editor=true intentionally (to prevent git from opening an interactive editor and blocking execution), but the newer version was throwing:

    GitPluginError: Configuring core.editor is not permitted without enabling allowUnsafeEditor

This fix keeps the existing behavior while satisfying the library new opt-in requirement.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `simple-git` to ^3.36.0 and enable `unsafe.allowUnsafeEditor` so the daemon can keep setting `core.editor=true` without opening an editor or throwing `GitPluginError` at startup.

<sup>Written for commit 27b6965529fe0057d97d0c07b92d2fb829bcf155. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated simple-git dependency to a newer version.
  * Enhanced git configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->