### PR TITLE
feat(matcher): make matcher-wrapped pages cacheable at CDN edge

### DIFF
--- a/blocks/matcher.test.ts
+++ b/blocks/matcher.test.ts
@@ -1,0 +1,144 @@
+// deno-lint-ignore-file no-explicit-any
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { getSetCookies } from "../deps.ts";
+import matcherBlock, {
+  DECO_MATCHER_PREFIX,
+  type MatcherStickySessionModule,
+} from "./matcher.ts";
+
+const buildHttpCtx = (respHeaders: Headers) =>
+  ({
+    resolveChain: [{ type: "resolvable", value: "test-matcher-id" }],
+    context: {
+      state: {
+        response: { headers: respHeaders },
+        flags: [] as any[],
+        global: {},
+        bag: new WeakMap(),
+      },
+    },
+    request: new Request("https://example.com/"),
+    resolve: (() => {}) as any,
+    revision: undefined,
+    resolverId: "test-resolver",
+    monitoring: undefined,
+  }) as any;
+
+const buildMatchCtx = (request: Request) =>
+  ({
+    device: "desktop",
+    siteId: 1,
+    request,
+    resolve: (() => {}) as any,
+    invoke: (() => {}) as any,
+    response: { headers: new Headers() },
+    bag: new WeakMap(),
+  }) as any;
+
+Deno.test("sticky matcher flips result and sets cookie WITHOUT Vary: cookie", async () => {
+  const respHeaders = new Headers();
+  const httpCtx = buildHttpCtx(respHeaders);
+
+  const module: MatcherStickySessionModule = {
+    default: () => true,
+    sticky: "session",
+  };
+
+  const result = await resolverFor(module, httpCtx, new Request("https://example.com/"));
+
+  assertEquals(result, true);
+
+  const setCookies = getSetCookies(respHeaders);
+  assertEquals(setCookies.length, 1, "expected one Set-Cookie on respHeaders");
+  assert(
+    setCookies[0].name.startsWith(DECO_MATCHER_PREFIX),
+    `expected Set-Cookie name to start with ${DECO_MATCHER_PREFIX}, got ${
+      setCookies[0].name
+    }`,
+  );
+
+  const vary = respHeaders.get("vary") ?? "";
+  assert(
+    !vary.toLowerCase().includes("cookie"),
+    `expected Vary header to NOT contain "cookie", got: ${vary}`,
+  );
+});
+
+Deno.test("sticky matcher with matching cookie does NOT set a cookie or Vary", async () => {
+  const respHeaders = new Headers();
+  const httpCtx = buildHttpCtx(respHeaders);
+
+  const module: MatcherStickySessionModule = {
+    default: () => true,
+    sticky: "session",
+  };
+
+  // Build the cookie name the matcher would use, then set it on the request
+  // with a value that decodes to `true` so result === isMatchFromCookie.
+  const { Murmurhash3 } = await import("../deps.ts");
+  const h = new Murmurhash3();
+  h.hash("test-matcher-id");
+  const cookieName = `${DECO_MATCHER_PREFIX}${h.result()}`;
+  // cookieValue.build: btoa(id) + "@" + (result ? 1 : 0)
+  const cookieVal = `${btoa("test-matcher-id")}@1`;
+
+  const request = new Request("https://example.com/", {
+    headers: { cookie: `${cookieName}=${cookieVal}` },
+  });
+
+  const result = await resolverFor(module, httpCtx, request);
+  assertEquals(result, true);
+
+  assertEquals(
+    getSetCookies(respHeaders).length,
+    0,
+    "expected no Set-Cookie when cookie value already matches result",
+  );
+  assertEquals(
+    respHeaders.get("vary"),
+    null,
+    "expected no Vary header when nothing was emitted",
+  );
+});
+
+Deno.test("non-sticky matcher does not touch respHeaders", async () => {
+  const respHeaders = new Headers();
+  const httpCtx = buildHttpCtx(respHeaders);
+
+  const module = {
+    default: () => true,
+    sticky: "none" as const,
+  };
+
+  const result = await resolverFor(
+    module as any,
+    httpCtx,
+    new Request("https://example.com/"),
+  );
+  assertEquals(result, true);
+
+  assertEquals(getSetCookies(respHeaders).length, 0);
+  assertEquals(respHeaders.get("vary"), null);
+});
+
+// Regression guard: if anyone re-adds Vary: cookie inside the sticky branch,
+// this scan will fail. The string check is deliberately broad.
+Deno.test("matcher.ts source does not append Vary: cookie", async () => {
+  const src = await Deno.readTextFile(new URL("./matcher.ts", import.meta.url));
+  assert(
+    !/append\(\s*["']vary["']\s*,\s*["']cookie["']\s*\)/i.test(src),
+    "blocks/matcher.ts must not append Vary: cookie — that disables CDN caching",
+  );
+  // Sanity: ensure the cookie-setting code path is still there.
+  assertStringIncludes(src, "setCookie(respHeaders");
+});
+
+async function resolverFor(
+  module: MatcherStickySessionModule | { default: any; sticky: "none" },
+  httpCtx: any,
+  request: Request,
+): Promise<boolean> {
+  const adapt = matcherBlock.adapt as any;
+  const resolver = adapt(module, "test-matcher-id")({}, httpCtx);
+  return await resolver(buildMatchCtx(request));
+}

--- a/blocks/matcher.ts
+++ b/blocks/matcher.ts
@@ -215,7 +215,6 @@ const matcherBlock: Block<
             sameSite: "Lax",
             expires: date,
           });
