### PR TITLE
Add next-channel prerelease pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
                 generate_release_notes: true,
                 name: `Release ${tag}`,
                 owner: context.repo.owner,
-                prerelease: tag.includes("rc-") || tag.includes("preview") || tag.includes("beta") || tag.includes("alpha"),
+                prerelease: tag.includes("rc-") || tag.includes("preview") || tag.includes("beta") || tag.includes("alpha") || tag.includes("next"),
                 repo: context.repo.repo,
                 tag_name: tag,
               });

--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - next
 
 permissions:
   contents: write # Necessary for accessing and modifying repository content
@@ -15,7 +16,7 @@ permissions:
 
 jobs:
   tag-discussion:
-    if: github.event_name == 'pull_request_target' && github.event.action == 'opened'
+    if: github.event_name == 'pull_request_target' && github.event.action == 'opened' && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -55,8 +56,50 @@ jobs:
             - 🎉 for **Minor** ${{ steps.calculate_versions.outputs.minor_version }} update
             - 🚀 for **Major** ${{ steps.calculate_versions.outputs.major_version }} update
 
+  prerelease-tag-discussion:
+    if: github.event_name == 'pull_request_target' && github.event.action == 'opened' && github.event.pull_request.base.ref == 'next'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          repository: ${{ github.event.pull_request.base.repo.full_name }}
+
+      - name: Calculate prerelease bases
+        id: calculate_versions
+        run: |
+          git fetch --tags
+          LATEST_TAG=$(git tag --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="0.0.0"
+          fi
+          MAJOR=$(echo $LATEST_TAG | cut -d. -f1)
+          MINOR=$(echo $LATEST_TAG | cut -d. -f2)
+          PATCH=$(echo $LATEST_TAG | cut -d. -f3)
+          echo "patch_base=$MAJOR.$MINOR.$((PATCH + 1))" >> $GITHUB_OUTPUT
+          echo "minor_base=$MAJOR.$((MINOR + 1)).0" >> $GITHUB_OUTPUT
+          echo "major_base=$((MAJOR + 1)).0.0" >> $GITHUB_OUTPUT
+
+      - name: Start Discussion for Prerelease Tagging
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## Prerelease Tagging
+            Merging this PR will publish a prerelease automatically.
+            By default this is a **Patch prerelease** (`${{ steps.calculate_versions.outputs.patch_base }}-next.N`).
+            A maintainer can override the bump by reacting:
+            - 👍 **Patch prerelease** `${{ steps.calculate_versions.outputs.patch_base }}-next.N` (default)
+            - 🎉 **Minor prerelease** `${{ steps.calculate_versions.outputs.minor_base }}-next.N`
+            - 🚀 **Major prerelease** `${{ steps.calculate_versions.outputs.major_base }}-next.N`
+
+            `.N` auto-increments per base. Consumers opt in via the explicit version
+            (e.g. `jsr:@deco/deco@${{ steps.calculate_versions.outputs.patch_base }}-next.1`); `jsr:@deco/deco` continues to resolve to the stable channel.
+
   determine-tag:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -187,3 +230,146 @@ jobs:
               -H "Accept: application/vnd.github.everest-preview+json" \
               https://api.github.com/repos/${{ github.repository }}/actions/workflows/publish-ai.yaml/dispatches \
               -d '{"ref":"main", "inputs":{"tag_name":"${{ steps.determine_version.outputs.new_version }}"}}'
+
+  determine-prerelease-tag:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/next'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          ref: next
+
+      - name: Find the Merged Pull Request
+        id: find_pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BASE_BRANCH="next"
+          RECENT_PR=$(gh pr list --state closed --base $BASE_BRANCH --json number,title,closedAt --jq '.[] | select(.closedAt >= "'$(date -u -d '1 minute ago' +%Y-%m-%dT%H:%M:%SZ)'") | {number, title}')
+          echo "RECENT_PR=$RECENT_PR" >> $GITHUB_ENV
+          echo "PR_NUMBER=$(echo $RECENT_PR | jq -r '.number')" >> $GITHUB_ENV
+
+      - name: Fetch latest stable tag (excluding prerelease tags)
+        id: get_latest_tag
+        run: |
+          git fetch --tags
+          LATEST_TAG=$(git tag --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="0.0.0"
+          fi
+          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+
+      - name: Determine the next prerelease version
+        id: determine_version
+        if: env.PR_NUMBER != ''
+        env:
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LATEST_TAG=${{ steps.get_latest_tag.outputs.latest_tag }}
+          MAJOR=$(echo $LATEST_TAG | cut -d. -f1)
+          MINOR=$(echo $LATEST_TAG | cut -d. -f2)
+          PATCH=$(echo $LATEST_TAG | cut -d. -f3)
+
+          # Define allowed users as a JSON array
+          ALLOWED_USERS=$(cat MAINTAINERS.txt | jq -R -s -c 'split("\n")[:-1]')
+          echo "Maintainers list: $ALLOWED_USERS"
+
+          # Fetch reactions on the prerelease tagging comment and filter by allowed users
+          REACTION=$(gh api graphql -f query='
+            query {
+              repository(owner:"${{ github.repository_owner }}", name:"${{ github.event.repository.name }}") {
+                pullRequest(number: '${PR_NUMBER}') {
+                  comments(last: 100) {
+                    nodes {
+                      body
+                      id
+                      reactions(last: 100) {
+                        nodes {
+                          content
+                          user {
+                            login
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' | jq -r --argjson allowed_users "$ALLOWED_USERS" '
+              .data.repository.pullRequest.comments.nodes[] |
+              select(.body | contains("## Prerelease Tagging")) |
+              .reactions.nodes[] |
+              select(.user.login | IN($allowed_users[])) |
+              .content'
+          )
+
+          echo "Captured reaction: $REACTION"
+          REACTION=$(echo "$REACTION" | tr '[:lower:]' '[:upper:]')
+
+          # Determine base version: 🚀 major, 🎉 minor, anything else (incl. 👍 or no reaction) -> patch.
+          # Unlike the stable flow, no-reaction defaults to PATCH instead of skipping the release.
+          if [[ "$REACTION" == *"ROCKET"* ]]; then
+            BASE="$((MAJOR + 1)).0.0"
+          elif [[ "$REACTION" == *"HOORAY"* ]]; then
+            BASE="$MAJOR.$((MINOR + 1)).0"
+          else
+            BASE="$MAJOR.$MINOR.$((PATCH + 1))"
+          fi
+
+          # Compute next N for this base (highest existing <BASE>-next.<N> + 1, else 1)
+          LATEST_N=$(git tag --list "${BASE}-next.*" | awk -F'-next.' 'NF==2 {print $2}' | grep -E '^[0-9]+$' | sort -n | tail -n 1)
+          if [ -z "$LATEST_N" ]; then
+            N=1
+          else
+            N=$((LATEST_N + 1))
+          fi
+
+          NEW_VERSION="${BASE}-next.${N}"
+          echo "Computed prerelease version: $NEW_VERSION"
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update deno.json Version
+        if: steps.determine_version.outputs.new_version != ''
+        run: |
+          jq --arg new_version "${{ steps.determine_version.outputs.new_version }}" '.version = $new_version' deno.json > tmp.$$.json && mv tmp.$$.json deno.json
+          jq --arg new_version "${{ steps.determine_version.outputs.new_version }}" '.version = $new_version' ./scripts/deno.json > tmp.$$.json && mv tmp.$$.json ./scripts/deno.json
+          jq --arg new_version "${{ steps.determine_version.outputs.new_version }}" '.version = $new_version' ./dev/deno.json > tmp.$$.json && mv tmp.$$.json ./dev/deno.json
+
+
+          git config user.name "decobot"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add deno.json ./scripts/deno.json ./dev/deno.json
+          git commit -m "Update version to ${{ steps.determine_version.outputs.new_version }}"
+          git push origin next
+
+      - name: Create and Push Tag
+        if: steps.determine_version.outputs.new_version != ''
+        run: |
+          git tag ${{ steps.determine_version.outputs.new_version }}
+          git push origin ${{ steps.determine_version.outputs.new_version }}
+      - name: Trigger Release Workflow
+        if: steps.determine_version.outputs.new_version != ''
+        run: |
+          curl -X POST \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.github.everest-preview+json" \
+              https://api.github.com/repos/${{ github.repository }}/actions/workflows/release.yaml/dispatches \
+              -d '{"ref":"next", "inputs":{"tag_name":"${{ steps.determine_version.outputs.new_version }}"}}'
+      - name: Trigger Publish Workflow
+        if: steps.determine_version.outputs.new_version != ''
+        run: |
+          curl -X POST \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.github.everest-preview+json" \
+              https://api.github.com/repos/${{ github.repository }}/actions/workflows/publish.yaml/dispatches \
+              -d '{"ref":"next", "inputs":{"tag_name":"${{ steps.determine_version.outputs.new_version }}"}}'
+      - name: Trigger Publish AI Workflow
+        if: steps.determine_version.outputs.new_version != ''
+        run: |
+          curl -X POST \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.github.everest-preview+json" \
+              https://api.github.com/repos/${{ github.repository }}/actions/workflows/publish-ai.yaml/dispatches \
+              -d '{"ref":"next", "inputs":{"tag_name":"${{ steps.determine_version.outputs.new_version }}"}}'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing to `@deco/deco`
+
+## Release channels
+
+This repository ships on two channels:
+
+| Channel | Branch | Example version | JSR resolution |
+|---------|--------|-----------------|----------------|
+| Stable  | `main` | `1.198.0`       | `jsr:@deco/deco` resolves here |
+| Prerelease | `next` | `1.198.0-next.3` | Opt-in only — must reference explicit version |
+
+Both channels publish all three packages (`@deco/deco`, `@deco/scripts`, `@deco/dev`) together to JSR, plus Docker images on `ghcr.io/deco-cx/deco` (and `…/deno2`, `…/ai`, `…/deno2-ai`). Prerelease tags **do not** move the Docker `:latest` tag.
+
+### Targeting `main` (stable)
+
+1. Open a PR with `main` as the base.
+2. A bot comments with **Patch / Minor / Major** options.
+3. A maintainer (listed in `MAINTAINERS.txt`) reacts with 👍 / 🎉 / 🚀.
+4. Merge the PR. The `Release Tagging` workflow bumps the version in the three `deno.json` files, tags the commit, and dispatches the publish workflows.
+5. **No reaction = no release.**
+
+### Targeting `next` (prerelease)
+
+1. Open a PR with `next` as the base.
+2. A bot comments with **Prerelease Tagging** info.
+3. Merge the PR. The `Release Tagging` workflow:
+   - Defaults to a **patch** prerelease (`<latest-stable-patch+1>-next.<N>`).
+   - A maintainer reaction overrides the base: 👍 patch / 🎉 minor / 🚀 major.
+   - `N` auto-increments from the highest existing `<base>-next.*` tag (or `1` if none).
+4. **Every merge to `next` publishes a prerelease** — there is no "no release" path.
+
+### Consuming a prerelease
+
+JSR has no dist-tags (unlike npm's `@next`), so consumers opt in explicitly:
+
+```jsonc
+// deno.json
+{
+  "imports": {
+    "@deco/deco": "jsr:@deco/deco@1.198.0-next.3"
+  }
+}
+```
+
+Plain `jsr:@deco/deco` (no version specifier) continues to resolve to the latest stable release.
+
+### Promoting `next` → `main`
+
+When a prerelease cycle is ready to ship:
+
+1. Open a PR from `next` into `main`.
+2. The bot comments with stable bump options.
+3. A maintainer reacts with the appropriate emoji.
+4. Merge. The stable `determine-tag` job publishes (e.g., `1.198.0`).
+
+## Branch protection (one-time setup)
+
+`next` must be protected to match `main`: require PR review, status checks, no force-push, no direct push. This requires repo-admin privileges and is configured via the GitHub UI / API, not via this repo.
+
+## Manual release (local fallback)
+
+`scripts/release.ts` exists for local-driven stable releases when the CI flow is unavailable. It does not handle prereleases — use the `next` branch for those.


### PR DESCRIPTION
## Summary

Adds a `next` release channel modeled on `@decocms/deco-start`, adapted to this repo's Deno/JSR + emoji-reaction toolchain.

- **Auto on merge to `next`**: publishes a prerelease `X.Y.Z-next.N` to JSR (all three packages) + GHCR (without moving `:latest`).
- **Default bump**: patch. A maintainer can override via 👍 / 🎉 / 🚀 reaction on the bot comment.
- **Counter `N`**: auto-increments per base across existing `<base>-next.*` tags.
- **No new infra**: leverages the existing prerelease-aware `publish.yaml` (already skips `:latest` when tag contains `-`) and `publish-ai.yaml`. Only `release.yaml` needed one extra keyword (`next`) in its GitHub-Release prerelease detector.
- **Stable pipeline untouched**: `tag-discussion` and `determine-tag` jobs now gated on `base.ref == 'main'` / `github.ref == 'refs/heads/main'` respectively — no behavior change since main is the only target today.
- **Docs**: new `CONTRIBUTING.md` covers both channels, JSR opt-in (`jsr:@deco/deco@1.198.0-next.3`), and the `next`-branch protection reminder.

## Why not semantic-release like deco-start?

deco-start is npm/Bun and uses conventional commits. This repo is Deno/JSR with three `deno.json` files and an emoji-reaction model. The new flow preserves the existing UX (same emoji palette, same `MAINTAINERS.txt` gate) while delivering the same two-channel outcome.

## Test plan

- [x] YAML syntax (`yaml.safe_load`) passes for both workflows
- [x] `actionlint` reports no new issues (pre-existing v3-checkout/shellcheck info notes only)
- [x] Version-computation logic smoke-tested against synthetic tags: correct N selection (10 > 3 numerically), prerelease tags excluded from stable-tag detection, `-beta` doesn't contaminate `-next.*` counting
- [ ] Post-merge: confirm stable flow still works (open a no-op PR against `main`, verify the bot comment appears as before)
- [ ] Post-merge: create `next` branch from updated `main` (`gh api -X POST repos/deco-cx/deco/git/refs -f ref='refs/heads/next' -f sha=…`) and add branch protection
- [ ] E2E prerelease: open a trivial PR against `next`, merge, verify `X.Y.Z-next.1` tag, JSR publish, GHCR `:X.Y.Z-next.1` image (without `:latest`), and GitHub Release marked Pre-release
- [ ] E2E promotion: open `next` → `main` PR, react 👍, merge, verify stable `X.Y.Z` tag and `:latest` published

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `next` prerelease channel that auto-publishes `X.Y.Z-next.N` to JSR and GHCR on merges to `next`, without touching the stable channel. Default bump is patch; maintainers can pick minor/major via reactions.

- **New Features**
  - Auto-publish on `next` merges to JSR for `@deco/deco`, `@deco/scripts`, `@deco/dev`, plus GHCR images; `:latest` is not moved.
  - Default bump is patch; override with 👍 (patch) / 🎉 (minor) / 🚀 (major) on the bot comment by a maintainer.
  - `N` auto-increments per base; prerelease tags don’t affect stable tag detection.
  - Stable flow unchanged: `tag-discussion` and `determine-tag` run only on `main`; a dedicated prerelease flow runs on `next`.
  - `release.yaml` now marks `next` tags as prereleases; docs added in `CONTRIBUTING.md`, including JSR opt-in (`jsr:@deco/deco@1.198.0-next.3`).

- **Migration**
  - Create and protect the `next` branch the same as `main`.
  - Consumers must pin explicit prerelease versions, e.g. `jsr:@deco/deco@1.198.0-next.3`.

<sup>Written for commit 845d985505b7196adae362477154e02c39cafa13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the release process, including stable and prerelease version channels.

* **Chores**
  * Enhanced release automation to support prerelease version management and multi-branch workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/deco/pull/1187)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->