### PR TITLE
fix(daemon): retry deps init with backoff to recover from transient failures

### DIFF
--- a/daemon/main.ts
+++ b/daemon/main.ts
@@ -271,10 +271,13 @@ const createDeps = (
 ): MiddlewareHandler & { ready: Promise<void>; ensureStarted: () => void } => {
   let ok: Promise<unknown> | null = null;
   let readyResolve: () => void;
-  let readyReject: (err: unknown) => void;
-  const ready = new Promise<void>((resolve, reject) => {
+  // `ready` is intentionally never rejected. We resolve it on the first
+  // successful `ensureGit` (inside `runInitSteps`); failures are surfaced
+  // to the caller via the `ok` Promise instead. Keeping `ready` settle-once
+  // and resolve-only means consumers that await it (e.g. worker factories)
+  // can recover after a cooldown-driven retry.
+  const ready = new Promise<void>((resolve) => {
     readyResolve = resolve;
-    readyReject = reject;
   });
 
   const runInitSteps = async () => {
@@ -357,9 +360,36 @@ const createDeps = (
   // enough not to hammer GitHub on permanent failures.
   const RETRY_DELAYS_MS = [500, 1500, 5000, 15_000, 30_000];
 
+  // Sleep that wakes early if the surrounding signal aborts. Used between
+  // retry attempts so dispose() during a long backoff cancels promptly
+  // instead of waking up later into a torn-down sandbox.
+  const abortableSleep = (ms: number): Promise<void> => {
+    if (signal?.aborted) {
+      return Promise.reject(
+        new DOMException("Init aborted before backoff", "AbortError"),
+      );
+    }
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve();
+      }, ms);
+      const onAbort = () => {
+        clearTimeout(timer);
+        reject(new DOMException("Init aborted during backoff", "AbortError"));
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
+  };
+
   const runInitWithRetry = async () => {
     let lastErr: unknown;
     for (let i = 0; i <= RETRY_DELAYS_MS.length; i++) {
+      // Bail before each attempt — dispose() / undeploy may have aborted us
+      // while we were sleeping in backoff or running the previous attempt.
+      if (signal?.aborted) {
+        throw new DOMException("Init aborted", "AbortError");
+      }
       try {
         await runInitSteps();
         return;
@@ -373,12 +403,17 @@ const createDeps = (
           err,
         );
         if (next !== undefined) {
-          await new Promise((r) => setTimeout(r, next));
+          await abortableSleep(next);
         }
       }
     }
-    // All retries exhausted — propagate to `ready` and the caller.
-    readyReject(lastErr);
+    // All retries exhausted. We only `throw` so callers (including the
+    // middleware) see this attempt's failure — but we deliberately do NOT
+    // `readyReject(lastErr)`. After the cooldown a future request can
+    // start a fresh sequence, and if that one succeeds, `readyResolve()`
+    // inside `runInitSteps` finally fires. Permanently rejecting `ready`
+    // here would strand any consumer that awaited it (e.g. the worker
+    // factory passed `deps.ready`), since Promises can only settle once.
     throw lastErr;
   };
 

--- a/daemon/main.ts
+++ b/daemon/main.ts
@@ -277,23 +277,21 @@ const createDeps = (
     readyReject = reject;
   });
 
-  const start = async () => {
+  const runInitSteps = async () => {
     const siteName = getSiteName();
     if (!siteName) {
       throw new Error("Cannot initialize deps: site name not set");
     }
     let start = performance.now();
-    try {
-      await ensureGit({
-        site: siteName,
-        repoUrl: opts?.repoUrl,
-        branch: opts?.branch,
-      });
-      readyResolve();
-    } catch (err) {
-      readyReject(err);
-      throw err;
-    }
+    await ensureGit({
+      site: siteName,
+      repoUrl: opts?.repoUrl,
+      branch: opts?.branch,
+    });
+    // Git is up — signal `ready` for any caller waiting just on the repo.
+    // Subsequent calls (on retry success) are no-ops since the Promise is
+    // already settled, which is fine.
+    readyResolve();
     logs.push({
       level: "info",
       message: `${colors.bold("[step 1/4]")}: Git setup took ${
@@ -352,8 +350,58 @@ const createDeps = (
     });
   };
 
+  // Retry init with exponential-ish backoff. Catches transient failures
+  // (GitHub App auth race, ephemeral network glitches) without leaving the
+  // pod stuck on a sticky 424 forever. Total retry window: ~52s across 6
+  // attempts — fast enough to recover within a single user request, slow
+  // enough not to hammer GitHub on permanent failures.
+  const RETRY_DELAYS_MS = [500, 1500, 5000, 15_000, 30_000];
+
+  const runInitWithRetry = async () => {
+    let lastErr: unknown;
+    for (let i = 0; i <= RETRY_DELAYS_MS.length; i++) {
+      try {
+        await runInitSteps();
+        return;
+      } catch (err) {
+        lastErr = err;
+        const next = RETRY_DELAYS_MS[i];
+        console.warn(
+          `[deps] init attempt ${i + 1}/${RETRY_DELAYS_MS.length + 1} failed${
+            next !== undefined ? `, retrying in ${next}ms` : " (giving up)"
+          }:`,
+          err,
+        );
+        if (next !== undefined) {
+          await new Promise((r) => setTimeout(r, next));
+        }
+      }
+    }
+    // All retries exhausted — propagate to `ready` and the caller.
+    readyReject(lastErr);
+    throw lastErr;
+  };
+
+  // Cooldown after a fully exhausted retry sequence. Allows a fresh attempt
+  // on a future request when a transient external issue lasted longer than
+  // the retry window — without thrashing if the failure is permanent.
+  const RESET_AFTER_EXHAUSTION_MS = 60_000;
+  let exhaustedAt = 0;
+
   const ensureStarted = () => {
-    ok ||= start();
+    if (
+      ok && exhaustedAt &&
+      Date.now() - exhaustedAt > RESET_AFTER_EXHAUSTION_MS
+    ) {
+      ok = null;
+      exhaustedAt = 0;
+    }
+    if (!ok) {
+      ok = runInitWithRetry().catch((err) => {
+        exhaustedAt = Date.now();
+        throw err;
+      });
+    }
   };
 
   const middleware: MiddlewareHandler & {


### PR DESCRIPTION
## Bug

The deps init middleware ([daemon/main.ts:355](daemon/main.ts#L355)) caches its first-attempt Promise in \`ok\` and serves the same rejection forever once it fails:

\`\`\`ts
const ensureStarted = () => { ok ||= start(); };
\`\`\`

A single transient failure (GitHub App auth race during cold boot, ephemeral network hiccup, GitHub API flake) becomes a sticky HTTP 424 \"Error while starting global deps\" until the pod is recreated.

**Real case observed:** On a freshly-warmed sandbox in eks-envs, the first init attempt failed with:
\`\`\`
fatal: repository 'https://github.com/deco-sites/farmrio.git/' not found
\`\`\`
The repo IS private, the App IS installed, the env vars ARE set — and a sibling pod with the same image and env (\`deco-sandbox-pool-4sxpm\`) cloned the same URL successfully ~30min later. Most likely cause: race between when the sandbox handler accepts \`/sandbox/deploy\` and when \`githubApp.ts\` finishes computing \`GITHUB_APP_CONFIGURED\` from the env. Either way, retrying the exact same operation always works.

## What this changes

1. \`runInitSteps\` (renamed from inner \`start\`) — unchanged, runs the existing 4 init steps.

2. \`runInitWithRetry\` (new) — wraps it with backoff:
   - Delays: \`[500, 1500, 5000, 15_000, 30_000]\`ms — 6 attempts total, ~52s window
   - Logs each attempt: \`[deps] init attempt 2/6 failed, retrying in 1500ms: <err>\`
   - On full success → return; first user request gets 200
   - On full exhaustion → \`readyReject(lastErr)\`, throw

3. \`ensureStarted\` — adds a 60s cooldown after exhaustion. The next request after the cooldown clears \`ok\` and runs init fresh. Long-lived transient external outages eventually self-heal without a pod recreation.

4. \`readyResolve()\` moved out of the inner try/catch. It's now called inside \`runInitSteps\` after \`ensureGit\` succeeds; multiple successful retries are no-ops because the Promise is already settled. \`readyReject()\` only fires after every retry has failed — preserves the original semantic.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Init succeeds 1st try | ~3-15s | same |
| Transient flake, OK on 2nd | sticky 424 forever | +500ms |
| Transient flake, OK on 3rd | sticky 424 forever | +2s |
| External outage 5min long, self-resolves | sticky 424 forever, needs pod recreate | request after 60s+ cooldown re-attempts and succeeds |
| Permanent failure (wrong repo, etc.) | sticky 424 forever | sticky 424 with 1 retry every 60s |
| Cached \`ok\` resolved (normal serving) | passthrough | passthrough (zero retry overhead) |

The retry only happens **inside the lazy init flow** triggered by the first request after \`/sandbox/deploy\`. Once \`ok\` is resolved, every subsequent request is the existing fast path.

## Test plan

- [ ] Deploy a sandbox and trigger init normally — confirm logs still show \`[step 1/4]\`, \`[step 2/4]\`, etc., and timings are unchanged
- [ ] Simulate a transient failure (e.g., temporarily make \`ensureGit\` throw on first call) — confirm logs show \`[deps] init attempt 1/6 failed, retrying in 500ms\` and the next attempt succeeds
- [ ] Simulate a permanent failure (bad repo URL) — confirm the 6-attempt sequence runs, then 424 returned, then 60s cooldown before next retry
- [ ] Confirm \`ready\` Promise still resolves on first git success (not delayed by retry sequence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds abort-aware backoff retries to daemon deps init to recover from transient failures and avoid sticky 424s. Also adds a 60s cooldown so long outages self-heal without recreating the pod; the happy path is unchanged.

- **Bug Fixes**
  - Wraps init in `runInitWithRetry` with backoff `[500, 1500, 5000, 15000, 30000]` ms (6 attempts, ~52s) and abort-aware sleep; logs each attempt.
  - Makes `ready` resolve-only: call `readyResolve` after `ensureGit` succeeds; never reject `ready`, so downstream consumers can recover after the cooldown.
  - Updates `ensureStarted` to clear cached `ok` after 60s when retries were exhausted, then re-run init on the next request. Renames `start` to `runInitSteps` (no behavior change).

<sup>Written for commit 29a64b18ad81295240fbe45d8eb515bad6836720. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup now automatically retries failed initialization attempts with a bounded retry loop and fixed backoff, plus a cooldown window before retrying again, improving recovery from transient startup failures without changing existing public behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->