-          respHeaders.append("vary", "cookie");
         }
       }
 

--- a/runtime/middleware.test.ts
+++ b/runtime/middleware.test.ts
@@ -1,0 +1,128 @@
+import { assert, assertEquals } from "@std/assert";
+import { setCookie } from "../utils/cookies.ts";
+import { DECO_MATCHER_PREFIX } from "../blocks/matcher.ts";
+import { applyPageCacheDecision, DECO_SEGMENT } from "./middleware.ts";
+
+const matcherCookie = `${DECO_MATCHER_PREFIX}1234567890_0.5`;
+
+const pageInput = {
+  flags: [],
+  isPageCacheAllowed: true,
+  shouldCacheFromVary: true,
+};
+
+Deno.test("no matcher, no Set-Cookie → public cache-control", () => {
+  const headers = new Headers({ "Content-Type": "text/html" });
+  applyPageCacheDecision(headers, pageInput);
+  const cc = headers.get("Cache-Control") ?? "";
+  assert(cc.startsWith("public,"), `expected public Cache-Control, got: ${cc}`);
+  assertEquals(headers.get("Deco-Cache-Vary-Cookies"), null);
+});
+
+Deno.test("matcher Set-Cookie only → public cache-control + hint header", () => {
+  const headers = new Headers({ "Content-Type": "text/html" });
+  setCookie(headers, { name: matcherCookie, value: "abc@1", path: "/" });
+  setCookie(headers, { name: DECO_SEGMENT, value: "%7B%7D", path: "/" });
+
+  applyPageCacheDecision(headers, pageInput);
+
+  const cc = headers.get("Cache-Control") ?? "";
+  assert(cc.startsWith("public,"), `expected public Cache-Control, got: ${cc}`);
+
+  const hint = headers.get("Deco-Cache-Vary-Cookies") ?? "";
+  assert(
+    hint.includes(matcherCookie),
+    `expected hint to include matcher cookie name, got: ${hint}`,
+  );
+  assert(
+    hint.includes(DECO_SEGMENT),
+    `expected hint to include deco_segment, got: ${hint}`,
+  );
+});
+
+Deno.test("foreign Set-Cookie → no-store (safety preserved)", () => {
+  const headers = new Headers({ "Content-Type": "text/html" });
+  setCookie(headers, { name: matcherCookie, value: "abc@1", path: "/" });
+  setCookie(headers, { name: "cart_count", value: "3", path: "/" });
+
+  applyPageCacheDecision(headers, pageInput);
+
+  assertEquals(
+    headers.get("Cache-Control"),
+    "no-store, no-cache, must-revalidate",
+  );
+  assertEquals(headers.get("Deco-Cache-Vary-Cookies"), null);
+});
+
+Deno.test("vary.shouldCache=false (personalizing loader) → no-store", () => {
+  const headers = new Headers({ "Content-Type": "text/html" });
+  setCookie(headers, { name: matcherCookie, value: "abc@1", path: "/" });
+
+  applyPageCacheDecision(headers, {
+    ...pageInput,
+    shouldCacheFromVary: false,
+  });
+
+  assertEquals(
+    headers.get("Cache-Control"),
+    "no-store, no-cache, must-revalidate",
+  );
+  assertEquals(headers.get("Deco-Cache-Vary-Cookies"), null);
+});
+
+Deno.test("flag with cacheable:false → no-store", () => {
+  const headers = new Headers({ "Content-Type": "text/html" });
+
+  applyPageCacheDecision(headers, {
+    flags: [{ cacheable: false }],
+    isPageCacheAllowed: true,
+    shouldCacheFromVary: true,
+  });
+
+  assertEquals(
+    headers.get("Cache-Control"),
+    "no-store, no-cache, must-revalidate",
+  );
+});
+
+Deno.test("isPageCacheAllowed=false → headers untouched", () => {
+  const headers = new Headers({ "Content-Type": "text/html" });
+  setCookie(headers, { name: matcherCookie, value: "abc@1", path: "/" });
+
+  applyPageCacheDecision(headers, {
+    ...pageInput,
+    isPageCacheAllowed: false,
+  });
+
+  assertEquals(headers.get("Cache-Control"), null);
+  assertEquals(headers.get("Deco-Cache-Vary-Cookies"), null);
+});
+
+Deno.test("respects pre-existing Cache-Control header", () => {
+  const headers = new Headers({
+    "Content-Type": "text/html",
+    "Cache-Control": "public, max-age=600",
+  });
+
+  applyPageCacheDecision(headers, pageInput);
+
+  assertEquals(headers.get("Cache-Control"), "public, max-age=600");
+});
+
+Deno.test(
+  "cacheDisqualified overrides a pre-existing Cache-Control header",
+  () => {
+    const headers = new Headers({
+      "Content-Type": "text/html",
+      "Cache-Control": "public, max-age=600",
+    });
+    setCookie(headers, { name: "session_id", value: "xyz", path: "/" });
+
+    applyPageCacheDecision(headers, pageInput);
+
+    assertEquals(
+      headers.get("Cache-Control"),
+      "no-store, no-cache, must-revalidate",
+    );
+  },
+);

