### PR TITLE
fix(otel): remove high-volume trace spans and access log noise

### DIFF
--- a/engine/core/resolver.ts
+++ b/engine/core/resolver.ts
@@ -471,33 +471,30 @@ const invokeResolverWithProps = async <
     );
     const metricsFunc = ctx.monitoring?.metrics;
     if (isAwaitable(respOrPromise)) {
-      await ctx?.monitoring?.tracer?.startActiveSpan?.(__resolveType, {
-        attributes: {
-          "block.kind": "resolver",
-        },
-      }, async (span) => {
-        await metricsFunc?.(__resolveType, async () => {
-          respOrPromise = await respOrPromise;
+      const resolve = async () => {
+        respOrPromise = await respOrPromise;
 
-          // (@mcandeia) there are some cases where the function returns a function. In such cases we should calculate the time to wait the inner function to return,
-          // in order to achieve the correct result we should wrap the inner function with the timings function.
-          if (typeof respOrPromise === "function") {
-            const original = respOrPromise;
-            respOrPromise = async (...args: any[]) => {
-              try {
-                return await original(...args);
-              } finally {
-                timing?.end();
-                span?.end?.();
-              }
-            };
-          } else {
-            timing?.end();
-            span?.end?.();
-          }
-          return respOrPromise;
-        });
-      });
+        // (@mcandeia) there are some cases where the function returns a function. In such cases we should calculate the time to wait the inner function to return,
+        // in order to achieve the correct result we should wrap the inner function with the timings function.
+        if (typeof respOrPromise === "function") {
+          const original = respOrPromise;
+          respOrPromise = async (...args: any[]) => {
+            try {
+              return await original(...args);
+            } finally {
+              timing?.end();
+            }
+          };
+        } else {
+          timing?.end();
+        }
+        return respOrPromise;
+      };
+      if (metricsFunc) {
+        await metricsFunc(__resolveType, resolve);
+      } else {
+        await resolve();
+      }
     }
     return respOrPromise;
   } catch (err) {

--- a/runtime/caches/common.ts
+++ b/runtime/caches/common.ts
@@ -1,5 +1,4 @@
-import { type Exception, ValueType } from "../../deps.ts";
-import { tracer } from "../../observability/otel/config.ts";
+import { ValueType } from "../../deps.ts";
 import { meter } from "../../observability/otel/metrics.ts";
 import { inFuture } from "./utils.ts";
 
@@ -37,26 +36,14 @@ export const withInstrumentation = (
         delete: cacheImpl.delete.bind(cacheImpl),
         put: cacheImpl.put.bind(cacheImpl),
         match: async (req, opts) => {
-          const span = tracer.startSpan("cache-match", {
-            attributes: { engine },
-          });
-          try {
-            const isMatch = await cacheImpl.match(req, opts);
-            //there is an edge case where there is no expires header, but technically our loader always sets it
-            const result = getCacheStatus(isMatch);
+          const isMatch = await cacheImpl.match(req, opts);
+          const result = getCacheStatus(isMatch);
 
-            span.setAttribute("cache_status", result);
-            cacheHit.add(1, {
-              result,
-              engine,
-            });
-            return isMatch;
-          } catch (err) {
-            span.recordException(err as Exception);
-            throw err;
-          } finally {
-            span.end();
-          }
+          cacheHit.add(1, {
+            result,
+            engine,
+          });
+          return isMatch;
         },
       };
     },

--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -305,15 +305,13 @@ export const middlewareFor = <TAppManifest extends AppManifest = AppManifest>(
               span.updateName(`${ctx.req.raw.method} ${ctx.req.raw.url}`);
             }
             span.end();
-            if (!url.pathname.startsWith("/_frsh")) {
+            if (ctx.var.debugEnabled && !url.pathname.startsWith("/_frsh")) {
               console.info(
                 formatLog({
                   status: ctx.res?.status ?? 500,
                   url,
                   begin,
-                  timings: ctx.var.debugEnabled
-                    ? ctx.var.monitoring.timings.get()
-                    : undefined,
+                  timings: ctx.var.monitoring.timings.get(),
                 }),
               );
             }


### PR DESCRIPTION
## Summary

Remove noisy OTEL trace spans and access logs that were generating ~6M+ events per 6h across storefronts, with 94% being "things went fine" (level:ok spans + level:log access logs).

Based on HyperDX 80/20 analysis:
- **fila-store**: 2.56M events/6h (99.8% level:ok spans)
- **technos**: 1.17M events/6h (same pattern)
- **farmrio, teciplast, als-storefront, lojastorra-2, oficina-reserva**: 100k-300k each

### Changes

- **Remove per-resolver/loader/section trace spans** (`resolver.ts`) — created 5-20 child spans per request (`invoke`, `cache-match`, `website/sections/Rendering/Lazy.tsx`, `website/handlers/router.ts`, etc.). Metrics (`block_op_duration` histogram via `observe()`) are preserved.
- **Remove cache-match trace spans** (`common.ts`) — fired on every `cache.match()` call (~260k/6h combined). The `cache_hit` metric counter is preserved.
- **Gate `console.info` access logs behind debug mode** (`middleware.ts`) — root HTTP span + `http_request_duration` histogram already capture method, route, status and latency. Access logs remain available via `?__d=enabled`.

### What is NOT affected

- ✅ `http_request_duration` histogram (metrics pipeline)
- ✅ Root HTTP request span (1 per request, with method/route/status)
- ✅ `cache_hit` counter metric (hit/miss/stale + engine)
- ✅ `block_op_duration` histogram (when `OTEL_ENABLE_EXTRA_METRICS` enabled)
- ✅ All `logger.error()` / `logger.warn()` calls (OTEL log exporter)
- ✅ FetchInstrumentation spans (outgoing HTTP)

### Estimated impact

~80% reduction in HyperDX ingestion volume (from ~7.67M to ~1.5M events/6h) with zero loss of error signal or metric data.

## Test plan

- [ ] Deploy to a staging storefront and verify `http_request_duration` and `cache_hit` metrics still appear in Grafana/HyperDX
- [ ] Verify root HTTP spans (with route/status) still appear in HyperDX traces
- [ ] Verify `logger.error()` logs still appear for error cases
- [ ] Verify access logs appear when debug mode is enabled (`?__d=enabled`)
- [ ] Monitor HyperDX ingestion volume for reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce OTEL trace and access log noise by removing high-volume spans and gating access logs behind debug mode. Cuts HyperDX ingestion ~80% with no loss of error signal or core metrics.

- **Bug Fixes**
  - Remove per-resolver/loader/section child spans in `engine/core/resolver.ts`; keep `block_op_duration` metrics.
  - Drop `cache-match` spans in `runtime/caches/common.ts`; keep `cache_hit` counter.
  - Gate `console.info` access logs in `runtime/middleware.ts` behind debug (`?__d=enabled`); root HTTP span and `http_request_duration` remain; error/warn logs and outgoing fetch spans unchanged.

<sup>Written for commit 684aa3eeef4f2fec005874a48c4bb84fa670b476. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/deco/pull/1176?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

