### PR TITLE
fix(render): handle stale resolve chains gracefully instead of crashing

### DIFF
--- a/runtime/features/render.tsx
+++ b/runtime/features/render.tsx
@@ -64,11 +64,32 @@ export const render = async <TAppManifest extends AppManifest = AppManifest>(
 
   if (resolveChain) {
     const index = resolveChain.findLastIndex((x) => x.type === "resolvable");
+    if (index === -1) {
+      throw new HttpError(
+        new Response("Invalid resolve chain: no resolvable found", {
+          status: 400,
+        }),
+      );
+    }
     section = resolvables[resolveChain[index].value];
 
     for (let it = 0; it < resolveChain.length; it++) {
       const item = resolveChain[it];
       if (it < index || item.type !== "prop") continue;
+
+      if (section == null) {
+        const chain = resolveChain
+          .slice(0, it + 1)
+          .map((r) => `${r.type}:${r.value}`)
+          .join(" → ");
+        logger.warn(
+          `Stale resolve chain: section is ${section} at step ${it} (${item.type}:${item.value}). Chain: ${chain}`,
+          { url: url.toString(), pathTemplate },
+        );
+        throw new HttpError(
+          new Response("Stale or invalid resolve chain", { status: 404 }),
+        );
+      }
 
       section = section[item.value];
     }


### PR DESCRIPTION
When a CMS publish changes the multivariate flag structure (e.g. removing a variant), cached pages still reference old resolve chains pointing to indices that no longer exist. The chain walk at render.tsx:73 would crash with `TypeError: Cannot read properties of undefined (reading 'value')` causing 500s and flooding error logs.

Add null checks during the resolve chain walk:
- Return 400 if the chain has no resolvable entry (malformed)
- Return 404 with a descriptive warn log if an intermediate step resolves to undefined (stale chain from cached HTML)

This converts unhandled TypeErrors (500 + error log) into graceful HTTP responses (404 + warn log), reducing noise in monitoring.

Made-with: Cursor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gracefully handle stale or malformed resolve chains in the renderer to prevent crashes and 500s after CMS changes. Now returns clear 400/404 responses with warn logs instead of unhandled TypeErrors.

- **Bug Fixes**
  - Add null checks during the resolve chain walk in `runtime/features/render.tsx`.
  - Return 400 when no resolvable entry exists; return 404 and log a warn if an intermediate step is undefined (stale cached HTML).
  - Prevent unhandled TypeErrors and reduce noisy 500s in monitoring.

<sup>Written for commit 69917bb306da3aee76d6e15fe812046198df2e07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation and error handling in the render process: Now detects invalid or stale data chains and returns appropriate error responses (400 for missing elements, 404 for stale chains) to provide clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->