### PR TITLE
fix(security): restrict /deco/render and /deco/previews to admin editor origin

### DIFF
--- a/runtime/routes/blockPreview.tsx
+++ b/runtime/routes/blockPreview.tsx
@@ -7,6 +7,7 @@ import { bodyFromUrl } from "../../utils/http.ts";
 import { createHandler, type DecoMiddlewareContext } from "../middleware.ts";
 import type { PageParams } from "../mod.ts";
 import Render from "./entrypoint.tsx";
+import { isPreviewAllowed } from "./previewAuth.ts";
 
 const decoder = new TextDecoder();
 export default function Preview(
@@ -39,6 +40,13 @@ export const handler = createHandler(async (
   ctx,
 ): Promise<Response> => {
   const { req: { raw: req }, var: state } = ctx;
+
+  if (!isPreviewAllowed(req)) {
+    return new Response("Preview only available from admin editor", {
+      status: 403,
+    });
+  }
+
   if (req.headers.get("upgrade") != "websocket") {
     const props = await getPropsFromRequest(req);
     return await render(req.url, await props, req, ctx);

--- a/runtime/routes/previewAuth.ts
+++ b/runtime/routes/previewAuth.ts
@@ -1,5 +1,8 @@
 const ALLOWED_ORIGINS = [
   "https://admin.deco.cx",
+  "https://admin.decocms.com",
+  "https://deco.cx",
+  "https://decocms.com",
   "http://localhost:3000", // local dev
   "http://localhost:8000",
 ];
@@ -22,9 +25,15 @@ export function isPreviewAllowed(req: Request): boolean {
     return true;
   }
 
-  // Allow if the request IS on admin.deco.cx itself
+  // Allow if the request IS on an allowed host itself
   const host = req.headers.get("host") || "";
-  if (host === "admin.deco.cx" || host.startsWith("localhost")) {
+  if (
+    host === "admin.deco.cx" ||
+    host === "admin.decocms.com" ||
+    host.endsWith(".deco.cx") ||
+    host.endsWith(".decocms.com") ||
+    host.startsWith("localhost")
+  ) {
     return true;
   }
 

--- a/runtime/routes/previewAuth.ts
+++ b/runtime/routes/previewAuth.ts
@@ -7,6 +7,14 @@ const ALLOWED_ORIGINS = [
   "http://localhost:8000",
 ];
 
+function safeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Checks whether a preview/render request originates from the admin editor.
  * Allows requests from admin.deco.cx, localhost dev servers, and requests
@@ -14,14 +22,14 @@ const ALLOWED_ORIGINS = [
  */
 export function isPreviewAllowed(req: Request): boolean {
   // Check Origin header (set on cross-origin requests from admin iframe/fetch)
-  const origin = req.headers.get("origin");
-  if (origin && ALLOWED_ORIGINS.some((o) => origin.startsWith(o))) {
+  const origin = safeOrigin(req.headers.get("origin") ?? "");
+  if (origin && ALLOWED_ORIGINS.includes(origin)) {
     return true;
   }
 
   // Check Referer as fallback (for GET requests that don't send Origin)
-  const referer = req.headers.get("referer");
-  if (referer && ALLOWED_ORIGINS.some((o) => referer.startsWith(o))) {
+  const referer = safeOrigin(req.headers.get("referer") ?? "");
+  if (referer && ALLOWED_ORIGINS.includes(referer)) {
     return true;
   }
 

--- a/runtime/routes/previewAuth.ts
+++ b/runtime/routes/previewAuth.ts
@@ -33,11 +33,13 @@ export function isPreviewAllowed(req: Request): boolean {
     return true;
   }
 
-  // Allow if the request IS on an admin host itself (not wildcard subdomains)
+  // Allow if the request IS on an allowed host
   const host = req.headers.get("host") || "";
   if (
     host === "admin.deco.cx" ||
     host === "admin.decocms.com" ||
+    host.endsWith(".deco.cx") ||
+    host.endsWith(".decocms.com") ||
     host.startsWith("localhost")
   ) {
     return true;

--- a/runtime/routes/previewAuth.ts
+++ b/runtime/routes/previewAuth.ts
@@ -33,13 +33,11 @@ export function isPreviewAllowed(req: Request): boolean {
     return true;
   }
 
-  // Allow if the request IS on an allowed host itself
+  // Allow if the request IS on an admin host itself (not wildcard subdomains)
   const host = req.headers.get("host") || "";
   if (
     host === "admin.deco.cx" ||
     host === "admin.decocms.com" ||
-    host.endsWith(".deco.cx") ||
-    host.endsWith(".decocms.com") ||
     host.startsWith("localhost")
   ) {
     return true;

--- a/runtime/routes/previewAuth.ts
+++ b/runtime/routes/previewAuth.ts
@@ -1,0 +1,32 @@
+const ALLOWED_ORIGINS = [
+  "https://admin.deco.cx",
+  "http://localhost:3000", // local dev
+  "http://localhost:8000",
+];
+
+/**
+ * Checks whether a preview/render request originates from the admin editor.
+ * Allows requests from admin.deco.cx, localhost dev servers, and requests
+ * made directly on admin.deco.cx itself.
+ */
+export function isPreviewAllowed(req: Request): boolean {
+  // Check Origin header (set on cross-origin requests from admin iframe/fetch)
+  const origin = req.headers.get("origin");
+  if (origin && ALLOWED_ORIGINS.some((o) => origin.startsWith(o))) {
+    return true;
+  }
+
+  // Check Referer as fallback (for GET requests that don't send Origin)
+  const referer = req.headers.get("referer");
+  if (referer && ALLOWED_ORIGINS.some((o) => referer.startsWith(o))) {
+    return true;
+  }
+
+  // Allow if the request IS on admin.deco.cx itself
+  const host = req.headers.get("host") || "";
+  if (host === "admin.deco.cx" || host.startsWith("localhost")) {
+    return true;
+  }
+
+  return false;
+}

--- a/runtime/routes/render.tsx
+++ b/runtime/routes/render.tsx
@@ -8,6 +8,7 @@ import { singleFlight } from "../../utils/mod.ts";
 import { createHandler, DEBUG_QS } from "../middleware.ts";
 import type { PageParams } from "../mod.ts";
 import Render, { type PageData } from "./entrypoint.tsx";
+import { isPreviewAllowed } from "./previewAuth.ts";
 
 interface Options {
   resolveChain?: FieldResolver[];
@@ -83,6 +84,13 @@ export const handler = createHandler(async (
   ctx,
 ) => {
   const { req: { raw: req }, var: state, render } = ctx;
+
+  if (!isPreviewAllowed(req)) {
+    return new Response("Preview only available from admin editor", {
+      status: 403,
+    });
+  }
+
   const opts = fromRequest(req);
   const isDebugRequest = opts.searchParams.has(DEBUG_QS);
 


### PR DESCRIPTION
**Summary**

  - Adds origin validation to /deco/render (render.tsx) and /deco/previews/* (blockPreview.tsx) to restrict access to trusted
   admin editor origins only
  - Creates shared previewAuth.ts utility with isPreviewAllowed() that checks Origin, Referer (fallback for iframe GET
  requests), and Host headers
  - Returns 403 for requests not originating from allowed domains

  **Allowed origins**

  - https://admin.deco.cx, https://admin.decocms.com
  - https://deco.cx, https://decocms.com
  - http://localhost:3000, http://localhost:8000 (local dev)
  - Host check: *.deco.cx, *.decocms.com, localhost

  **What was vulnerable**

  - /deco/render  — Accepts user-controlled __resolveType + props in query string. An attacker could craft a URL
  that resolves arbitrary sections and renders attacker-controlled HTML. No auth required. Reflected XSS confirmed on
  admin.deco.cx and all storefronts.
  - /deco/previews/*  — POST accepts __decofile in body, replacing the site's resolver with an attacker-supplied
  decofile via fromJSON(). Attacker defines custom block definitions and resolves them server-side. Also has a WebSocket path
   for persistent preview connections.

  Both endpoints are framework-level (affect ALL deco sites, not just admin).


  **Test plan**

  - Verify admin editor block previews still render correctly on storefronts
  - Verify WebSocket preview connection in blockPreview.tsx still works from admin
  - Verify local dev (localhost:3000, localhost:8000) previews still work
  - Verify direct navigation to /deco/render?props=...&__resolveType=... returns 403
  - Verify cross-origin fetch from a non-allowed domain returns 403

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts `/deco/render` and `/deco/previews/*` to trusted admin/editor origins and allowed hosts. Blocks reflected XSS via `__resolveType` and decofile injection; restores safe wildcard host fallback for `*.deco.cx` and `*.decocms.com` to keep subdomain previews working.

- **Bug Fixes**
  - Added `isPreviewAllowed()` in `runtime/routes/previewAuth.ts` to validate Origin/Referer with exact `URL().origin` matching; ignores malformed headers.
  - Enforced checks in `runtime/routes/render.tsx` and `runtime/routes/blockPreview.tsx` (incl. WebSocket); returns 403 when invalid.
  - Allowed origins: https://admin.deco.cx, https://admin.decocms.com, https://deco.cx, https://decocms.com, http://localhost:3000, http://localhost:8000. Host fallback: `admin.deco.cx`, `admin.decocms.com`, any `*.deco.cx`/`*.decocms.com`, and `localhost`.

<sup>Written for commit 773f24c5db47e288212619d60599a6c6cd5d07c7. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/deco/pull/1197?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened preview/render protection: requests from unapproved origins or non-admin editors are now blocked with a 403 response.
* **New Features**
  * Added origin and host-based authorization checks to determine whether preview access is allowed, including support for localhost and known admin/public domains.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/deco/pull/1197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->