### PR TITLE
Only set deco_segment cookie for sticky matchers

### DIFF
--- a/blocks/matcher.ts
+++ b/blocks/matcher.ts
@@ -223,6 +223,7 @@ const matcherBlock: Block<
         name: uniqueId,
         value: result,
         isSegment,
+        sticky: shouldStickyOnSession,
         cacheable: matcherModule.cacheable,
       });
 

--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -393,7 +393,7 @@ export const middlewareFor = <TAppManifest extends AppManifest = AppManifest>(
         const active = new Set(segment.active || []);
         const inactiveDrawn = new Set(segment.inactiveDrawn || []);
         for (const flag of ctx.var.flags) {
-          if (flag.isSegment) {
+          if (flag.isSegment && flag.sticky) {
             if (flag.value) {
               active.add(flag.name);
               inactiveDrawn.delete(flag.name);

--- a/types.ts
+++ b/types.ts
@@ -82,6 +82,7 @@ export interface Flag {
   name: string;
   value: boolean;
   isSegment?: boolean;
+  sticky?: boolean;
   cacheable?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Added `sticky` property to the `Flag` interface and propagated `shouldStickyOnSession` from matcher block to flags
- Changed `deco_segment` cookie logic to only persist flags that are both `isSegment` and `sticky`
- Non-sticky flags no longer produce a `Set-Cookie` header, allowing Cloudflare to cache those responses

## Test plan
- [ ] Verify sticky-session matchers still write to `deco_segment` cookie correctly
- [ ] Verify non-sticky segment flags (e.g. "ETC Segment") no longer produce a `Set-Cookie: deco_segment` header
- [ ] Confirm Cloudflare caches responses that previously were busted by the unnecessary `Set-Cookie`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the `deco_segment` cookie only for sticky segment matchers to avoid unnecessary Set-Cookie headers and allow Cloudflare to cache first-visit responses. Adds a `sticky` field to the `Flag` interface and propagates matcher `shouldStickyOnSession` to set it.

<sup>Written for commit 1ba901ab6dda91492d5bd20b63aa2bc978eb3f02. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/deco/pull/1198?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session stickiness tracking to flags, enabling more precise control over how flagged features persist across user sessions.

* **Bug Fixes**
  * Updated segment flag mapping logic to only apply to flags configured for session stickiness, improving consistency in segment behavior and cookie value computation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/deco/pull/1198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->