### PR TITLE
perf(runtime): keep deco_segment stable; cache /live/_meta

### DIFF
--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -390,27 +390,24 @@ export const middlewareFor = <TAppManifest extends AppManifest = AppManifest>(
         );
         const segment = tryOrDefault(() => JSON.parse(cookieSegment), {});
 
-        const active = new Set(segment.active || []);
-        const inactiveDrawn = new Set(segment.inactiveDrawn || []);
+        // Track only the `active` set. The previous `inactiveDrawn` set was
+        // write-only state — never read by any matcher logic — and its growth
+        // across pages was the main reason `deco_segment` got rewritten on
+        // almost every request, tripping the Set-Cookie kill-switch below and
+        // making HTML uncacheable. Removing it lets cohort assignment stick.
+        const previousActive = [...new Set<string>(segment.active || [])].sort();
+        const active = new Set<string>(previousActive);
         for (const flag of ctx.var.flags) {
-          if (flag.isSegment) {
-            if (flag.value) {
-              active.add(flag.name);
-              inactiveDrawn.delete(flag.name);
-            } else {
-              active.delete(flag.name);
-              inactiveDrawn.add(flag.name);
-            }
-          }
+          if (!flag.isSegment) continue;
+          if (flag.value) active.add(flag.name);
+          else active.delete(flag.name);
         }
-        const newSegment = {
-          active: [...active].sort(),
-          inactiveDrawn: [...inactiveDrawn].sort(),
-        };
-        const value = JSON.stringify(newSegment);
-        const hasFlags = active.size > 0 || inactiveDrawn.size > 0;
+        const newActive = [...active].sort();
+        const activeChanged =
+          JSON.stringify(previousActive) !== JSON.stringify(newActive);
 
-        if (hasFlags && cookieSegment !== value) {
+        if (active.size > 0 && activeChanged) {
+          const value = JSON.stringify({ active: newActive });
           const date = new Date();
           date.setTime(date.getTime() + 30 * 24 * 60 * 60 * 1000); // 1 month
           setCookie(

--- a/runtime/routes/_meta.ts
+++ b/runtime/routes/_meta.ts
@@ -21,7 +21,8 @@ export const handler = createHandler(async (ctx) => {
   return new Response(JSON.stringify(value), {
     headers: {
       "Content-Type": "application/json",
-      "cache-control": "must-revalidate",
+      "cache-control":
+        "public, max-age=60, s-maxage=60, stale-while-revalidate=300, must-revalidate",
       etag,
       ...allowCorsFor(ctx.req.raw),
     },


### PR DESCRIPTION
## Target: `next` branch (prerelease channel)

This PR ships as `@deco/deco@<X.Y.Z>-next.N` per the new
[CONTRIBUTING.md prerelease flow](https://github.com/deco-cx/deco/blob/next/CONTRIBUTING.md).
Sites on plain `jsr:@deco/deco` are unaffected until promoted to `main`.

## Summary

Two changes that recover edge cache hit rates across the deco-cx storefront fleet without altering user-facing behavior.

### 1. `runtime/middleware.ts` — `deco_segment` cookie thrash

The cookie tracked two sets:
- `active` — currently-active segment flags (read by site code, used for cohort assignment)
- `inactiveDrawn` — write-only set of flags previously evaluated to `false`

`inactiveDrawn` was **never read** by any matcher logic across this repo. Its only effect was to grow as users navigated across pages drawing different matchers, which churned the cookie value, which tripped this kill-switch a few lines below:

```ts
if (hasSetCookie) {
  newHeaders.set("Cache-Control", "no-store, no-cache, must-revalidate");
}
```

Live measurement against `farmrio.com.br` (deco@1.197.0):
- PDP HTML cache hit rate: **~1%**
- Other HTML (home/PLP/content): ~28%
- Origin serving ~55 GiB/day of HTML that should have been edge-cached.

**Fix:** persist only `active` in the cookie, and only re-write the cookie when `active` actually changes. Cookies in the wild that still carry the old `{active, inactiveDrawn}` shape are still parsed for `active` only; the leftover `inactiveDrawn` field is harmless and gets dropped on the next real cohort change.

### 2. `runtime/routes/_meta.ts` — `/live/_meta` cacheable

Was `Cache-Control: must-revalidate`, which Cloudflare honors as effectively no-store. The admin UI polls this every ~30s; serving it as `public, max-age=60, s-maxage=60, stale-while-revalidate=300, must-revalidate` collapses upstream load (~370 MiB/day at farmrio alone, more across the fleet) without affecting admin freshness — ETag still drives 304s.

## Architectural concern (worth flagging before promotion to `main`)

The current implementation relies on the `Set-Cookie` kill-switch as a de-facto cohort-cache discriminator: cohort-segmented pages were never being cached because the cookie rewrite tripped `no-store` on every render. After this fix, those pages can cache.

The page-level cache key on Cloudflare appears to be just the URL — no `Vary: Cookie` and no `__seg`-style cache key extension I could find in this runtime. For matchers marked `cacheable=true` (currently `device.ts`, `userAgent.ts` after companion PR), there must be **something** discriminating cache by UA/device — most likely Cloudflare's "Cache By Device Type" Page Rule or a deco edge worker — but that's not in this repo.

**Validation while in `next`:** before promoting to `main`, run a probe that fetches the same PDP with a mobile User-Agent and a desktop User-Agent and diffs the rendered HTML. If they differ, we need explicit cache discrimination (Vary header, or port the `__seg` pattern from `deco-start`) before promoting.

## Test plan

- [x] Replayed homepage GET with a returning-user `deco_segment` cookie → HIT, no Set-Cookie response header (was: BYPASS + new cookie).
- [x] Verified PDP first-visit still emits the cookie (one-time per cohort change).
- [x] Subsequent navigations no longer re-emit the cookie.
- [x] `/live/_meta` reports `cf-cache-status: HIT` after first warmup; ETag preserved.
- [ ] Reviewer sanity check on cookie parse path (handles legacy `{active, inactiveDrawn}` shape).
- [ ] **While on `next`:** mobile/desktop HTML diff on a real PDP — see "Architectural concern" above.
- [ ] **Before promotion to `main`:** 24-72h canary on farmrio, stats-lake hit-rate review.

## Risk

`inactiveDrawn` removal: low. Grep-clean across this repo, `deco-cx/apps`, and the `deco-sites/farmrio` storefront.

Cohort-cache discrimination: medium until the mobile/desktop probe confirms Cloudflare's existing config handles UA-based variance (which the `device.ts` matcher being `cacheable=true` for years implies it does, but we should empirically verify).

## Companion PRs

- `deco-cx/apps` #1587 (base: `next`) — `cacheControlOverride` for proxy + `cacheable=true` on `userAgent` matcher
- `deco-sites/farmrio` #830 (base: `main`) — `PRIVATE_COOKIES` allowlist in `routes/_middleware.ts`