### PR TITLE
Revert "fix(daemon): remove Deno HTTP proxy client from worker fetch"

### DIFF
--- a/daemon/workers/denoRun.ts
+++ b/daemon/workers/denoRun.ts
@@ -56,6 +56,7 @@ export class DenoRun implements Isolate {
     | ReturnType<typeof Promise.withResolvers<void>>
     | undefined;
   protected proxyUrl: string;
+  protected client?: Deno.HttpClient;
   constructor(options: IsolateOptions | CommandIsolate) {
     if (isCmdIsolate(options)) {
       this.port = options.port;
@@ -81,9 +82,16 @@ export class DenoRun implements Isolate {
         },
       });
     }
-    // Use 127.0.0.1 as the connect address (not 0.0.0.0 which is a bind wildcard).
-    const hostname = Deno.build.os === "windows" ? "localhost" : "127.0.0.1";
+    const hostname = Deno.build.os === "windows" ? "localhost" : "0.0.0.0";
     this.proxyUrl = `http://${hostname}:${this.port}`;
+    this.client = typeof Deno.createHttpClient === "function"
+      ? Deno.createHttpClient({
+        allowHost: true,
+        proxy: {
+          url: this.proxyUrl,
+        },
+      })
+      : undefined;
   }
 
   signal(sig: Deno.Signal) {
@@ -140,11 +148,12 @@ export class DenoRun implements Isolate {
     const headers = new Headers(request.headers);
     headers.set("host", request.headers.get("host") ?? url.hostname);
 
-    return fetch(url, {
+    return fetch(this.client ? request.url : url, {
       method: request.method,
       headers,
       body: request.body,
       redirect: "manual",
+      ...this.client ? { client: this.client } : {},
     }).finally(() => {
       this.inflightRequests--;
       if (this.inflightRequests === 0) {


### PR DESCRIPTION
Reverts deco-cx/deco#1170

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reinstates the worker HTTP proxy by restoring `Deno.HttpClient` usage, so worker fetches route through the local proxy again. This reverts the previous removal and fixes environments that require absolute-URI proxying.

- **Bug Fixes**
  - Create a `Deno.HttpClient` with `proxy: { url: this.proxyUrl }` (when available) and pass it to `fetch`, using the original request URL to enable proxying.
  - Build `proxyUrl` with `0.0.0.0` on non-Windows (and `localhost` on Windows) to match the prior behavior.

<sup>Written for commit a69319281ed2799b29f50e03fa8fefef1ef8252c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced network request handling with optimized proxy configuration for improved compatibility across different platforms
  * Refined hostname selection for proxy routing on non-Windows systems to ensure more reliable request handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->