### PR TITLE
fix(otel): restore cache-match span — metrics pipeline disabled

### DIFF
--- a/runtime/caches/common.ts
+++ b/runtime/caches/common.ts
@@ -1,4 +1,5 @@
-import { ValueType } from "../../deps.ts";
+import { type Exception, ValueType } from "../../deps.ts";
+import { tracer } from "../../observability/otel/config.ts";
 import { meter } from "../../observability/otel/metrics.ts";
 import { inFuture } from "./utils.ts";
 
@@ -36,14 +37,26 @@ export const withInstrumentation = (
         delete: cacheImpl.delete.bind(cacheImpl),
         put: cacheImpl.put.bind(cacheImpl),
         match: async (req, opts) => {
-          const isMatch = await cacheImpl.match(req, opts);
-          const result = getCacheStatus(isMatch);
-
-          cacheHit.add(1, {
-            result,
-            engine,
+          const span = tracer.startSpan("cache-match", {
+            attributes: { engine },
           });
-          return isMatch;
+          try {
+            const isMatch = await cacheImpl.match(req, opts);
+            //there is an edge case where there is no expires header, but technically our loader always sets it
+            const result = getCacheStatus(isMatch);
+
+            span.setAttribute("cache_status", result);
+            cacheHit.add(1, {
+              result,
+              engine,
+            });
+            return isMatch;
+          } catch (err) {
+            span.recordException(err as Exception);
+            throw err;
+          } finally {
+            span.end();
+          }
         },
       };
     },


### PR DESCRIPTION
## Summary

- Restores the `cache-match` trace span removed in #1176
- With OTEL metrics export disabled, the span is the **only source** of cache hit/miss/stale visibility
- Dashboards querying `span_name:"cache-match" cache_status:"hit"` depend on this span

The other noise reductions from #1176 (resolver spans removal + access log gating) remain in place.

## Test plan

- [ ] Verify `cache-match` spans with `cache_status` attribute appear again in HyperDX after bump
- [ ] Verify cache dashboard panels recover data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the `cache-match` OTEL trace span so we can see cache hit/miss/stale while metrics export is disabled. Cache dashboards that query span_name:"cache-match" with `cache_status` will populate again.

- **Bug Fixes**
  - Wrapped `match` with a `cache-match` span. Sets `engine` and `cache_status` attributes.
  - Records exceptions and always ends the span. Keeps prior noise reductions intact.

<sup>Written for commit 0640dd9a67dca0178f3326939c39f9dbaecf885f. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/deco/pull/1178?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced cache operation monitoring with improved tracing instrumentation.
  * Improved error tracking and reporting in trace spans.
  * Refined span lifecycle management for better observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->