### PR TITLE
release: promote 1.197.1-next.1 to stable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Release channels
 
-This repository ships on two channels:
+This repository publishes on two channels:
 
 | Channel | Branch | Example version | JSR resolution |
 |---------|--------|-----------------|----------------|

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@deco/deco",
-  "version": "1.197.0",
+  "version": "1.197.1-next.1",
   "lock": false,
   "nodeModulesDir": "auto",
   "exports": {

--- a/dev/deno.json
+++ b/dev/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@deco/dev",
-  "version": "1.197.0",
+  "version": "1.197.1-next.1",
   "exports": {
     "./tailwind": "./tailwind.ts"
   },

--- a/scripts/deno.json
+++ b/scripts/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@deco/scripts",
-  "version": "1.197.0",
+  "version": "1.197.1-next.1",
   "exports": {
     "./release": "./release.ts",
     "./update": "./update.run.ts",


### PR DESCRIPTION
## Summary

Promotion PR from `next` to `main` — second half of the e2e test for the new prerelease pipeline (PR #1187).

Bundles two commits from `next`:
- `5c2e46fb` — CONTRIBUTING wording tweak (the trigger PR, #1189)
- `83d84edf` — auto-generated "Update version to 1.197.1-next.1"

The stable `determine-tag` job will overwrite the `-next.1` version with whatever the maintainer-reaction bump produces (defaults to **patch → 1.197.1** if 👍).

### Expected on merge with 👍 from a maintainer

- New tag `1.197.1` (stable).
- All three `deno.json` files bumped from `1.197.1-next.1` to `1.197.1`.
- JSR `latest` advances from `1.197.0` to `1.197.1`.
- GHCR `:latest` moves to `1.197.1`.
- GitHub Release created — NOT marked Pre-release.

### Maintainer action required

A maintainer listed in `MAINTAINERS.txt` (mcandeia, tlgimenes, hugo-ccabral, guitavano, aka-sacci-ccr, pedrofrxncx, igoramf, nicacioliveira) must react **👍** on the bot's "Tagging Options" comment, then merge. Without a maintainer reaction the workflow exits cleanly without bumping (verified safely on PR #1187).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes 1.197.1-next.1 to stable via the prerelease pipeline. Includes a small wording tweak in CONTRIBUTING and prepares version updates for `@deco/deco`, `@deco/dev`, and `@deco/scripts`.

- **On merge**
  - Tags `1.197.1` (stable).
  - Bumps all three `deno.json` files from `1.197.1-next.1` to `1.197.1`.
  - Advances JSR `latest` and GHCR `:latest` to `1.197.1`.
  - Creates a GitHub Release (not a pre-release).

- **Maintainer action required**
  - React 👍 on the bot’s “Tagging Options” comment, then merge.

<sup>Written for commit 83d84edf7e71fce094cf14422b605b478e6673df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines wording

* **Chores**
  * Bumped package version to 1.197.1-next.1

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/deco/pull/1190)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->