### PR TITLE
[WIP] - feat(render): add ?format=json branch with serializeResolvedSection

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -45,6 +45,16 @@ export { type DecoRouteState } from "./runtime/middleware.ts";
 export * from "./runtime/mod.ts";
 export { Deco } from "./runtime/mod.ts";
 export type { PageData } from "./runtime/mod.ts";
+export {
+  buildLazyUrl,
+  serializeResolvedSection,
+} from "./runtime/routes/serialize-section.ts";
+export type {
+  LazyUrlContext,
+  ResolvedSection,
+  SerializedSection,
+} from "./runtime/routes/serialize-section.ts";
+export { Murmurhash3 } from "./deps.ts";
 export * from "./types.ts";
 export { allowCorsFor } from "./utils/http.ts";
 export type { StreamProps } from "./utils/invoke.ts";

--- a/runtime/routes/render.tsx
+++ b/runtime/routes/render.tsx
@@ -8,6 +8,11 @@ import { singleFlight } from "../../utils/mod.ts";
 import { createHandler, DEBUG_QS } from "../middleware.ts";
 import type { PageParams } from "../mod.ts";
 import Render, { type PageData } from "./entrypoint.tsx";
+import {
+  type LazyUrlContext,
+  type ResolvedSection,
+  serializeResolvedSection,
+} from "./serialize-section.ts";
 
 interface Options {
   resolveChain?: FieldResolver[];
@@ -91,6 +96,29 @@ export const handler = createHandler(async (
   if (isDebugRequest) {
     return Response.json({ debugData: state.vary.debug.build() });
   }
+
+  if (opts.searchParams.get("format") === "json") {
+    const lazyCtx: LazyUrlContext = {
+      href: opts.href,
+      pathTemplate: opts.pathTemplate,
+      renderSalt: opts.renderSalt,
+      cb: opts.searchParams.get("__cb") ?? undefined,
+    };
+    const serialized = serializeResolvedSection(
+      page as ResolvedSection,
+      lazyCtx,
+    );
+    const jsonResponse = Response.json(serialized);
+    const shouldCacheFromVary = ctx?.var?.vary?.shouldCache === true;
+    jsonResponse.headers.set(
+      "cache-control",
+      shouldCache && shouldCacheFromVary
+        ? DECO_RENDER_CACHE_CONTROL
+        : "no-store, no-cache, must-revalidate",
+    );
+    return jsonResponse;
+  }
+
   const props = {
     params: ctx.req.param(),
     url: ctx.var.url,

--- a/runtime/routes/serialize-section.ts
+++ b/runtime/routes/serialize-section.ts
@@ -1,0 +1,110 @@
+import { FieldResolver } from "../../engine/core/resolver.ts";
+
+const LAZY_SECTION_PATH = "/Rendering/Lazy.tsx";
+
+export interface ResolvedSection {
+  Component?: unknown;
+  props?: Record<string, unknown>;
+  metadata?: {
+    component?: string;
+    resolveChain?: FieldResolver[];
+  };
+}
+
+export type SerializedSection =
+  | { component: string; props: Record<string, unknown> }
+  | { component: string; lazyUrl: string };
+
+export interface LazyUrlContext {
+  href: string;
+  pathTemplate: string;
+  renderSalt?: string;
+  cb?: string;
+}
+
+export function buildLazyUrl(
+  resolveChain: FieldResolver[],
+  ctx: LazyUrlContext,
+): string {
+  const params = new URLSearchParams([
+    ["format", "json"],
+    ["props", JSON.stringify({ loading: "eager" })],
+    ["href", ctx.href],
+    ["pathTemplate", ctx.pathTemplate],
+    [
+      "resolveChain",
+      JSON.stringify(FieldResolver.minify(resolveChain.slice(0, -1))),
+    ],
+  ]);
+  if (ctx.renderSalt) params.set("renderSalt", ctx.renderSalt);
+  if (ctx.cb) params.set("__cb", ctx.cb);
+  return `/deco/render?${params}`;
+}
+
+function isSectionShape(value: unknown): value is ResolvedSection {
+  if (!value || typeof value !== "object") return false;
+  const meta = (value as ResolvedSection).metadata;
+  return typeof meta?.component === "string";
+}
+
+function isLazyComponent(component: string | undefined): boolean {
+  return !!component?.endsWith(LAZY_SECTION_PATH);
+}
+
+function getInnerSection(node: ResolvedSection): ResolvedSection | undefined {
+  const inner = (node.props as { section?: unknown } | undefined)?.section;
+  return isSectionShape(inner) ? inner : undefined;
+}
+
+function getLoading(node: ResolvedSection): string | undefined {
+  return (node.props as { loading?: string } | undefined)?.loading;
+}
+
+export function serializeResolvedSection(
+  node: ResolvedSection,
+  ctx: LazyUrlContext,
+): SerializedSection {
+  let current = node;
+  while (
+    isLazyComponent(current.metadata?.component) &&
+    getLoading(current) === "eager"
+  ) {
+    const inner = getInnerSection(current);
+    if (!inner) break;
+    current = inner;
+  }
+
+  if (
+    isLazyComponent(current.metadata?.component) &&
+    getLoading(current) === "lazy"
+  ) {
+    const inner = getInnerSection(current);
+    return {
+      component: inner?.metadata?.component ?? current.metadata!.component!,
+      lazyUrl: buildLazyUrl(current.metadata!.resolveChain ?? [], ctx),
+    };
+  }
+
+  return {
+    component: current.metadata!.component!,
+    props: walkValue(current.props ?? {}, ctx) as Record<string, unknown>,
+  };
+}
+
+function walkValue(value: unknown, ctx: LazyUrlContext): unknown {
+  if (Array.isArray(value)) {
+    return value.map((v) => walkValue(v, ctx));
+  }
+  if (value && typeof value === "object") {
+    if (isSectionShape(value)) {
+      return serializeResolvedSection(value, ctx);
+    }
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (k === "Component" && typeof v === "function") continue;
+      out[k] = walkValue(v, ctx);
+    }
+    return out;
+  }
+  return value;
+}


### PR DESCRIPTION
New helper serializeResolvedSection turns the resolved page tree into a JSON-safe shape: strips Component functions, unwraps eager-resolved Lazy wrappers, and emits {component, lazyUrl} placeholders for deferred Lazies. Recursive walk covers Sections nested inside arbitrary props.

The /deco/render handler branches on ?format=json before the HTML render path, returning Response.json(serialized) with the same cache-control treatment. Single-flight is intentionally not added on the JSON path (serialization is cheap).

Companion to ADR-0001 in oficina-reserva (mobile-app appJson lazy support).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a JSON render path to `/deco/render` via `?format=json`, returning a JSON-safe section tree with proper lazy placeholders. This lets clients consume page structure without HTML.

- **New Features**
  - `?format=json` branch returns `Response.json(...)` with the same cache-control as HTML; single-flight is skipped.
  - `serializeResolvedSection` recursively removes function refs, unwraps `Lazy` with `loading: "eager"`, and outputs `{ component, lazyUrl }` for `loading: "lazy"`.
  - `buildLazyUrl` constructs deferred fetch URLs using `href`, `pathTemplate`, `renderSalt`, and `__cb`.
  - Exports: `serializeResolvedSection`, `buildLazyUrl`, `ResolvedSection`, `SerializedSection`, `LazyUrlContext`, and `Murmurhash3`.

<sup>Written for commit e2bcd43ea549e9069d668f0b8c4486a1b1b2dcec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added JSON response format support for page requests, enabling structured data access via query parameter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/deco/pull/1188)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->