### PR TITLE
test: e2e prerelease pipeline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Release channels
 
-This repository ships on two channels:
+This repository publishes on two channels:
 
 | Channel | Branch | Example version | JSR resolution |
 |---------|--------|-----------------|----------------|


### PR DESCRIPTION
## Summary

Trivial wording tweak to exercise the new `next`-channel prerelease pipeline end-to-end.

Expected on merge:
- Bot posts a **## Prerelease Tagging** comment (this is the discovery test).
- `determine-prerelease-tag` job auto-bumps to `1.197.1-next.1` (default patch, no reaction needed).
- JSR publishes `@deco/deco@1.197.1-next.1` (and `scripts`, `dev` siblings).
- GHCR builds `ghcr.io/deco-cx/deco:1.197.1-next.1` (without touching `:latest`).
- GitHub Release marked as Pre-release.

Will be followed by a promotion PR (`next` → `main`) to test the stable side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Minor wording change in `CONTRIBUTING.md` to trigger the new `next` prerelease pipeline end-to-end. Validates auto-bump to 1.197.1-next.1, JSR publish of `@deco/deco@1.197.1-next.1` (and siblings), GHCR image `ghcr.io/deco-cx/deco:1.197.1-next.1`, and marking a GitHub pre-release.

<sup>Written for commit 5c2e46fbad5b1fefb0a737a010114dfbaeb8c885. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

