### PR TITLE
feat(matcher): make matcher-wrapped pages cacheable at CDN edge

### DIFF
--- a/blocks/matcher.test.ts
+++ b/blocks/matcher.test.ts
@@ -1,0 +1,144 @@
+// deno-lint-ignore-file no-explicit-any
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { getSetCookies } from "../deps.ts";
+import matcherBlock, {
+  DECO_MATCHER_PREFIX,
+  type MatcherStickySessionModule,
+} from "./matcher.ts";
+
+const buildHttpCtx = (respHeaders: Headers) =>
+  ({
+    resolveChain: [{ type: "resolvable", value: "test-matcher-id" }],
+    context: {
+      state: {
+        response: { headers: respHeaders },
+        flags: [] as any[],
+        global: {},
+        bag: new WeakMap(),
+      },
+    },
+    request: new Request("https://example.com/"),
+    resolve: (() => {}) as any,
+    revision: undefined,
+    resolverId: "test-resolver",
+    monitoring: undefined,
+  }) as any;
+
+const buildMatchCtx = (request: Request) =>
+  ({
+    device: "desktop",
+    siteId: 1,
+    request,
+    resolve: (() => {}) as any,
+    invoke: (() => {}) as any,
+    response: { headers: new Headers() },
+    bag: new WeakMap(),
+  }) as any;
+
+Deno.test("sticky matcher flips result and sets cookie WITHOUT Vary: cookie", async () => {
+  const respHeaders = new Headers();
+  const httpCtx = buildHttpCtx(respHeaders);
+
+  const module: MatcherStickySessionModule = {
+    default: () => true,
+    sticky: "session",
+  };
+
+  const result = await resolverFor(module, httpCtx, new Request("https://example.com/"));
+
+  assertEquals(result, true);
+
+  const setCookies = getSetCookies(respHeaders);
+  assertEquals(setCookies.length, 1, "expected one Set-Cookie on respHeaders");
+  assert(
+    setCookies[0].name.startsWith(DECO_MATCHER_PREFIX),
+    `expected Set-Cookie name to start with ${DECO_MATCHER_PREFIX}, got ${
+      setCookies[0].name
+    }`,
+  );
+
+  const vary = respHeaders.get("vary") ?? "";
+  assert(
+    !vary.toLowerCase().includes("cookie"),
+    `expected Vary header to NOT contain "cookie", got: ${vary}`,
+  );
+});
+
+Deno.test("sticky matcher with matching cookie does NOT set a cookie or Vary", async () => {
+  const respHeaders = new Headers();
+  const httpCtx = buildHttpCtx(respHeaders);
+
+  const module: MatcherStickySessionModule = {
+    default: () => true,
+    sticky: "session",
+  };
+
+  // Build the cookie name the matcher would use, then set it on the request
+  // with a value that decodes to `true` so result === isMatchFromCookie.
+  const { Murmurhash3 } = await import("../deps.ts");
+  const h = new Murmurhash3();
+  h.hash("test-matcher-id");
+  const cookieName = `${DECO_MATCHER_PREFIX}${h.result()}`;
+  // cookieValue.build: btoa(id) + "@" + (result ? 1 : 0)
+  const cookieVal = `${btoa("test-matcher-id")}@1`;
+
+  const request = new Request("https://example.com/", {
+    headers: { cookie: `${cookieName}=${cookieVal}` },
+  });
+
+  const result = await resolverFor(module, httpCtx, request);
+  assertEquals(result, true);
+
+  assertEquals(
+    getSetCookies(respHeaders).length,
+    0,
+    "expected no Set-Cookie when cookie value already matches result",
+  );
+  assertEquals(
+    respHeaders.get("vary"),
+    null,
+    "expected no Vary header when nothing was emitted",
+  );
+});
+
+Deno.test("non-sticky matcher does not touch respHeaders", async () => {
+  const respHeaders = new Headers();
+  const httpCtx = buildHttpCtx(respHeaders);
+
+  const module = {
+    default: () => true,
+    sticky: "none" as const,
+  };
+
+  const result = await resolverFor(
+    module as any,
+    httpCtx,
+    new Request("https://example.com/"),
+  );
+  assertEquals(result, true);
+
+  assertEquals(getSetCookies(respHeaders).length, 0);
+  assertEquals(respHeaders.get("vary"), null);
+});
+
+// Regression guard: if anyone re-adds Vary: cookie inside the sticky branch,
+// this scan will fail. The string check is deliberately broad.
+Deno.test("matcher.ts source does not append Vary: cookie", async () => {
+  const src = await Deno.readTextFile(new URL("./matcher.ts", import.meta.url));
+  assert(
+    !/append\(\s*["']vary["']\s*,\s*["']cookie["']\s*\)/i.test(src),
+    "blocks/matcher.ts must not append Vary: cookie — that disables CDN caching",
+  );
+  // Sanity: ensure the cookie-setting code path is still there.
+  assertStringIncludes(src, "setCookie(respHeaders");
+});
+
+async function resolverFor(
+  module: MatcherStickySessionModule | { default: any; sticky: "none" },
+  httpCtx: any,
+  request: Request,
+): Promise<boolean> {
+  const adapt = matcherBlock.adapt as any;
+  const resolver = adapt(module, "test-matcher-id")({}, httpCtx);
+  return await resolver(buildMatchCtx(request));
+}

--- a/blocks/matcher.ts
+++ b/blocks/matcher.ts
@@ -215,7 +215,6 @@ const matcherBlock: Block<
             sameSite: "Lax",
             expires: date,
           });
