### PR TITLE
feat(hooks): prefix-match BLOCKED_QS and add ad-network params

### DIFF
--- a/hooks/useSection.ts
+++ b/hooks/useSection.ts
@@ -7,8 +7,10 @@ import { Murmurhash3 } from "../deps.ts";
 
 const hasher = new Murmurhash3();
 
-// List from cloudflare APO https://developers.cloudflare.com/automatic-platform-optimization/reference/query-parameters
-/** List of querystring that should not vary cache */
+// Seed list adapted from Cloudflare APO
+// (https://developers.cloudflare.com/automatic-platform-optimization/reference/query-parameters),
+// extended with ad-network families seen in production traffic on commerce sites.
+/** Exact-match querystring names that should not vary cache. */
 const BLOCKED_QS = new Set<string>([
   "ref",
   "fbclid",
@@ -19,7 +21,11 @@ const BLOCKED_QS = new Set<string>([
   "mc_eid",
   "gclid",
   "dclid",
+  "msclkid",
+  "ttclid",
+  "yclid",
   "_ga",
+  "_gl",
   "campaignid",
   "adgroupid",
   "_ke",
@@ -32,10 +38,32 @@ const BLOCKED_QS = new Set<string>([
   "ck_subscriber_id",
 ]);
 
+/**
+ * Prefix-matched querystring names that should not vary cache. Used for
+ * families where individual params are open-ended (e.g. utm_source, utm_medium,
+ * utm_id, utm_campaign, utm_content, utm_term — enumerating every variant is
+ * impractical, and ad platforms keep inventing new ones).
+ */
+const BLOCKED_QS_PREFIXES: string[] = [
+  "utm_",
+  "gad_",
+  "dgen_",
+  "_hsenc",
+  "_hsmi",
+];
+
 const ALLOWED_QS = new Set<string>();
 
 export const addBlockedQS = (queryStrings: string[]): void => {
   queryStrings.forEach((qs) => BLOCKED_QS.add(qs));
+};
+
+export const addBlockedQSPrefix = (prefixes: string[]): void => {
+  for (const p of prefixes) {
+    if (!BLOCKED_QS_PREFIXES.includes(p)) {
+      BLOCKED_QS_PREFIXES.push(p);
+    }
+  }
 };
 
 export const addAllowedQS = (queryStrings: string[]): void => {
@@ -50,7 +78,8 @@ const createStableHref = (href: string): string => {
   qsList.forEach((qsName: string) => {
     const shouldRemove = ALLOWED_QS.size > 0
       ? !ALLOWED_QS.has(qsName)
-      : BLOCKED_QS.has(qsName);
+      : (BLOCKED_QS.has(qsName) ||
+        BLOCKED_QS_PREFIXES.some((prefix) => qsName.startsWith(prefix)));
 
     if (shouldRemove) {
       hrefUrl.searchParams.delete(qsName);

--- a/hooks/useSection.ts
+++ b/hooks/useSection.ts
@@ -36,6 +36,8 @@ const BLOCKED_QS = new Set<string>([
   "mkt_tok",
   "epik",
   "ck_subscriber_id",
+  "_hsenc",
+  "_hsmi",
 ]);
 
 /**
@@ -48,8 +50,6 @@ const BLOCKED_QS_PREFIXES: string[] = [
   "utm_",
   "gad_",
   "dgen_",
-  "_hsenc",
-  "_hsmi",
 ];
 
 const ALLOWED_QS = new Set<string>();
@@ -60,6 +60,10 @@ export const addBlockedQS = (queryStrings: string[]): void => {
 
 export const addBlockedQSPrefix = (prefixes: string[]): void => {
   for (const p of prefixes) {
+    // Empty prefix would make startsWith("") match every param, silently
+    // stripping the entire querystring. Skip without throwing so a single bad
+    // entry doesn't break the caller.
+    if (!p) continue;
     if (!BLOCKED_QS_PREFIXES.includes(p)) {
       BLOCKED_QS_PREFIXES.push(p);
     }


### PR DESCRIPTION
## Summary

`createStableHref` (`hooks/useSection.ts`) strips known tracking params before computing `__cb` and the `href=` query of `/deco/render` partials, so that ad-click variants resolve to one shared cache entry. The exact-match `BLOCKED_QS` set misses two huge families:

- **`utm_*`** — `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, `utm_id`, plus arbitrary custom `utm_*` keys marketing teams invent.
- **`gad_*` / `dgen_*`** — Google Ads / DemandGen open-ended names (`gad_campaignid`, `gad_source`, `dgen_g_id`).

Enumerating every variant is brittle. This PR introduces prefix matching.

## Changes

- New `BLOCKED_QS_PREFIXES = ["utm_", "gad_", "dgen_", "_hsenc", "_hsmi"]`.
- `createStableHref` now matches against both `BLOCKED_QS` (exact) and `BLOCKED_QS_PREFIXES` (`startsWith`).
- New `addBlockedQSPrefix(prefixes)` export so apps can extend.
- Added `msclkid` (Bing), `ttclid` (TikTok), `yclid` (Yandex), `_gl` (GA4 cross-domain linker) to the exact set.

## Why it matters

CDN data on `lojastorra.com.br`: `/dia-dos-namorados` produced **11,351 distinct `__cb` values in 3 hours** because the Facebook `utm_id` was changing per impression and feeding the hash. After this lands, `__cb` collapses to one value per real vary input.

## Test plan

- [ ] `deno task test` passes
- [ ] Manual: `createStableHref("https://x/page?utm_source=a&utm_id=b&gad_source=c&legit=d")` returns `https://x/page?legit=d`
- [ ] Manual: `createStableHref("https://x/page?msclkid=a&legit=b")` returns `https://x/page?legit=b`
- [ ] Manual: `createStableHref("https://x/page?legit=a")` is unchanged

## Related

Pairs with #1193 (immutable Cache-Control on `/deco/render` when `__cb` is set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add prefix-based filtering of tracking query params in `createStableHref` to reduce cache fragmentation and collapse `__cb` across ad-click variants. Uses `utm_`, `gad_`, and `dgen_` families, adds new exact matches, and tightens HubSpot handling and extension safety.

- **New Features**
  - Added `BLOCKED_QS_PREFIXES`: `utm_`, `gad_`, `dgen_`.
  - `createStableHref` now filters by exact names and prefixes.
  - Exported `addBlockedQSPrefix(prefixes)` for app-level extension.
  - Added exact blocked params: `msclkid`, `ttclid`, `yclid`, `_gl`.

- **Bug Fixes**
  - Moved `_hsenc` and `_hsmi` to exact matches to avoid over-matching.
  - Guarded `addBlockedQSPrefix` against empty strings to prevent stripping all params.

<sup>Written for commit 36f9ffdc2061bae324a2a69c0abe0b4966c2f219. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/deco/pull/1194?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance & Optimization**
  * Improved cache stability by more robust handling of URL query parameters, reducing cache fragmentation
  * Extended automatic filtering to strip additional tracking/advertising-related parameters (including prefix-based patterns) for consistent cache behavior
  * Reduced redundant cache entries and optimized parameter processing for better overall application performance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/deco/pull/1194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->