### PR TITLE
feat(runtime): switch page cache to opt-in via PAGE_CACHE_ALLOWED_KEY

### DIFF
--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -1,7 +1,7 @@
 // deno-lint-ignore-file no-explicit-any
 import { HTTPException } from "@hono/hono/http-exception";
 import { DECO_MATCHER_HEADER_QS } from "../blocks/matcher.ts";
-import { PAGE_DIRTY_KEY } from "../blocks/utils.tsx";
+import { PAGE_CACHE_ALLOWED_KEY } from "../blocks/utils.tsx";
 import { Context, context } from "../deco.ts";
 import {
   type Exception,
@@ -106,7 +106,6 @@ async (ctx, next) => {
 
 const DEBUG_COOKIE = "deco_debug";
 const DEBUG_ENABLED = "enabled";
-const PAGE_CACHE_ENABLED = Deno.env.get("DECO_PAGE_CACHE_ENABLED") === "true";
 const PAGE_CACHE_CONTROL = Deno.env.get("DECO_PAGE_CACHE_CONTROL") ??
   "public, max-age=90, s-maxage=90, stale-while-revalidate=3600, stale-if-error=86400";
 
@@ -430,12 +429,12 @@ export const middlewareFor = <TAppManifest extends AppManifest = AppManifest>(
       const hasSetCookie = getSetCookies(newHeaders).length > 0;
       const contentType = newHeaders.get("Content-Type") ?? "";
       const isHtmlResponse = contentType.includes("text/html");
-      const isPageDirty = ctx.var.bag?.has(PAGE_DIRTY_KEY);
+      const isPageCacheAllowed = ctx.var.bag?.has(PAGE_CACHE_ALLOWED_KEY);
 
       if (hasSetCookie) {
         // Set-cookie present: never cache (same behavior as main)
         newHeaders.set("Cache-Control", "no-store, no-cache, must-revalidate");
-      } else if (isHtmlResponse && PAGE_CACHE_ENABLED && !isPageDirty) {
+      } else if (isHtmlResponse && isPageCacheAllowed) {
         const flags = ctx.var?.flags ?? [];
         const allFlagsCacheable = flags.length > 0
           ? flags.every((flag) => flag.cacheable === true)


### PR DESCRIPTION
## Summary

- Removes `DECO_PAGE_CACHE_ENABLED` env var — CDN caching no longer needs to be explicitly enabled via environment variable
- Replaces opt-out caching model with opt-in: runtime only sets public `Cache-Control` when `PAGE_CACHE_ALLOWED_KEY` is present in the bag
- Removes `PAGE_DIRTY_KEY` import/usage from the runtime middleware
- `PAGE_CACHE_ALLOWED_KEY` was already defined in `blocks/utils.tsx` and exported from `blocks/mod.ts`; this PR wires it into the runtime

## Context

Previously, the runtime applied `Cache-Control: public, max-age=90...` to all HTML responses when `DECO_PAGE_CACHE_ENABLED=true`, relying on apps to set `PAGE_DIRTY_KEY` to opt out. This had two problems:

1. Required an env var to be set per-site to activate
2. Any site without a middleware that explicitly marked pages dirty would get CDN caching — even if unintended

The new model requires apps to explicitly set `PAGE_CACHE_ALLOWED_KEY` in the bag to receive CDN cache headers. No env var needed. Apps that don't set the key are unaffected (their existing proxy/CDN behavior is preserved).

## Test plan

- [ ] VTEX site with cacheable segment → `PAGE_CACHE_ALLOWED_KEY` set by vtex middleware → runtime applies `Cache-Control: public, max-age=90, s-maxage=90, stale-while-revalidate=3600, stale-if-error=86400`
- [ ] VTEX site with non-cacheable segment → no key set → runtime does not apply public cache headers
- [ ] Non-VTEX site (no middleware setting the key) → runtime does not apply public cache headers
- [ ] Response with `Set-Cookie` → always `no-store` regardless of key (existing behavior preserved)
- [ ] Site without `DECO_PAGE_CACHE_ENABLED=true` in env → cache works normally (env var no longer required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)