### PR TITLE
fix: guard Deno.env.get in utils/admin.ts for browser bundles

### DIFF
--- a/utils/admin.ts
+++ b/utils/admin.ts
@@ -1,17 +1,19 @@
 import type { JSONSchema7 } from "../deps.ts";
 
-const extraAdminDomains = Deno.env.get("ADMIN_DOMAINS")
-  ?.split(",")
-  .map((d) => d.trim())
-  .filter(Boolean)
-  .flatMap((d) => {
-    try {
-      return [new URL(d).origin];
-    } catch {
-      console.warn(`[admin] Skipping invalid ADMIN_DOMAINS entry: "${d}"`);
-      return [];
-    }
-  }) ?? [];
+const extraAdminDomains = typeof Deno !== "undefined"
+  ? (Deno.env.get("ADMIN_DOMAINS")
+    ?.split(",")
+    .map((d) => d.trim())
+    .filter(Boolean)
+    .flatMap((d) => {
+      try {
+        return [new URL(d).origin];
+      } catch {
+        console.warn(`[admin] Skipping invalid ADMIN_DOMAINS entry: "${d}"`);
+        return [];
+      }
+    }) ?? [])
+  : [];
 
 export const adminDomains = [
   "https://admin.deco.cx",


### PR DESCRIPTION
## Summary

- `utils/admin.ts` calls `Deno.env.get("ADMIN_DOMAINS")` at module top-level
- This file is re-exported via `utils/mod.ts` and transitively included in client bundles through `mod.ts` → `engine/schema/lazy.ts` → `utils/admin.ts`
- In the browser, this throws `Uncaught ReferenceError: Deno is not defined`
- Fix: wrap with `typeof Deno !== "undefined"` guard

## Test plan

- [ ] Verify admin dashboard loads without `Deno is not defined` console error
- [ ] Verify `ADMIN_DOMAINS` env var still works server-side

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded `Deno.env.get("ADMIN_DOMAINS")` in `utils/admin.ts` to prevent "Deno is not defined" errors in browser bundles loaded via `utils/mod.ts` → `engine/schema/lazy.ts`. Server behavior is unchanged.

- **Bug Fixes**
  - Check `typeof Deno !== "undefined"` at module load; default to empty domains in the browser.
  - Keep server-side `ADMIN_DOMAINS` parsing and origin normalization; invalid entries still logged and skipped.

<sup>Written for commit 6cb8049f25bde2b24360d8c8138956f75eca69fb. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/deco/pull/1177?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment detection to properly support non-Deno runtime environments without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->