### PR TITLE
feat(cache): remove s-maxage from default cache-control headers

### DIFF
--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -107,7 +107,7 @@ async (ctx, next) => {
 const DEBUG_COOKIE = "deco_debug";
 const DEBUG_ENABLED = "enabled";
 const PAGE_CACHE_CONTROL = Deno.env.get("DECO_PAGE_CACHE_CONTROL") ??
-  "public, max-age=90, s-maxage=90, stale-while-revalidate=3600, stale-if-error=86400";
+  "public, max-age=90, stale-while-revalidate=3600, stale-if-error=86400";
 
 export const DEBUG_QS = "__d";
 const addHours = (date: Date, h: number) => {

--- a/runtime/routes/render.tsx
+++ b/runtime/routes/render.tsx
@@ -73,7 +73,7 @@ const fromRequest = (req: Request): Options => {
 };
 
 const DECO_RENDER_CACHE_CONTROL = Deno.env.get("DECO_RENDER_CACHE_CONTROL") ||
-  "public, max-age=60, s-maxage=60, stale-while-revalidate=3600, stale-if-error=86400";
+  "public, max-age=60, stale-while-revalidate=3600, stale-if-error=86400";
 
 const AsyncRenderSF = singleFlight<Response>();
 const SHOULD_USE_ASYNC_RENDER_SINGLE_FLIGHT =


### PR DESCRIPTION
## Summary

- Remove `s-maxage` directive from the default value of `DECO_PAGE_CACHE_CONTROL` (`runtime/middleware.ts`)
- Remove `s-maxage` directive from the default value of `DECO_RENDER_CACHE_CONTROL` (`runtime/routes/render.tsx`)

Sites that rely on the environment variable override are not affected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `s-maxage` from the default Cache-Control headers for page and render responses to avoid unintended shared-cache behavior. Defaults now use `max-age`, `stale-while-revalidate`, and `stale-if-error`; overrides via `DECO_PAGE_CACHE_CONTROL` and `DECO_RENDER_CACHE_CONTROL` remain supported and unchanged.

<sup>Written for commit 6f4179a32b6495772b5a2dfa50769ff84b997f88. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/deco/pull/1201?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted cache control settings for HTML pages and rendered content to improve cache behavior across shared caches and CDNs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/deco/pull/1201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->