### PR TITLE
fix(daemon/meta): handle HTTP 304 in watchMeta and skip empty If-None…

### DIFF
--- a/daemon/meta.ts
+++ b/daemon/meta.ts
@@ -41,7 +41,9 @@ const metaRequest = (etag: string) =>
     method: "GET",
     headers: {
       "Content-Type": "application/json",
-      "If-None-Match": etag,
+      // Only send If-None-Match when we actually have an etag.
+      // Sending an empty string causes servers to return 304 unconditionally.
+      ...(etag ? { "If-None-Match": etag } : {}),
     },
   });
 
@@ -85,6 +87,16 @@ export const watchMeta = async (signal?: AbortSignal) => {
       const w = await worker();
 
       const response = await w.fetch(metaRequest(etag));
+
+      // 304 means the meta hasn't changed since the last etag — not an error.
+      // Still update the etag from the response so future requests are correct,
+      // then wait briefly before polling again.
+      if (response.status === 304) {
+        etag = response.headers.get("etag") ?? etag;
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        continue;
+      }
+
       if (!response.ok) {
         throw response;
       }


### PR DESCRIPTION
…-Match

Made-with: Cursor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle meta polling correctly by treating HTTP 304 as “no change” and by not sending an empty `If-None-Match` header. This prevents unnecessary errors and tight polling when metadata hasn’t changed.

- **Bug Fixes**
  - Send `If-None-Match` only when an `etag` exists to avoid unconditional 304s from some servers.
  - In `watchMeta`, handle 304 by updating the `etag`, waiting 1s, and continuing without throwing.

<sup>Written for commit f9518c22fb9c858a8f4829567b17ae0c5f33c803. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Optimized data polling requests for improved efficiency and reduced unnecessary data transfers.
* Enhanced handling of unchanged data during periodic updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->