### PR TITLE
fix(daemon): stop dev-mode restarts from 0.0.0.0 connect + watchMeta retry spin

### DIFF
--- a/daemon/main.ts
+++ b/daemon/main.ts
@@ -148,6 +148,14 @@ if (SANDBOX_MODE) {
   );
 }
 
+// Surface scheduled-restart configuration so it's easy to rule out as the cause
+// of "the daemon keeps restarting" reports.
+console.log(
+  `[daemon] ${UNSTABLE_WORKER_RESPAWN_INTERVAL_MS_ENV_NAME}=${
+    UNSTABLE_WORKER_RESPAWN_INTERVAL_MS ?? "unset"
+  }`,
+);
+
 globalThis.addEventListener(
   "unhandledrejection",
   (e: { promise: Promise<unknown>; reason: unknown }) => {

--- a/daemon/meta.ts
+++ b/daemon/meta.ts
@@ -131,6 +131,10 @@ export const watchMeta = async (signal?: AbortSignal) => {
 
       dispatchWorkerState("updating");
       console.error(error);
+      // Backoff to avoid a tight retry spin when the worker fetch fails fast
+      // (e.g. connection refused mid-restart); without this, the loop pegs CPU
+      // and floods stderr until a supervisor kills the daemon.
+      await new Promise((resolve) => setTimeout(resolve, 1000));
     }
   }
 

--- a/daemon/workers/denoRun.ts
+++ b/daemon/workers/denoRun.ts
@@ -82,7 +82,9 @@ export class DenoRun implements Isolate {
         },
       });
     }
-    const hostname = Deno.build.os === "windows" ? "localhost" : "0.0.0.0";
+    // 127.0.0.1 is the correct loopback for outbound connections;
+    // 0.0.0.0 is a bind wildcard and not a valid connect target on macOS/Linux.
+    const hostname = Deno.build.os === "windows" ? "localhost" : "127.0.0.1";
     this.proxyUrl = `http://${hostname}:${this.port}`;
     this.client = typeof Deno.createHttpClient === "function"
       ? Deno.createHttpClient({


### PR DESCRIPTION
## Summary

Lead reported that the dev experience for deco sites has degraded over the last few weeks with intermittent restarts. After investigating I found two issues that compound to produce that symptom:

- **`daemon/workers/denoRun.ts:85`** — PR #1173 (Apr 17) wholesale-reverted #1170, which silently brought back \`0.0.0.0\` as the worker connect hostname. \`0.0.0.0\` is a bind wildcard, not a valid outbound connect target on macOS/Linux — connections through it are platform/Deno-version-dependent and flake. This PR restores only the hostname half of #1170 (\`127.0.0.1\`) and leaves the proxy-client decision alone, since that was reverted for a separate legitimate Vite asset-routing reason.
- **`daemon/meta.ts`** — \`watchMeta\`'s long-poll loop has a catch path that just logs and continues, with no backoff. When the worker fetch fails fast (connection refused mid-restart, the hostname flake above, etc.) it becomes a tight CPU-pegging spin that floods stderr until a process supervisor kills the daemon — i.e. the "restarts". This PR adds a 1s backoff, matching the pattern already used on the 304 path.
- **`daemon/main.ts`** — added a one-line startup log of \`UNSTABLE_WORKER_RESPAWN_INTERVAL_MS\` so scheduled restarts (\`Deno.exit(1)\` on a timer) can be ruled in/out at a glance.

15 lines changed across 3 files.

## Test plan

- [x] \`deno check daemon/main.ts daemon/workers/denoRun.ts daemon/meta.ts\` passes
- [ ] Run dev mode on macOS against a real deco site and confirm the worker-fetch errors disappear from logs and the site responds without intermittent failures
- [ ] \`kill -9\` the child Deno worker mid-session and confirm the daemon recovers without a tight spin (≤1 error/sec in stderr until the worker comes back, not thousands)
- [ ] Confirm the new startup log shows the respawn-interval value (or "unset")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops intermittent dev-mode restarts by connecting workers to `127.0.0.1` (not `0.0.0.0`) and adding a 1s backoff to prevent tight retry spins. Also logs `UNSTABLE_WORKER_RESPAWN_INTERVAL_MS` at startup for quick diagnosis.

- **Bug Fixes**
  - Use `127.0.0.1` for worker outbound connections on non-Windows (`0.0.0.0` -> `127.0.0.1`).
  - Add 1s backoff in `watchMeta` error path to avoid CPU spin and stderr flood during worker restarts.

- **New Features**
  - Log `UNSTABLE_WORKER_RESPAWN_INTERVAL_MS` on daemon startup to help rule out scheduled restarts.

<sup>Written for commit 383efeecdeea7723783ebd607175092bef2f17ee. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/deco/pull/1179?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup logging to display the configured worker respawn interval setting for better visibility.

* **Bug Fixes**
  * Fixed proxy configuration for non-Windows systems to use the correct loopback address.
  * Improved retry behavior with throttling to reduce CPU usage and excessive logging during failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->