### PR TITLE
feat(daemon): self-scale to zero via in-pod ServiceAccount

### DIFF
--- a/blocks/matcher.ts
+++ b/blocks/matcher.ts
@@ -202,7 +202,7 @@ const matcherBlock: Block<
           : "";
         const cookieName = `${DECO_MATCHER_PREFIX}${h.result()}${_sessionKey}`;
         const isMatchFromCookie = cookieValue.boolean(
-          getCookies(enrichedCtx.request.headers)[cookieName],
+          getCookies(enrichedCtx.request.headers)[cookieName] ?? "",
         );
         result ??= isMatchFromCookie ?? await matcherFunc(enrichedCtx);
         if (result !== isMatchFromCookie) {

--- a/daemon/monitor.ts
+++ b/daemon/monitor.ts
@@ -1,12 +1,16 @@
 import type { Handler, MiddlewareHandler } from "@hono/hono";
 
 const ONE_MINUTE_MS = 1e3 * 60;
+
 const DECO_IDLE_THRESHOLD_MINUTES_STR = Deno.env.get(
   "DECO_IDLE_THRESHOLD_MINUTES",
 );
 const DECO_IDLE_NOTIFICATION_ENDPOINT = Deno.env.get(
   "DECO_IDLE_NOTIFICATION_ENDPOINT",
 );
+const DECO_SELF_SCALE_ENABLED =
+  Deno.env.get("DECO_SELF_SCALE_ENABLED") === "true";
+const DECO_STATEFULSET_NAME = Deno.env.get("DECO_STATEFULSET_NAME");
 
 const DECO_IDLE_THRESHOLD_MINUTES = DECO_IDLE_THRESHOLD_MINUTES_STR &&
     typeof +DECO_IDLE_THRESHOLD_MINUTES_STR === "number"
@@ -17,38 +21,172 @@ const hasNotificationEndpoint = DECO_IDLE_NOTIFICATION_ENDPOINT !== undefined &&
   URL.canParse(DECO_IDLE_NOTIFICATION_ENDPOINT) &&
   DECO_IDLE_THRESHOLD_MINUTES !== undefined;
 
+let lastActivity = Date.now();
+
 const isIdle = () => {
   if (!DECO_IDLE_THRESHOLD_MINUTES) return false;
   const now = Date.now();
   return now - lastActivity > (DECO_IDLE_THRESHOLD_MINUTES * ONE_MINUTE_MS);
 };
 
-const checkActivity = async (notificationUrl: URL) => {
-  if (isIdle()) {
-    console.log(`env is considered idle notifying ${notificationUrl}`);
-    await fetch(notificationUrl, { method: "GET" }).then(async (resp) => {
-      if (!resp.ok) {
-        console.error(
-          `Failed to notify ${notificationUrl} with status ${resp.status} ${await resp
-            .text()}`,
-        );
-      }
-    }).catch(
-      (_err) => {
-        console.error(`Failed to notify ${notificationUrl}`, _err);
-      },
-    );
+// ─── Self-scale via in-pod ServiceAccount ────────────────────────────────
+// The daemon PATCHes its own StatefulSet's scale subresource directly via
+// the k8s API instead of asking admin to do it. The pod's ServiceAccount
+// (provisioned by admin at env-create time) is RBAC-scoped to ONLY this
+// StatefulSet's scale subresource, so blast radius is one env.
+
+const SA_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+const SA_CA_CERT_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
+const SA_NAMESPACE_PATH =
+  "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+
+interface SelfScaleConfig {
+  apiHost: string;
+  namespace: string;
+  token: string;
+  client: Deno.HttpClient;
+}
+
+let selfScaleConfig: SelfScaleConfig | undefined | null = undefined;
+
+const initSelfScale = async (): Promise<SelfScaleConfig | null> => {
+  if (selfScaleConfig !== undefined) return selfScaleConfig;
+  if (!DECO_SELF_SCALE_ENABLED || !DECO_STATEFULSET_NAME) {
+    selfScaleConfig = null;
+    return null;
+  }
+  try {
+    const [token, caCert, namespace] = await Promise.all([
+      Deno.readTextFile(SA_TOKEN_PATH),
+      Deno.readTextFile(SA_CA_CERT_PATH),
+      Deno.readTextFile(SA_NAMESPACE_PATH),
+    ]);
+    const host = Deno.env.get("KUBERNETES_SERVICE_HOST");
+    const port = Deno.env.get("KUBERNETES_SERVICE_PORT") ?? "443";
+    if (!host) {
+      console.error(
+        "[self-scale] KUBERNETES_SERVICE_HOST not set; falling back to HTTP",
+      );
+      selfScaleConfig = null;
+      return null;
+    }
+    selfScaleConfig = {
+      apiHost: `https://${host}:${port}`,
+      namespace: namespace.trim(),
+      token: token.trim(),
+      client: Deno.createHttpClient({ caCerts: [caCert] }),
+    };
+    return selfScaleConfig;
+  } catch (err) {
+    console.error("[self-scale] init failed; falling back to HTTP:", err);
+    selfScaleConfig = null;
+    return null;
   }
 };
 
-let lastActivity = Date.now();
+const scaleSelfToZero = async (): Promise<boolean> => {
+  const cfg = await initSelfScale();
+  if (!cfg || !DECO_STATEFULSET_NAME) return false;
+  const url =
+    `${cfg.apiHost}/apis/apps/v1/namespaces/${cfg.namespace}/statefulsets/${DECO_STATEFULSET_NAME}/scale`;
+  try {
+    const resp = await fetch(url, {
+      method: "PATCH",
+      headers: {
+        "Authorization": `Bearer ${cfg.token}`,
+        "Content-Type": "application/strategic-merge-patch+json",
+      },
+      body: JSON.stringify({ spec: { replicas: 0 } }),
+      client: cfg.client,
+    });
+    if (!resp.ok) {
+      const body = await resp.text();
+      console.error(
+        `[self-scale] PATCH failed status=${resp.status} body=${body}`,
+      );
+      return false;
+    }
+    console.log(
+      `[self-scale] scaled self to zero sts=${DECO_STATEFULSET_NAME} ns=${cfg.namespace}`,
+    );
+    return true;
+  } catch (err) {
+    console.error("[self-scale] PATCH error:", err);
+    return false;
+  }
+};
+
+// ─── HTTP fallback (legacy admin path) ───────────────────────────────────
+
+const notifyViaHttp = async (notificationUrl: URL): Promise<boolean> => {
+  try {
+    const resp = await fetch(notificationUrl, { method: "GET" });
+    if (!resp.ok) {
+      console.error(
+        `Failed to notify ${notificationUrl} with status ${resp.status} ${await resp
+          .text()}`,
+      );
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.error(`Failed to notify ${notificationUrl}`, err);
+    return false;
+  }
+};
+
+// ─── Idle loop ────────────────────────────────────────────────────────────
+// The interval fires once a minute, but only triggers a single notification
+// per idle window: on a successful fire we clear the interval. If activity
+// resumes (resetActivity / activityMonitor), we re-arm. This avoids the old
+// behavior of pinging admin every minute for the entire pod-termination
+// window, which dominated admin's request load.
+
+let idleInterval: number | undefined;
+let armedNotificationUrl: URL | undefined;
+
+const fireOnce = async (notificationUrl: URL) => {
+  console.log(`env is considered idle notifying ${notificationUrl}`);
+  // Self-scale path is preferred; HTTP fallback runs on failure (or when
+  // the env is not provisioned with the SA, e.g. existing envs pre-migration).
+  let success = false;
+  if (DECO_SELF_SCALE_ENABLED) {
+    success = await scaleSelfToZero();
+  }
+  if (!success) {
+    success = await notifyViaHttp(notificationUrl);
+  }
+  if (success && idleInterval !== undefined) {
+    clearInterval(idleInterval);
+    idleInterval = undefined;
+  }
+};
+
+const checkActivity = (notificationUrl: URL) => {
+  if (isIdle()) {
+    fireOnce(notificationUrl);
+  }
+};
+
+const armIdleInterval = (notificationUrl: URL) => {
+  if (idleInterval !== undefined) return;
+  idleInterval = setInterval(
+    () => checkActivity(notificationUrl),
+    ONE_MINUTE_MS,
+  );
+};
 
 export const resetActivity = () => {
   lastActivity = Date.now();
+  // If we previously cleared the interval after firing, re-arm so that a
+  // subsequent idle period will fire again.
+  if (idleInterval === undefined && armedNotificationUrl) {
+    armIdleInterval(armedNotificationUrl);
+  }
 };
 
 export const activityMonitor: MiddlewareHandler = async (_ctx, next) => {
-  lastActivity = Date.now();
+  resetActivity();
   await next();
 };
 
@@ -60,7 +198,8 @@ export const createIdleHandler = (site: string, envName: string): Handler => {
     const notificationUrl = new URL(DECO_IDLE_NOTIFICATION_ENDPOINT);
     notificationUrl.searchParams.set("site", site);
     notificationUrl.searchParams.set("name", envName);
-    setInterval(() => checkActivity(notificationUrl), ONE_MINUTE_MS);
+    armedNotificationUrl = notificationUrl;
+    armIdleInterval(notificationUrl);
   }
   return () =>
     new Response(`${isIdle()}`, {
@@ -72,6 +211,7 @@ export const createIdleHandler = (site: string, envName: string): Handler => {
           : "",
         "x-deco-idle-notification-endpoint": DECO_IDLE_NOTIFICATION_ENDPOINT ??
           "",
+        "x-deco-self-scale-enabled": `${DECO_SELF_SCALE_ENABLED}`,
       },
     });
 };

--- a/daemon/monitor.ts
+++ b/daemon/monitor.ts
@@ -222,10 +222,12 @@ export const createIdleHandler = (site: string, envName: string): Handler => {
     typeof envName === "string";
   if (idleEnabled) {
     // The URL is the HTTP fallback target. Build it only if the endpoint is
-    // configured; if it's not, fireOnce uses self-scale exclusively.
-    const notificationUrl: URL | null = DECO_IDLE_NOTIFICATION_ENDPOINT
+    // configured AND parseable; if it's not, fireOnce uses self-scale
+    // exclusively. Guarding on the raw env var would crash here when
+    // self-scale is enabled but the fallback URL is malformed.
+    const notificationUrl: URL | null = hasNotificationEndpoint
       ? (() => {
-        const u = new URL(DECO_IDLE_NOTIFICATION_ENDPOINT);
+        const u = new URL(DECO_IDLE_NOTIFICATION_ENDPOINT!);
         u.searchParams.set("site", site);
         u.searchParams.set("name", envName);
         return u;

--- a/daemon/monitor.ts
+++ b/daemon/monitor.ts
@@ -43,7 +43,6 @@ const SA_NAMESPACE_PATH =
 interface SelfScaleConfig {
   apiHost: string;
   namespace: string;
-  token: string;
   client: Deno.HttpClient;
 }
 
@@ -56,8 +55,10 @@ const initSelfScale = async (): Promise<SelfScaleConfig | null> => {
     return null;
   }
   try {
-    const [token, caCert, namespace] = await Promise.all([
-      Deno.readTextFile(SA_TOKEN_PATH),
+    // CA cert + namespace are stable for the pod's lifetime; cache them.
+    // The SA token has a TTL (~1h) and is rotated in place by kubelet, so we
+    // re-read it on every PATCH instead of caching it here.
+    const [caCert, namespace] = await Promise.all([
       Deno.readTextFile(SA_CA_CERT_PATH),
       Deno.readTextFile(SA_NAMESPACE_PATH),
     ]);
@@ -73,7 +74,6 @@ const initSelfScale = async (): Promise<SelfScaleConfig | null> => {
     selfScaleConfig = {
       apiHost: `https://${host}:${port}`,
       namespace: namespace.trim(),
-      token: token.trim(),
       client: Deno.createHttpClient({ caCerts: [caCert] }),
     };
     return selfScaleConfig;
@@ -87,13 +87,20 @@ const initSelfScale = async (): Promise<SelfScaleConfig | null> => {
 const scaleSelfToZero = async (): Promise<boolean> => {
   const cfg = await initSelfScale();
   if (!cfg || !DECO_STATEFULSET_NAME) return false;
+  let token: string;
+  try {
+    token = (await Deno.readTextFile(SA_TOKEN_PATH)).trim();
+  } catch (err) {
+    console.error("[self-scale] failed to read SA token:", err);
+    return false;
+  }
   const url =
     `${cfg.apiHost}/apis/apps/v1/namespaces/${cfg.namespace}/statefulsets/${DECO_STATEFULSET_NAME}/scale`;
   try {
     const resp = await fetch(url, {
       method: "PATCH",
       headers: {
-        "Authorization": `Bearer ${cfg.token}`,
+        "Authorization": `Bearer ${token}`,
         "Content-Type": "application/strategic-merge-patch+json",
       },
       body: JSON.stringify({ spec: { replicas: 0 } }),
@@ -106,6 +113,8 @@ const scaleSelfToZero = async (): Promise<boolean> => {
       );
       return false;
     }
+    // Drain the body so the connection is returned to the pool promptly.
+    await resp.body?.cancel();
     console.log(
       `[self-scale] scaled self to zero sts=${DECO_STATEFULSET_NAME} ns=${cfg.namespace}`,
     );
@@ -128,6 +137,8 @@ const notifyViaHttp = async (notificationUrl: URL): Promise<boolean> => {
       );
       return false;
     }
+    // Drain the body so the connection is returned to the pool promptly.
+    await resp.body?.cancel();
     return true;
   } catch (err) {
     console.error(`Failed to notify ${notificationUrl}`, err);
@@ -143,17 +154,19 @@ const notifyViaHttp = async (notificationUrl: URL): Promise<boolean> => {
 // window, which dominated admin's request load.
 
 let idleInterval: number | undefined;
-let armedNotificationUrl: URL | undefined;
+let armedNotificationUrl: URL | undefined | null;
 
-const fireOnce = async (notificationUrl: URL) => {
-  console.log(`env is considered idle notifying ${notificationUrl}`);
+const fireOnce = async (notificationUrl: URL | undefined | null) => {
+  console.log(
+    `env is considered idle (self-scale=${DECO_SELF_SCALE_ENABLED} http=${!!notificationUrl})`,
+  );
   // Self-scale path is preferred; HTTP fallback runs on failure (or when
   // the env is not provisioned with the SA, e.g. existing envs pre-migration).
   let success = false;
   if (DECO_SELF_SCALE_ENABLED) {
     success = await scaleSelfToZero();
   }
-  if (!success) {
+  if (!success && notificationUrl) {
     success = await notifyViaHttp(notificationUrl);
   }
   if (success && idleInterval !== undefined) {
@@ -162,13 +175,21 @@ const fireOnce = async (notificationUrl: URL) => {
   }
 };
 
-const checkActivity = (notificationUrl: URL) => {
-  if (isIdle()) {
-    fireOnce(notificationUrl);
-  }
-};
+// Guard against re-entrancy: if a previous fireOnce() is still in flight when
+// the next interval tick arrives (network hang, slow k8s API), don't kick off
+// a second concurrent notification.
+const checkActivity = (() => {
+  let inFlight = false;
+  return (notificationUrl: URL | undefined | null) => {
+    if (!isIdle() || inFlight) return;
+    inFlight = true;
+    fireOnce(notificationUrl).finally(() => {
+      inFlight = false;
+    });
+  };
+})();
 
-const armIdleInterval = (notificationUrl: URL) => {
+const armIdleInterval = (notificationUrl: URL | undefined | null) => {
   if (idleInterval !== undefined) return;
   idleInterval = setInterval(
     () => checkActivity(notificationUrl),
@@ -180,7 +201,7 @@ export const resetActivity = () => {
   lastActivity = Date.now();
   // If we previously cleared the interval after firing, re-arm so that a
   // subsequent idle period will fire again.
-  if (idleInterval === undefined && armedNotificationUrl) {
+  if (idleInterval === undefined && armedNotificationUrl !== undefined) {
     armIdleInterval(armedNotificationUrl);
   }
 };
@@ -191,13 +212,25 @@ export const activityMonitor: MiddlewareHandler = async (_ctx, next) => {
 };
 
 export const createIdleHandler = (site: string, envName: string): Handler => {
-  const shouldNotify = hasNotificationEndpoint &&
+  // Idle monitoring runs whenever a threshold is set and at least one of the
+  // two fire paths is configured. Previously this was gated only on the HTTP
+  // endpoint, which meant envs with self-scale enabled but no fallback URL
+  // would never arm the timer.
+  const idleEnabled = DECO_IDLE_THRESHOLD_MINUTES !== undefined &&
+    (hasNotificationEndpoint || DECO_SELF_SCALE_ENABLED) &&
     typeof site === "string" &&
     typeof envName === "string";
-  if (shouldNotify && DECO_IDLE_NOTIFICATION_ENDPOINT) {
-    const notificationUrl = new URL(DECO_IDLE_NOTIFICATION_ENDPOINT);
-    notificationUrl.searchParams.set("site", site);
-    notificationUrl.searchParams.set("name", envName);
+  if (idleEnabled) {
+    // The URL is the HTTP fallback target. Build it only if the endpoint is
+    // configured; if it's not, fireOnce uses self-scale exclusively.
+    const notificationUrl: URL | null = DECO_IDLE_NOTIFICATION_ENDPOINT
+      ? (() => {
+        const u = new URL(DECO_IDLE_NOTIFICATION_ENDPOINT);
+        u.searchParams.set("site", site);
+        u.searchParams.set("name", envName);
+        return u;
+      })()
+      : null;
     armedNotificationUrl = notificationUrl;
     armIdleInterval(notificationUrl);
   }

--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -385,7 +385,7 @@ export const middlewareFor = <TAppManifest extends AppManifest = AppManifest>(
       if (ctx.var?.flags.length > 0) {
         const currentCookies = getCookies(ctx.req.raw.headers);
         const cookieSegment = tryOrDefault(
-          () => decodeCookie(currentCookies[DECO_SEGMENT]),
+          () => decodeCookie(currentCookies[DECO_SEGMENT] ?? ""),
           "",
         );
         const segment = tryOrDefault(() => JSON.parse(cookieSegment), {});


### PR DESCRIPTION
## Summary

- The daemon now PATCHes its own `StatefulSet/scale` subresource via the projected SA token at `/var/run/secrets/kubernetes.io/serviceaccount/` when `DECO_SELF_SCALE_ENABLED=true` and `DECO_STATEFULSET_NAME` is set. This removes the deco-sites/admin control plane from the scale-to-zero hot path — its `/events/idle.ts` was being hit ~800/min by idle daemon heartbeats.
- Also fixes a longstanding amplification bug: the `setInterval` in `monitor.ts` is now cleared after a successful fire and re-armed on next activity via `resetActivity`. Previously a single idle env kept firing every 60s for the entire pod-termination grace period, multiplying admin's load by N per idle cycle.
- Falls back automatically to the existing HTTP notification path (`DECO_IDLE_NOTIFICATION_ENDPOINT`) when self-scale init fails, the SA token is missing, or the PATCH errors. Existing envs without the new env vars or SA continue working exactly as before.

## How it works

```
[idle detected]
      ▼
init self-scale config (lazy, one-shot):
  read SA token, CA cert, namespace
  build Deno.HttpClient with caCerts
      ▼
PATCH https://kubernetes.default:443/apis/apps/v1/namespaces/{ns}
       /statefulsets/{DECO_STATEFULSET_NAME}/scale
       { spec: { replicas: 0 } }
      ▼
  ok → clearInterval; pod gets SIGTERM from kubelet
  err → fall through to legacy HTTP fetch(DECO_IDLE_NOTIFICATION_ENDPOINT)
```

The per-env ServiceAccount + Role + RoleBinding that grant patch on `statefulsets/scale` (scoped to one resourceName) are provisioned by admin at env create time — see paired PR in deco-sites/admin.

## Why this is safe

- The per-env Role is `resourceNames`-scoped to a single StatefulSet, so a compromised env's daemon can only scale itself, not any neighbor.
- `Deno.createHttpClient({ caCerts })` is stable since Deno 1.27; we run Deno 1.44.4 on env images, and `daemon/workers/denoRun.ts` already uses `createHttpClient` in production.
- The HTTP fallback means envs deployed before the SA provisioning lands still scale via admin. Backwards-compatible by default.

## Related

- PRD: `05_engineering/platform/admin-cx/SELF_SCALING_ENV_DAEMON.md` in the context repo
- Admin-side PR: deco-sites/admin#3212

## Test plan

- [ ] Lint passes (verified)
- [ ] In an env pod with all flags set: trigger idle, observe `[self-scale] scaled self to zero` log line; admin's `/events/idle.ts` should NOT receive the call
- [ ] In an env pod WITHOUT `DECO_SELF_SCALE_ENABLED`: idle still fires the legacy HTTP notification (no regression)
- [ ] In an env pod where the SA token is missing or RBAC is misconfigured: PATCH fails, daemon falls through to HTTP (no regression)
- [ ] After a successful fire, the interval is cleared (verified by no second log line within the termination window)
- [ ] After resuming activity (any request through `activityMonitor`), the interval re-arms and the env can be detected idle again on the next cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the daemon to self-scale to zero by PATCHing its own `StatefulSet/scale` using the in-pod ServiceAccount, removing admin from the hot path. Fires once per idle window and re-arms on activity to stop minute-by-minute spam.

- **New Features**
  - Self-scale to zero via the projected SA token when `DECO_SELF_SCALE_ENABLED=true` and `DECO_STATEFULSET_NAME` are set; falls back to `DECO_IDLE_NOTIFICATION_ENDPOINT` if init or PATCH fails.
  - Arms idle monitoring when a threshold is set and at least one path (self-scale or HTTP) is available.

- **Bug Fixes**
  - Clear the idle interval after a successful fire and re-arm on activity; guard against re-entrancy so only one fire runs at a time.
  - Re-read the SA token on every PATCH; cache CA cert and namespace; drain response bodies; and only build the notification URL when `hasNotificationEndpoint` so a malformed `DECO_IDLE_NOTIFICATION_ENDPOINT` can’t crash when self-scale is enabled.
  - Guard cookie lookups against undefined in matcher and runtime middleware under stricter type checks.

<sup>Written for commit 59221c40d7b68cbc37bd5e9c4c4bcad0067ff49e. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/deco/pull/1199?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional automatic self-scale-to-zero for idle instances with HTTP-notify fallback.

* **Enhancements**
  * Improved idle detection to prevent duplicate triggers and re-arm timers when activity resumes.
  * Idle endpoint now exposes whether self-scaling is enabled for better observability.

* **Bug Fixes**
  * Safer cookie handling for session sticky matching and segment decoding to avoid missing-value issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/deco/pull/1199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->