### PR TITLE
fix(LiveControls): restrict postMessage handler to trusted origins

### DIFF
--- a/components/LiveControls.tsx
+++ b/components/LiveControls.tsx
@@ -4,6 +4,7 @@
 import { context } from "../deco.ts";
 import { DomInspector, DomInspectorActivators } from "../deps.ts";
 import type { Flag, Site } from "../types.ts";
+import { adminDomains } from "../utils/admin.ts";
 
 const IS_LOCALHOST = context.deploymentId === undefined;
 
@@ -110,11 +111,26 @@ const main = () => {
     }
   };
 
-  const TRUSTED_ORIGINS = [
+  const STATIC_TRUSTED_ORIGINS = [
     "https://deco.cx",
     "https://admin.deco.cx",
     "https://play.deco.cx",
+    "https://admin-cx.deco.page",
+    "https://deco.chat",
+    "https://admin.decocms.com",
+    "https://decocms.com",
+    "https://studio.decocms.com",
   ];
+  const runtimeTrustedOrigins = (() => {
+    try {
+      const el = document.getElementById("__DECO_TRUSTED_ORIGINS");
+      const parsed = JSON.parse(el?.textContent || "[]");
+      return Array.isArray(parsed) ? parsed.filter((o) => typeof o === "string") : [];
+    } catch {
+      return [];
+    }
+  })();
+  const TRUSTED_ORIGINS = STATIC_TRUSTED_ORIGINS.concat(runtimeTrustedOrigins);
   const isTrustedOrigin = (origin: string) =>
     TRUSTED_ORIGINS.indexOf(origin) !== -1 ||
     (origin.startsWith("https://") && origin.endsWith(".deco.cx")) ||
@@ -126,6 +142,13 @@ const main = () => {
     }
 
     const { data } = event;
+
+    if (
+      typeof data !== "object" || data === null ||
+      typeof (data as { type?: unknown }).type !== "string"
+    ) {
+      return;
+    }
 
     switch (data.type) {
       case "scrollToComponent": {
@@ -195,6 +218,13 @@ function LiveControls({ site, page, flags }: Props) {
         id="__DECO_STATE"
         dangerouslySetInnerHTML={{
           __html: JSON.stringify({ page, site, flags }),
+        }}
+      />
+      <script
+        type="application/json"
+        id="__DECO_TRUSTED_ORIGINS"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(adminDomains),
         }}
       />
       <script

--- a/components/LiveControls.tsx
+++ b/components/LiveControls.tsx
@@ -110,7 +110,21 @@ const main = () => {
     }
   };
 
+  const TRUSTED_ORIGINS = [
+    "https://deco.cx",
+    "https://admin.deco.cx",
+    "https://play.deco.cx",
+  ];
+  const isTrustedOrigin = (origin: string) =>
+    TRUSTED_ORIGINS.indexOf(origin) !== -1 ||
+    (origin.startsWith("https://") && origin.endsWith(".deco.cx")) ||
+    origin === WINDOW.location.origin;
+
   const onMessage = (event: MessageEvent<LiveEvent>) => {
+    if (!isTrustedOrigin(event.origin)) {
+      return;
+    }
+
     const { data } = event;
 
     switch (data.type) {


### PR DESCRIPTION
The onMessage handler executed eval() on script payloads from any sender. Gate it behind an origin allowlist (deco.cx, *.deco.cx, same-origin) to prevent cross-origin XSS via the editor::inject message type.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lock down LiveControls postMessage handling to trusted origins and validate messages to block cross-origin XSS from editor::inject. Expands the allowlist and supports runtime admin domains so legitimate editor messages keep working.

- **Bug Fixes**
  - Gate messages behind `isTrustedOrigin` with same-origin, `*.deco.cx`, `deco.cx`, `admin.deco.cx`, `play.deco.cx`, plus `admin-cx.deco.page`, `deco.chat`, `admin.decocms.com`, `decocms.com`, `studio.decocms.com`.
  - Inject runtime trusted origins from `adminDomains` via a `__DECO_TRUSTED_ORIGINS` JSON script tag.
  - Validate `event.data` is a non-null object with a string `type`; ignore untrusted or malformed messages.

<sup>Written for commit 3517f048ad653dd4350b70501dea9db4675ea01b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security and stability of live controls by only accepting control messages from trusted origins and ignoring malformed messages, reducing unexpected behavior and potential cross-origin risks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->