--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -1,6 +1,9 @@
 // deno-lint-ignore-file no-explicit-any
 import { HTTPException } from "@hono/hono/http-exception";
-import { DECO_MATCHER_HEADER_QS } from "../blocks/matcher.ts";
+import {
+  DECO_MATCHER_HEADER_QS,
+  DECO_MATCHER_PREFIX,
+} from "../blocks/matcher.ts";
 import { PAGE_DIRTY_KEY } from "../blocks/utils.tsx";
 import { Context, context } from "../deco.ts";
 import {
@@ -109,6 +112,80 @@ const DEBUG_ENABLED = "enabled";
 const PAGE_CACHE_ENABLED = Deno.env.get("DECO_PAGE_CACHE_ENABLED") === "true";
 const PAGE_CACHE_CONTROL = Deno.env.get("DECO_PAGE_CACHE_CONTROL") ??
   "public, max-age=90, s-maxage=90, stale-while-revalidate=3600, stale-if-error=86400";
+
+// Cookies the framework itself emits. CDNs are expected to include these in
+// their custom cache key so cache identity tracks the variant, instead of
+// treating the Set-Cookie as a reason to bypass cache entirely.
+// Deferred to a getter to dodge a TDZ from the blocks/matcher.ts circular import.
+const frameworkCookiePrefixes = (): readonly string[] => [
+  DECO_MATCHER_PREFIX,
+  DECO_SEGMENT,
+];
+
+const isFrameworkCookieName = (name: string): boolean =>
+  frameworkCookiePrefixes().some((p) => name.startsWith(p));
+
+const hasNonFrameworkSetCookie = (headers: Headers): boolean => {
+  for (const c of getSetCookies(headers)) {
+    if (!isFrameworkCookieName(c.name)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const frameworkSetCookieNames = (headers: Headers): string[] =>
+  getSetCookies(headers)
+    .filter((c) => isFrameworkCookieName(c.name))
+    .map((c) => c.name);
+
+const NO_STORE = "no-store, no-cache, must-revalidate";
+
+export interface PageCacheDecisionInput {
+  flags: readonly { cacheable?: boolean }[];
+  isPageCacheAllowed: boolean;
+  /** false iff some loader vetoed caching (cache:"no-store" or null cache key). */
+  shouldCacheFromVary: boolean;
+}
+
+/**
+ * Mutates `headers` to set Cache-Control (and the Deco-Cache-Vary-Cookies
+ * hint header) according to the matcher-aware caching rules. Exported for
+ * direct testability; the request middleware is the only production caller.
+ */
+export const applyPageCacheDecision = (
+  headers: Headers,
+  input: PageCacheDecisionInput,
+): void => {
+  const hasForeignSetCookie = hasNonFrameworkSetCookie(headers);
+  const cacheDisqualified = hasForeignSetCookie || !input.shouldCacheFromVary;
+
+  if (cacheDisqualified) {
+    headers.set("Cache-Control", NO_STORE);
+    return;
+  }
+
+  if (!input.isPageCacheAllowed) {
+    return;
+  }
+
+  const allFlagsCacheable = input.flags.length > 0
+    ? input.flags.every((flag) => flag.cacheable === true)
+    : true;
+
+  if (!allFlagsCacheable) {
+    headers.set("Cache-Control", NO_STORE);
+    return;
+  }
+
+  if (!headers.has("Cache-Control")) {
+    headers.set("Cache-Control", PAGE_CACHE_CONTROL);
+  }
+  const frameworkNames = frameworkSetCookieNames(headers);
+  if (frameworkNames.length > 0) {
+    headers.set("Deco-Cache-Vary-Cookies", frameworkNames.join(", "));
+  }
+};
 
 export const DEBUG_QS = "__d";
 const addHours = (date: Date, h: number) => {
@@ -424,29 +501,16 @@ export const middlewareFor = <TAppManifest extends AppManifest = AppManifest>(
         }
       }
 
-      const hasSetCookie = getSetCookies(newHeaders).length > 0;
       const contentType = newHeaders.get("Content-Type") ?? "";
       const isHtmlResponse = contentType.includes("text/html");
       const isPageDirty = ctx.var.bag?.has(PAGE_DIRTY_KEY);
-
-      if (hasSetCookie) {
-        // Set-cookie present: never cache (same behavior as main)
-        newHeaders.set("Cache-Control", "no-store, no-cache, must-revalidate");
-      } else if (isHtmlResponse && PAGE_CACHE_ENABLED && !isPageDirty) {
-        const flags = ctx.var?.flags ?? [];
-        const allFlagsCacheable = flags.length > 0
-          ? flags.every((flag) => flag.cacheable === true)
-          : true;
-
-        if (!allFlagsCacheable) {
-          newHeaders.set(
-            "Cache-Control",
-            "no-store, no-cache, must-revalidate",
-          );
-        } else if (!newHeaders.has("Cache-Control")) {
-          newHeaders.set("Cache-Control", PAGE_CACHE_CONTROL);
-        }
-      }
+      const isPageCacheAllowed = isHtmlResponse && PAGE_CACHE_ENABLED &&
+        !isPageDirty;
+      applyPageCacheDecision(newHeaders, {
+        flags: ctx.var?.flags ?? [],
+        isPageCacheAllowed,
+        shouldCacheFromVary: ctx.var?.vary?.shouldCache !== false,
+      });
 
       // for some reason hono deletes content-type when response is not fresh.
       // which means that sometimes it will fail as headers are immutable.


### PR DESCRIPTION
## Summary

- Drops `Vary: cookie` from sticky-session matchers (`blocks/matcher.ts:218`) — the cookie *value* is what determines the variant; CDN cache keys target the specific cookie name, so `Vary: cookie` is overbroad and forces every CDN to bypass cache for matcher pages.
- Filters framework-managed Set-Cookies (`deco_matcher_*`, `deco_segment`) out of the kill-switch in `runtime/middleware.ts`. Only *foreign* Set-Cookies (cart, profile, etc.) downgrade `Cache-Control` to `no-store`.
- Wires `ctx.var.vary.shouldCache` into the full-page kill-switch (Change 2.5). Loaders that declare `cache: "no-store"` (the documented contract for personalizing loaders) now veto full-page caching the same way they already veto partial-section caching (see `runtime/routes/render.tsx:118-134` for the pre-existing reference pattern).
- Emits a `Deco-Cache-Vary-Cookies` hint header listing the framework cookies present, so CDN operators can discover which cookies belong in the custom cache key.
- Extracts the kill-switch logic into an exported pure `applyPageCacheDecision(headers, input)` for testability.
- Adds first-ever tests for `blocks/matcher.ts` and `runtime/middleware.ts`.

## Why

Customer Lojas Torra (~9% of fleet egress, ~5 TB/month) is 100% origin-bound on PDP/PLP/search/home despite a 70-83% overall hit rate. Every matcher-wrapped page emits `Vary: cookie` + `Cache-Control: no-store`, making the response uncacheable at any CDN regardless of cache rules. This is a fleet-wide issue — any deco-cx/deco site with active matchers (A/B tests, banners, sticky variants) has uncacheable pages.

After this PR, matcher-wrapped pages emit:
```
Vary: Accept-Encoding
Set-Cookie: deco_matcher_<hash>_<split>=...
Set-Cookie: deco_segment=...
Cache-Control: public, max-age=90, swr=3600, sie=86400
Deco-Cache-Vary-Cookies: deco_matcher_<hash>_<split>, deco_segment
```

The CDN can then cache them using a custom cache key that includes the matcher cookie values.

## Decision table (new)

| Condition | Cache-Control |
|---|---|
| Any foreign Set-Cookie (cart, profile, etc.) | `no-store, no-cache, must-revalidate` |
| Any loader marked `cache: "no-store"` (vary.shouldCache===false) | `no-store, no-cache, must-revalidate` |
| Any flag with `cacheable: false` | `no-store, no-cache, must-revalidate` |
| Matcher-only page, all loaders cacheable, HTML, PAGE_CACHE_ENABLED, not PAGE_DIRTY | `PAGE_CACHE_CONTROL` + `Deco-Cache-Vary-Cookies` hint |
| Anything else | headers untouched |

## Safety — landmines in `@deco/apps`

The old `Vary: cookie` + `no-store` sledgehammer also incidentally protected pages whose loaders read auth cookies and bake personalization into SSR HTML *without* emitting any Set-Cookie back. Change 2.5 replaces that protection with the loader-`cache: "no-store"` contract, but the contract is only as good as the loaders that respect it.

Pre-merge audit of `deco-cx/apps` found **~24 personalizing loaders** that read auth cookies but do NOT declare `cache: "no-store"`. Each is a silent data-leak vector after this PR. They need a companion PR in `deco-cx/apps`:

**VTEX (~14):** `user.ts`, `profile/getCurrentProfile.ts`, `profile/getProfileByEmail.ts`, `wishlist.ts`, `address/getUserAddresses.ts`, `payment/userPayments.ts`, `payment/paymentSystems.ts`, `orders/list.ts`, `orders/getById.ts`, `orders/orderplaced.ts`, `session/getSession.ts`, `session/getUserSessions.ts`, `masterdata/searchDocuments.ts`, `promotion/getPromotionById.ts`

**Linx (3):** `user.ts`, `cart.ts`, `wishlist/search.ts`
**Shopify (2):** `user.ts`, `cart.ts`
**WAP (3):** `user.ts`, `cart.ts`, `wishlist.ts`
**Vnda (1):** `cart.ts`
**Nuvemshop (1):** `cart.ts`

Per-file fix: add `export const cache = "no-store";`.

**Wake is already correctly protected** (`user.ts`, `cart.ts`, `wishlist.ts` declare no-store; partner-token loaders use null cacheKey which already flips `vary.shouldCache=false`).

**Sequencing constraint for stable promotion:** the `@deco/apps` companion PR must merge AND be released to npm AND consumed by canary sites BEFORE this framework PR can promote from `next` to stable.

## Canary gate for stable promotion

`next`-channel canary must include at least one site exercising **all three** logged-in patterns: (a) SSR user greeting, (b) SSR mini-cart with items, (c) per-user/B2B pricing baked into product cards. Run 24-48h two-session soak (auth as U1 in browser A, browse same pages in clean B). Stable promotion blocked until zero cross-user leakage observed.

## Test plan

- [x] `deno test --unstable-http -A blocks/matcher.test.ts runtime/middleware.test.ts` — 12 new tests pass
- [x] `deno test --unstable-http -A runtime/caches/ engine/ clients/ utils/` — all 26 existing tests still pass
- [x] `deno check live.ts` clean
- [ ] Deploy to a `next`-tagged site with active matcher; `curl -sI` → confirm `Vary: Accept-Encoding` (no `cookie`) and `Cache-Control: public, max-age=…`
- [ ] Companion `@deco/apps` PR adding `cache: "no-store"` to ~24 personalizing loaders (separate PR, blocker for stable)
- [ ] 24-48h two-session logged-in soak on canary sites covering SSR header/mini-cart/per-user-pricing (blocker for stable)
- [ ] End-to-end on Lojas Torra after stable: re-enable Cloudflare cache rule `b2cb2d5a5a784f0fb8eba5a39b3784c2`, confirm `cf-cache-status: HIT` on PDPs, stats lake shows bypass collapse from ~600k req/day to <50k

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make matcher-wrapped pages cacheable at the CDN edge. Removes overbroad cookie variance and keeps safety by letting loaders and flags veto caching.

- **New Features**
  - Removed `Vary: cookie` from sticky-session matchers; CDN can cache by specific matcher cookie values.
  - Framework `Set-Cookie`s (`deco_matcher_*`, `deco_segment`) no longer force `no-store`; only foreign cookies do.
  - Full-page cache kill-switch now respects loader veto via `ctx.var.vary.shouldCache` (e.g., loaders with `cache: "no-store"`).
  - Added `Deco-Cache-Vary-Cookies` header listing framework cookies to include in CDN cache keys.
  - Extracted `applyPageCacheDecision(headers, input)` for reuse and testing; added tests for matcher and middleware.

- **Migration**
  - CDN: include `deco_matcher_*` and `deco_segment` cookie values in the custom cache key for HTML pages.
  - Apps: ensure any personalizing loader exports `cache: "no-store"`; a companion `@deco/apps` PR is required before promoting this to stable.

<sup>Written for commit a6344688b9d732795dc3474da4234de5c797e2d4. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/deco/pull/1202?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