-          respHeaders.append("vary", "cookie");
         }
       }
 

--- a/runtime/middleware.test.ts
+++ b/runtime/middleware.test.ts
@@ -1,0 +1,128 @@
+import { assert, assertEquals } from "@std/assert";
+import { setCookie } from "../utils/cookies.ts";
+import { DECO_MATCHER_PREFIX } from "../blocks/matcher.ts";
+import { applyPageCacheDecision, DECO_SEGMENT } from "./middleware.ts";
+
+const matcherCookie = `${DECO_MATCHER_PREFIX}1234567890_0.5`;
+
+const pageInput = {
+  flags: [],
+  isPageCacheAllowed: true,
+  shouldCacheFromVary: true,
+};
+
+Deno.test("no matcher, no Set-Cookie → public cache-control", () => {
+  const headers = new Headers({ "Content-Type": "text/html" });
+  applyPageCacheDecision(headers, pageInput);
+  const cc = headers.get("Cache-Control") ?? "";
+  assert(cc.startsWith("public,"), `expected public Cache-Control, got: ${cc}`);
+  assertEquals(headers.get("Deco-Cache-Vary-Cookies"), null);
+});
+
+Deno.test("matcher Set-Cookie only → public cache-control + hint header", () => {
+  const headers = new Headers({ "Content-Type": "text/html" });
+  setCookie(headers, { name: matcherCookie, value: "abc@1", path: "/" });
+  setCookie(headers, { name: DECO_SEGMENT, value: "%7B%7D", path: "/" });
+
+  applyPageCacheDecision(headers, pageInput);
+
+  const cc = headers.get("Cache-Control") ?? "";
+  assert(cc.startsWith("public,"), `expected public Cache-Control, got: ${cc}`);
+
+  const hint = headers.get("Deco-Cache-Vary-Cookies") ?? "";
+  assert(
+    hint.includes(matcherCookie),
+    `expected hint to include matcher cookie name, got: ${hint}`,
+  );
+  assert(
+    hint.includes(DECO_SEGMENT),
+    `expected hint to include deco_segment, got: ${hint}`,
+  );
+});
+
+Deno.test("foreign Set-Cookie → no-store (safety preserved)", () => {
+  const headers = new Headers({ "Content-Type": "text/html" });
+  setCookie(headers, { name: matcherCookie, value: "abc@1", path: "/" });
+  setCookie(headers, { name: "cart_count", value: "3", path: "/" });
+
+  applyPageCacheDecision(headers, pageInput);
+
+  assertEquals(
+    headers.get("Cache-Control"),
+    "no-store, no-cache, must-revalidate",
+  );
+  assertEquals(headers.get("Deco-Cache-Vary-Cookies"), null);
+});
+
+Deno.test("vary.shouldCache=false (personalizing loader) → no-store", () => {
+  const headers = new Headers({ "Content-Type": "text/html" });
+  setCookie(headers, { name: matcherCookie, value: "abc@1", path: "/" });
+
+  applyPageCacheDecision(headers, {
+    ...pageInput,
+    shouldCacheFromVary: false,
+  });
+
+  assertEquals(
+    headers.get("Cache-Control"),
+    "no-store, no-cache, must-revalidate",
+  );
+  assertEquals(headers.get("Deco-Cache-Vary-Cookies"), null);
+});
+
+Deno.test("flag with cacheable:false → no-store", () => {
+  const headers = new Headers({ "Content-Type": "text/html" });
+
+  applyPageCacheDecision(headers, {
+    flags: [{ cacheable: false }],
+    isPageCacheAllowed: true,
+    shouldCacheFromVary: true,
+  });
+
+  assertEquals(
+    headers.get("Cache-Control"),
+    "no-store, no-cache, must-revalidate",
+  );
+});
+
+Deno.test("isPageCacheAllowed=false → headers untouched", () => {
+  const headers = new Headers({ "Content-Type": "text/html" });
+  setCookie(headers, { name: matcherCookie, value: "abc@1", path: "/" });
+
+  applyPageCacheDecision(headers, {
+    ...pageInput,
+    isPageCacheAllowed: false,
+  });
+
+  assertEquals(headers.get("Cache-Control"), null);
+  assertEquals(headers.get("Deco-Cache-Vary-Cookies"), null);
+});
+
+Deno.test("respects pre-existing Cache-Control header", () => {
+  const headers = new Headers({
+    "Content-Type": "text/html",
+    "Cache-Control": "public, max-age=600",
+  });
+
+  applyPageCacheDecision(headers, pageInput);
+
+  assertEquals(headers.get("Cache-Control"), "public, max-age=600");
+});
+
+Deno.test(
+  "cacheDisqualified overrides a pre-existing Cache-Control header",
+  () => {
+    const headers = new Headers({
+      "Content-Type": "text/html",
+      "Cache-Control": "public, max-age=600",
+    });
+    setCookie(headers, { name: "session_id", value: "xyz", path: "/" });
+
+    applyPageCacheDecision(headers, pageInput);
+
+    assertEquals(
+      headers.get("Cache-Control"),
+      "no-store, no-cache, must-revalidate",
+    );
+  },
+);

