### PR TITLE
fix(daemon): remove Deno HTTP proxy client from worker fetch

### DIFF
--- a/daemon/workers/denoRun.ts
+++ b/daemon/workers/denoRun.ts
@@ -56,7 +56,6 @@ export class DenoRun implements Isolate {
     | ReturnType<typeof Promise.withResolvers<void>>
     | undefined;
   protected proxyUrl: string;
-  protected client?: Deno.HttpClient;
   constructor(options: IsolateOptions | CommandIsolate) {
     if (isCmdIsolate(options)) {
       this.port = options.port;
@@ -82,16 +81,9 @@ export class DenoRun implements Isolate {
         },
       });
     }
-    const hostname = Deno.build.os === "windows" ? "localhost" : "0.0.0.0";
+    // Use 127.0.0.1 as the connect address (not 0.0.0.0 which is a bind wildcard).
+    const hostname = Deno.build.os === "windows" ? "localhost" : "127.0.0.1";
     this.proxyUrl = `http://${hostname}:${this.port}`;
-    this.client = typeof Deno.createHttpClient === "function"
-      ? Deno.createHttpClient({
-        allowHost: true,
-        proxy: {
-          url: this.proxyUrl,
-        },
-      })
-      : undefined;
   }
 
   signal(sig: Deno.Signal) {
@@ -148,12 +140,11 @@ export class DenoRun implements Isolate {
     const headers = new Headers(request.headers);
     headers.set("host", request.headers.get("host") ?? url.hostname);
 
-    return fetch(this.client ? request.url : url, {
+    return fetch(url, {
       method: request.method,
       headers,
       body: request.body,
       redirect: "manual",
-      ...this.client ? { client: this.client } : {},
     }).finally(() => {
       this.inflightRequests--;
       if (this.inflightRequests === 0) {


### PR DESCRIPTION
## Problem

`DenoRun.fetch()` was using a `Deno.createHttpClient` configured as a **forward HTTP proxy** pointing to the worker's local port, then fetching `request.url` (the original URL) through it.

This caused Deno to send **proxy-format requests** to the worker:

```
GET http://localhost:8000/style.css HTTP/1.1
Host: localhost:8000
```

Node.js sets `req.url` to the **full absolute URI** for this kind of request (not just the path). So Vite — and any Node-based worker — could not match asset routes. CSS, JS and other static files returned 404 or wrong responses.

HTML appeared to work only because Vite falls back to `index.html` for unmatched routes (SPA fallback behavior).

For **HTTPS tunnel URLs** (e.g. `*.deco.host`), the problem was worse: the proxy client would attempt an HTTP `CONNECT` tunnel through the local Vite server, which Vite does not support, causing complete failures for all requests from that origin.

## Fix

Always fetch the **path-rewritten URL** (`http://127.0.0.1:<workerPort>/path`) directly, bypassing the proxy client entirely. The rewritten `url` was already being constructed correctly on every request — it just wasn't being used when `this.client` was set.

This sends a clean path-only request to the worker, which correctly routes all asset types regardless of which port or tunnel URL the browser used (`localhost:8000`, `localhost:<workerPort>`, or `*.deco.host`).

Also changes the connect hostname from `0.0.0.0` (a bind wildcard — valid for listening, not for connecting) to `127.0.0.1` (the correct loopback address for outbound connections on macOS/Linux).

## Changes

- Removed `protected client?: Deno.HttpClient` field and its `Deno.createHttpClient` initialization
- `fetch()` now always uses the rewritten `url` directly (no proxy client)
- `proxyUrl` hostname changed from `0.0.0.0` to `127.0.0.1` on non-Windows

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the forward HTTP proxy from the worker fetch and always hit the rewritten local URL. This fixes asset routing in Vite/Node workers and stops failures for `*.deco.host` tunnels.

- **Bug Fixes**
  - Drop `Deno.createHttpClient` proxy and fetch the rewritten URL in `fetch()` to avoid proxy-format requests that set absolute-URI `req.url`.
  - Use `127.0.0.1` (not `0.0.0.0`) as the connect host on non-Windows.

<sup>Written for commit 4acdceb1a1540acdd63633335db06f88074f831f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified HTTP proxy handling to enhance network connectivity and stability
  * Improved proxy configuration consistency across platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->