### PR TITLE
fix: remove console.error that logs raw Response on invoke failure

### DIFF
--- a/clients/withManifest.ts
+++ b/clients/withManifest.ts
@@ -158,7 +158,6 @@ const fetchWithProps = async (
     return response.json();
   }
 
-  console.error(init?.body, response);
   const error = await response.text();
   if (response.headers.get("content-type") === "application/json") {
     const errorObj = JSON.parse(error);


### PR DESCRIPTION
## Summary
- `fetchWithProps` in `clients/withManifest.ts` was calling `console.error(init?.body, response)` on every non-ok response
- The raw `Response` object has no `.name` property, so HyperDX/OTEL formatted it as `(undefined) [object Response]`
- This produced ~3400 errors/hour in production HyperDX
- The `InvokeError` thrown immediately after already carries status, body, and correlationId — no debug info is lost
- Removed the `console.error` line

## Test plan
- [ ] Invoke a loader/action that returns 403/500 from the browser
- [ ] Confirm `InvokeError` is still thrown with correct status and cause
- [ ] Verify `(undefined) [object Response]` errors stop appearing in HyperDX after deploy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a noisy `console.error` in `clients/withManifest.ts` (`fetchWithProps`) that logged the raw Response on non-OK fetches. This stops the "(undefined) [object Response]" spam in HyperDX/OTEL without losing error details.

- **Bug Fixes**
  - Stop logging the raw `Response` object; reduces ~3400 errors/hour in prod.
  - Keep behavior: still throws `InvokeError` with status, body, and correlationId.

<sup>Written for commit 8a696f2645da94d7be0ca1cf773c94629ea54e4f. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/deco/pull/1175?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined error logging behavior in request handling to reduce logged information during failures while maintaining error tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->