--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -1,6 +1,9 @@
 // deno-lint-ignore-file no-explicit-any
 import { HTTPException } from "@hono/hono/http-exception";
-import { DECO_MATCHER_HEADER_QS } from "../blocks/matcher.ts";
+import {
+  DECO_MATCHER_HEADER_QS,
+  DECO_MATCHER_PREFIX,
+} from "../blocks/matcher.ts";
 import { PAGE_CACHE_ALLOWED_KEY } from "../blocks/utils.tsx";
 import { Context, context } from "../deco.ts";
 import {
@@ -108,6 +111,80 @@ const DEBUG_COOKIE = "deco_debug";
 const DEBUG_ENABLED = "enabled";
 const PAGE_CACHE_CONTROL = Deno.env.get("DECO_PAGE_CACHE_CONTROL") ??
   "public, max-age=90, stale-while-revalidate=3600, stale-if-error=86400";
+
+// Cookies the framework itself emits. CDNs are expected to include these in
+// their custom cache key so cache identity tracks the variant, instead of
+// treating the Set-Cookie as a reason to bypass cache entirely.
+// Deferred to a getter to dodge a TDZ from the blocks/matcher.ts circular import.
+const frameworkCookiePrefixes = (): readonly string[] => [
+  DECO_MATCHER_PREFIX,
+  DECO_SEGMENT,
+];
+
+const isFrameworkCookieName = (name: string): boolean =>
+  frameworkCookiePrefixes().some((p) => name.startsWith(p));
+
+const hasNonFrameworkSetCookie = (headers: Headers): boolean => {
+  for (const c of getSetCookies(headers)) {
+    if (!isFrameworkCookieName(c.name)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const frameworkSetCookieNames = (headers: Headers): string[] =>
+  getSetCookies(headers)
+    .filter((c) => isFrameworkCookieName(c.name))
+    .map((c) => c.name);
+
+const NO_STORE = "no-store, no-cache, must-revalidate";
+
+export interface PageCacheDecisionInput {
+  flags: readonly { cacheable?: boolean }[];
+  isPageCacheAllowed: boolean;
+  /** false iff some loader vetoed caching (cache:"no-store" or null cache key). */
+  shouldCacheFromVary: boolean;
+}
+
+/**
+ * Mutates `headers` to set Cache-Control (and the Deco-Cache-Vary-Cookies
+ * hint header) according to the matcher-aware caching rules. Exported for
+ * direct testability; the request middleware is the only production caller.
+ */
+export const applyPageCacheDecision = (
+  headers: Headers,
+  input: PageCacheDecisionInput,
+): void => {
+  const hasForeignSetCookie = hasNonFrameworkSetCookie(headers);
+  const cacheDisqualified = hasForeignSetCookie || !input.shouldCacheFromVary;
+
+  if (cacheDisqualified) {
+    headers.set("Cache-Control", NO_STORE);
+    return;
+  }
+
+  if (!input.isPageCacheAllowed) {
+    return;
+  }
+
+  const allFlagsCacheable = input.flags.length > 0
+    ? input.flags.every((flag) => flag.cacheable === true)
+    : true;
+
+  if (!allFlagsCacheable) {
+    headers.set("Cache-Control", NO_STORE);
+    return;
+  }
+
+  if (!headers.has("Cache-Control")) {
+    headers.set("Cache-Control", PAGE_CACHE_CONTROL);
+  }
+  const frameworkNames = frameworkSetCookieNames(headers);
+  if (frameworkNames.length > 0) {
+    headers.set("Deco-Cache-Vary-Cookies", frameworkNames.join(", "));
+  }
+};
 
 export const DEBUG_QS = "__d";
 const addHours = (date: Date, h: number) => {
@@ -426,29 +503,15 @@ export const middlewareFor = <TAppManifest extends AppManifest = AppManifest>(
         }
       }
 
-      const hasSetCookie = getSetCookies(newHeaders).length > 0;
       const contentType = newHeaders.get("Content-Type") ?? "";
       const isHtmlResponse = contentType.includes("text/html");
-      const isPageCacheAllowed = ctx.var.bag?.has(PAGE_CACHE_ALLOWED_KEY);
-
-      if (hasSetCookie) {
-        // Set-cookie present: never cache (same behavior as main)
-        newHeaders.set("Cache-Control", "no-store, no-cache, must-revalidate");
-      } else if (isHtmlResponse && isPageCacheAllowed) {
-        const flags = ctx.var?.flags ?? [];
-        const allFlagsCacheable = flags.length > 0
-          ? flags.every((flag) => flag.cacheable === true)
-          : true;
-
-        if (!allFlagsCacheable) {
-          newHeaders.set(
-            "Cache-Control",
-            "no-store, no-cache, must-revalidate",
-          );
-        } else if (!newHeaders.has("Cache-Control")) {
-          newHeaders.set("Cache-Control", PAGE_CACHE_CONTROL);
-        }
-      }
+      const isPageCacheAllowed = ctx.var.bag?.has(PAGE_CACHE_ALLOWED_KEY) ===
+          true && isHtmlResponse;
+      applyPageCacheDecision(newHeaders, {
+        flags: ctx.var?.flags ?? [],
+        isPageCacheAllowed,
+        shouldCacheFromVary: ctx.var?.vary?.shouldCache !== false,
+      });
 
       // for some reason hono deletes content-type when response is not fresh.
       // which means that sometimes it will fail as headers are immutable.


### PR DESCRIPTION
## Summary

- Drops `Vary: cookie` from sticky-session matchers (`blocks/matcher.ts`). The cookie *value* determines the variant; CDN cache keys target the specific cookie name, so `Vary: cookie` is overbroad and forces every CDN to bypass cache for matcher pages.
- Filters framework-managed Set-Cookies (`deco_matcher_*`, `deco_segment`) out of the kill-switch in `runtime/middleware.ts`. Only *foreign* Set-Cookies (cart, profile, etc.) downgrade `Cache-Control` to `no-store`.
- Wires `ctx.var.vary.shouldCache` into the full-page kill-switch. Loaders that declare `cache: "no-store"` (the documented contract for personalizing loaders) now veto full-page caching the same way they already veto partial-section caching at `runtime/routes/render.tsx:118-134`.
- Emits a `Deco-Cache-Vary-Cookies` hint header listing the framework cookies present, so CDN operators can discover which cookies belong in the custom cache key.
- Extracts the kill-switch logic into an exported pure `applyPageCacheDecision(headers, input)` for testability.
- Adds first-ever tests for `blocks/matcher.ts` and `runtime/middleware.ts`.

## Why

Customer Lojas Torra (~9% of fleet egress, ~5 TB/month) was 100% origin-bound on PDP/PLP/search/home despite a 70-83% overall hit rate. Every matcher-wrapped page emitted `Vary: cookie` + `Cache-Control: no-store`, making the response uncacheable at any CDN regardless of cache rules. This is a fleet-wide issue — any deco-cx/deco site with active matchers (A/B tests, banners, sticky variants) has uncacheable pages.

## Validation on `@deco/deco@1.200.1-next.2`

Already prereleased as `jsr:@deco/deco@1.200.1-next.2` (tag points to a separate branch with the same single commit + a prerelease version bump — kept off this PR to keep the diff clean for the bot's auto-bump).

Verified on Lojas Torra: matcher-wrapped pages now emit `Vary: Accept-Encoding` + `Cache-Control: public, max-age=90, swr=3600, sie=86400` + `Deco-Cache-Vary-Cookies: deco_matcher_<hash>, deco_segment`. CDN cache hit rate moved as expected once the Cloudflare cache rule was re-enabled. No cross-user leakage observed.

## Decision table (new)

| Condition | Cache-Control |
|---|---|
| Any foreign Set-Cookie (cart, profile, etc.) | `no-store, no-cache, must-revalidate` |
| Any loader marked `cache: "no-store"` (vary.shouldCache===false) | `no-store, no-cache, must-revalidate` |
| Any flag with `cacheable: false` | `no-store, no-cache, must-revalidate` |
| Matcher-only page, all loaders cacheable, HTML, PAGE_CACHE_ALLOWED_KEY set | `PAGE_CACHE_CONTROL` + `Deco-Cache-Vary-Cookies` hint |
| Anything else | headers untouched |

## Safety / sequencing

This relies on the loader-level `cache: "no-store"` contract being respected for personalizing loaders. Companion work in `deco-cx/apps` adds the declaration to 24 loaders that personalize SSR but didn't declare it (VTEX/Linx/Shopify/WAP/Vnda/Nuvemshop). That PR is being prepared in parallel and should be released before broader rollout. Wake was already correct (declares `no-store` on user/cart/wishlist; partner-token loaders use null cacheKey which already flips `vary.shouldCache=false`).

## Test plan

- [x] `deno test --unstable-http -A blocks/matcher.test.ts runtime/middleware.test.ts` — 12 new tests pass
- [x] `deno test --unstable-http -A runtime/caches/ engine/ clients/ utils/` — 26 pre-existing tests still pass
- [x] `deno check live.ts` clean
- [x] `1.200.1-next.2` prerelease published to JSR; published from a clean main-based branch (the original PR #1202 merged into a polluted `next` branch and was reverted)
- [x] End-to-end verified on Lojas Torra (`www.lojastorra.com.br`) with the prerelease — cache HITs, no cross-user leakage
- [ ] Companion `@deco/apps` PR adding `cache: "no-store"` to 24 personalizing loaders (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make matcher-wrapped pages cacheable at the CDN edge by removing `Vary: cookie` and only disabling caching when foreign cookies or personalizing loaders are present. Adds a hint header so CDNs can include framework cookies in the cache key.

- New Features
  - Dropped `Vary: cookie` from sticky matchers; framework cookies (`deco_matcher_*`, `deco_segment`) no longer force `no-store`.
  - Respects `ctx.var.vary.shouldCache`; loaders with `cache: "no-store"` veto full-page cache.
  - Emits `Deco-Cache-Vary-Cookies` listing framework cookies for CDN cache-key rules.

- Refactors
  - Extracted `applyPageCacheDecision(headers, input)`; added tests for `blocks/matcher.ts` and `runtime/middleware.ts`.
  - Page cache applies only to HTML with `PAGE_CACHE_ALLOWED_KEY`; foreign `Set-Cookie` or `cacheable: false` flags set `no-store`.

<sup>Written for commit ab02230734c5dd8c19203abec5ff03156fcdf71e. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/deco/pull/1203?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary `Vary: cookie` header from sticky-matcher cookie responses, improving cache efficiency.

* **Improvements**
  * Enhanced page cache decision logic to intelligently manage cache control headers based on cookie presence and cache eligibility, preventing cache issues with framework-specific cookies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/deco/pull/1203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->