### PR TITLE
feat(runtime): immutable Cache-Control on /deco/render when __cb is set

### DIFF
--- a/runtime/routes/render.tsx
+++ b/runtime/routes/render.tsx
@@ -75,6 +75,15 @@ const fromRequest = (req: Request): Options => {
 const DECO_RENDER_CACHE_CONTROL = Deno.env.get("DECO_RENDER_CACHE_CONTROL") ||
   "public, max-age=60, s-maxage=60, stale-while-revalidate=3600, stale-if-error=86400";
 
+// When the request carries a __cb (content-bust) query param, the response is
+// fully content-addressed: __cb is a Murmurhash3 of revisionId|vary|stableHref
+// |deploymentId (see hooks/useSection.ts), so a new deploy or vary change
+// produces a new __cb by construction. Treat these responses as immutable so
+// CDNs cache them aggressively and stop re-validating against origin.
+const DECO_RENDER_CACHE_CONTROL_IMMUTABLE =
+  Deno.env.get("DECO_RENDER_CACHE_CONTROL_IMMUTABLE") ||
+  "public, max-age=31536000, s-maxage=31536000, immutable, stale-if-error=86400";
+
 const AsyncRenderSF = singleFlight<Response>();
 const SHOULD_USE_ASYNC_RENDER_SINGLE_FLIGHT =
   Deno.env.get("SHOULD_USE_ASYNC_RENDER_SINGLE_FLIGHT") === "true";
@@ -120,11 +129,15 @@ export const handler = createHandler(async (
   // ideally cachebust should be calculated per section as well so that you can reuse section across pages and produce same cacheBusts.
   const shouldCacheFromVary = ctx?.var?.vary?.shouldCache === true;
   if (shouldCache && shouldCacheFromVary) {
-    // Stale cache on CDN, but make the browser fetch every single time.
-    // We can test if caching on the browser helps too.
+    // When __cb (content-bust) is present, the response is content-addressed
+    // and may be cached effectively forever. Without __cb, fall back to the
+    // short-TTL default so any handler that bypassed useSection still works.
+    const hasContentHash = opts.searchParams.has("__cb");
     response.headers.set(
       "cache-control",
-      DECO_RENDER_CACHE_CONTROL,
+      hasContentHash
+        ? DECO_RENDER_CACHE_CONTROL_IMMUTABLE
+        : DECO_RENDER_CACHE_CONTROL,
     );
   } else {
     response.headers.set(


### PR DESCRIPTION
## Summary

Treat `/deco/render` responses as immutable when the request carries the `__cb` (content-bust) query param. `__cb` is already a Murmurhash3 of `revisionId | vary | stableHref | deploymentId` (`hooks/useSection.ts`), so the response is fully content-addressed — a deploy or vary change yields a new `__cb` by construction.

Today `/deco/render` returns `max-age=60, s-maxage=60` for every partial, regardless of `__cb` presence. Production CDN data on `lojastorra.com.br` showed **33%-92% expired or miss rates** on these requests across major pages, with tens of thousands of distinct `__cb` values all expiring every 60s.

This PR introduces a new `DECO_RENDER_CACHE_CONTROL_IMMUTABLE` env var (default `public, max-age=31536000, s-maxage=31536000, immutable, stale-if-error=86400`) applied when `__cb` is present. Requests without `__cb` keep the existing short TTL.

## Risk and mitigation

- If `__cb` ever collides or is computed incorrectly, stale content could be served for up to a year per key.
- `deploymentId` is part of the hash input (`hooks/useSection.ts:93`), so any redeploy invalidates all keys for the affected site.
- Murmurhash3 collision risk over the working set of a single site is negligible.
- The env var lets operators roll back without redeploying.

## Roll-out

1. Merge. Default is on (`immutable`).
2. Operators who want to A/B can set `DECO_RENDER_CACHE_CONTROL_IMMUTABLE=public, max-age=60, s-maxage=60, ...` to keep the old behavior per-environment.

## Test plan

- [ ] Run existing test suite: `deno task test`
- [ ] Local smoke: hit `/deco/render?__cb=x&...` → response has `Cache-Control: public, max-age=31536000, immutable, ...`
- [ ] Hit `/deco/render` without `__cb` → falls back to 60s default (should be uncommon; useSection always sets `__cb`)
- [ ] Set `DECO_RENDER_CACHE_CONTROL_IMMUTABLE="public, max-age=120"` → response uses the override

## Related

Pairs with the `BLOCKED_QS` prefix-matching PR (utm_*, gad_*, dgen_* stripping in `createStableHref`) — both reduce origin load for sites with heavy ad traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `/deco/render` responses immutable when the `__cb` param is present to enable long-lived CDN caching and reduce origin load. Requests without `__cb` still use the 60s TTL.

- **New Features**
  - Apply `DECO_RENDER_CACHE_CONTROL_IMMUTABLE` when `__cb` exists (default: `public, max-age=31536000, s-maxage=31536000, immutable, stale-if-error=86400`).
  - Keep `DECO_RENDER_CACHE_CONTROL` for requests without `__cb`; operators can override or roll back by setting `DECO_RENDER_CACHE_CONTROL_IMMUTABLE`.

<sup>Written for commit 3f8f455c6df0a4c9b9708ef36f8633d49eb746ba. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/deco/pull/1193?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced cache control configuration to optimize content delivery performance for specific request patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/deco/pull/1193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->