### PR TITLE
feat(matcher): strip framework Set-Cookie from cacheable HTML responses

### DIFF
--- a/runtime/clientCookies.ts
+++ b/runtime/clientCookies.ts
@@ -85,3 +85,31 @@ export const injectScriptIntoHtml = (html: string, script: string): string => {
   }
   return html + script;
 };
+
+/**
+ * Remove framework-managed Set-Cookies (`deco_matcher_*`, `deco_segment`) from
+ * `headers` in place. Foreign Set-Cookies (cart, profile, etc.) are kept.
+ *
+ * Used after `buildClientCookieScript` has captured the framework cookies into
+ * an inline `<script>`. The script handles client-side persistence, which
+ * means the response header is redundant — and a CDN running under
+ * `respect_origin` cache mode (e.g. Cloudflare) treats any `Set-Cookie` as a
+ * personalization signal and refuses to cache the response. Stripping the
+ * framework Set-Cookies lets cold-visit responses cache cleanly.
+ *
+ * Trade-off: no-JS clients lose framework-cookie stickiness because they
+ * cannot execute the inline script. That is an accepted side effect — the
+ * matcher-stickiness model has been implicitly JS-dependent ever since 1.201.1.
+ */
+export const stripFrameworkSetCookies = (headers: Headers): void => {
+  const remaining = headers.getSetCookie().filter((raw) => {
+    const eq = raw.indexOf("=");
+    if (eq < 0) return true;
+    const name = raw.slice(0, eq);
+    return !frameworkCookiePrefixes().some((p) => name.startsWith(p));
+  });
+  headers.delete("Set-Cookie");
+  for (const raw of remaining) {
+    headers.append("Set-Cookie", raw);
+  }
+};

--- a/runtime/middleware.test.ts
+++ b/runtime/middleware.test.ts
@@ -5,6 +5,7 @@ import { applyPageCacheDecision, DECO_SEGMENT } from "./middleware.ts";
 import {
   buildClientCookieScript,
   injectScriptIntoHtml,
+  stripFrameworkSetCookies,
 } from "./clientCookies.ts";
 
 const matcherCookie = `${DECO_MATCHER_PREFIX}1234567890_0.5`;
@@ -254,5 +255,100 @@ Deno.test("injectScriptIntoHtml: prefers first </head> (handles embedded HTML)",
   assertEquals(
     out.slice(firstHeadClose - SCRIPT.length, firstHeadClose),
     SCRIPT,
+  );
+});
+
+// ---------- stripFrameworkSetCookies ----------
+
+Deno.test("stripFrameworkSetCookies: removes deco_matcher_* and deco_segment, keeps foreign", () => {
+  const headers = new Headers();
+  setCookie(headers, { name: matcherCookie, value: "abc@1", path: "/" });
+  setCookie(
+    headers,
+    { name: DECO_SEGMENT, value: '{"active":["foo"]}', path: "/" },
+    { encode: true },
+  );
+  setCookie(headers, { name: "cart_count", value: "3", path: "/" });
+  setCookie(headers, { name: "session_id", value: "xyz", path: "/" });
+
+  stripFrameworkSetCookies(headers);
+
+  const names = headers.getSetCookie().map((raw) => {
+    const eq = raw.indexOf("=");
+    return raw.slice(0, eq);
+  });
+  assertEquals(names.sort(), ["cart_count", "session_id"]);
+});
+
+Deno.test("stripFrameworkSetCookies: no-op when there are no Set-Cookie headers", () => {
+  const headers = new Headers({ "Content-Type": "text/html" });
+  stripFrameworkSetCookies(headers);
+  assertEquals(headers.getSetCookie().length, 0);
+  assertEquals(headers.get("Content-Type"), "text/html");
+});
+
+Deno.test("stripFrameworkSetCookies: no-op when only foreign Set-Cookies present", () => {
+  const headers = new Headers();
+  setCookie(headers, { name: "cart_count", value: "3", path: "/" });
+  setCookie(headers, { name: "session_id", value: "xyz", path: "/" });
+
+  stripFrameworkSetCookies(headers);
+
+  assertEquals(headers.getSetCookie().length, 2);
+});
+
+Deno.test("flow: build script captures cookies, strip removes them, hint header preserved", () => {
+  // Simulate the production middleware flow:
+  // 1. applyPageCacheDecision runs first — sets the Deco-Cache-Vary-Cookies hint.
+  // 2. buildClientCookieScript reads the framework Set-Cookies into a <script>.
+  // 3. stripFrameworkSetCookies removes the now-redundant headers.
+  // Final state: hint header preserved, script has the original cookie bytes,
+  // response has no framework Set-Cookies.
+  const headers = new Headers({ "Content-Type": "text/html" });
+  setCookie(headers, { name: matcherCookie, value: "abc@1", path: "/" });
+  setCookie(
+    headers,
+    { name: DECO_SEGMENT, value: '{"active":["foo"]}', path: "/" },
+    { encode: true },
+  );
+  setCookie(headers, { name: "cart_count", value: "3", path: "/" });
+
+  // Step 1: apply page-cache decision (this also sets the hint header).
+  // Foreign Set-Cookie present → cache disqualified → no-store. So we test
+  // the hint header path with foreign cookie removed.
+  // Build a separate headers object without the foreign cookie, run the
+  // decision so the hint header is set, then add back the foreign cookie
+  // and proceed.
+  const headersForDecision = new Headers({ "Content-Type": "text/html" });
+  setCookie(headersForDecision, {
+    name: matcherCookie,
+    value: "abc@1",
+    path: "/",
+  });
+  setCookie(
+    headersForDecision,
+    { name: DECO_SEGMENT, value: '{"active":["foo"]}', path: "/" },
+    { encode: true },
+  );
+  applyPageCacheDecision(headersForDecision, pageInput);
+  const hint = headersForDecision.get("Deco-Cache-Vary-Cookies");
+  assert(hint !== null, "expected hint header from applyPageCacheDecision");
+
+  // Step 2: build the script from the (now decided) headers.
+  const script = buildClientCookieScript(headersForDecision);
+  assert(script !== null);
+  assertStringIncludes(script, matcherCookie);
+  assertStringIncludes(script, DECO_SEGMENT);
+
+  // Step 3: strip framework Set-Cookies — script already captured them.
+  stripFrameworkSetCookies(headersForDecision);
+
+  // Verify final state.
+  const remaining = headersForDecision.getSetCookie();
+  assertEquals(remaining.length, 0, "expected no Set-Cookies remaining");
+  assertEquals(
+    headersForDecision.get("Deco-Cache-Vary-Cookies"),
+    hint,
+    "hint header must survive the strip",
   );
 });

--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -31,6 +31,7 @@ import type {
 import {
   buildClientCookieScript,
   injectScriptIntoHtml,
+  stripFrameworkSetCookies,
 } from "./clientCookies.ts";
 import { setLogger } from "./fetch/fetchLog.ts";
 import { liveness } from "./middlewares/liveness.ts";
@@ -533,6 +534,13 @@ export const middlewareFor = <TAppManifest extends AppManifest = AppManifest>(
       ctx.res = undefined;
       if (cookieScript) {
         const html = await initialResponse.text();
+        // Script captured the framework cookies; remove the now-redundant
+        // Set-Cookie headers so CDNs under `respect_origin` cache mode treat
+        // the response as non-personalized and cache cold-visit responses.
+        // The Deco-Cache-Vary-Cookies hint header (set by applyPageCacheDecision
+        // above) is preserved so operators still know which cookies belong in
+        // the custom cache key.
+        stripFrameworkSetCookies(newHeaders);
         ctx.res = new Response(injectScriptIntoHtml(html, cookieScript), {
           status: responseStatus,
           headers: newHeaders,


### PR DESCRIPTION
## Summary

Removes framework Set-Cookie response headers (`deco_matcher_*`, `deco_segment`) on HTML 200 responses where the inline cookie-setting script (from 1.201.1) was injected. The script handles cookie persistence client-side; the response headers become redundant — and they currently prevent CDNs running under `respect_origin` cache mode from caching the response.

## Why

The CDN team is moving Cloudflare's fleet cache rule from `cache: true + edge_ttl: override_origin` (force-cache, strip Set-Cookie) to `respect_origin` (honor origin headers). Under `respect_origin`:

- **Cold visitor** (no cookie) → origin emits Set-Cookie to seed the matcher variant → CF treats as personalized → `cf-cache-status: BYPASS`. **Cold visits never populate the cache.**
- **Warm visitor** (matching cookie) → no Set-Cookie (framework already correctly suppresses) → CF caches.

Net: cache only fills via repeat visitors. Cold first-visit traffic always slow. Torra PDP HIT% dropped to ~0% in their respect_origin tests.

Since 1.201.1's inline `<script>document.cookie=…</script>` already mirrors framework cookies into the HTML body, the `Set-Cookie` header is redundant for HTML 200 responses. Stripping it removes the personalization signal so respect_origin can cache cold-visit responses.

## Change

`runtime/clientCookies.ts` — add `stripFrameworkSetCookies(headers)` that filters Set-Cookie headers by framework prefix, deletes all Set-Cookie entries from `headers`, and re-appends only the foreign ones.

`runtime/middleware.ts` — call `stripFrameworkSetCookies(newHeaders)` after the inline script has been built (so the script captures the original cookie bytes) but before constructing the final Response.

Ordering in middleware:
1. `applyPageCacheDecision` runs first — sets `Cache-Control` and the `Deco-Cache-Vary-Cookies` hint (reads framework Set-Cookies at that point).
2. `buildClientCookieScript` reads framework Set-Cookies and produces the script.
3. `stripFrameworkSetCookies` removes the framework Set-Cookie headers.
4. New `Response` constructed: HTML body has the script, headers have `Cache-Control: public, …` + `Deco-Cache-Vary-Cookies: deco_matcher_…, deco_segment` (hint preserved), no `Set-Cookie` for framework cookies.

Non-HTML responses and non-200 responses are unchanged.

## Final response shape after this PR

```
HTTP/1.1 200 OK
Content-Type: text/html
Cache-Control: public, max-age=90, stale-while-revalidate=3600, stale-if-error=86400
Deco-Cache-Vary-Cookies: deco_matcher_<hash>, deco_segment
Vary: Accept-Encoding
# NO Set-Cookie: deco_matcher_*
# NO Set-Cookie: deco_segment

<html><head>…<script>document.cookie="deco_matcher_<hash>=…@1; path=/; max-age=2592000; samesite=Lax";document.cookie="deco_segment=…; path=/; max-age=2592000; samesite=Lax";</script></head>…
```

## Trade-off (acknowledged)

No-JS clients (curl without cookie jar, RSS readers, very old crawlers, accessibility tools with JS off) lose framework-cookie stickiness for all sites on 1.202.0+. They re-randomize variants on every request because they can't execute the inline script.

Acceptable: matcher-stickiness has been implicitly JS-dependent since 1.201.1 (CDN-cached responses with stripped Set-Cookie only re-set the cookie via the inline script). This change makes that dependency explicit and unblocks CDN-side fleet-wide caching under respect_origin.

## Test plan

- [x] `deno test` — 22 middleware + 4 matcher tests pass (4 new strip-related tests)
- [x] `deno test runtime/caches/ engine/ clients/ utils/` — 26 existing tests still pass
- [x] `deno check live.ts` clean
- [x] `deno fmt` clean
- [ ] Deploy 1.202.0 to Lojas Torra. Confirm via `curl -i` (cache-busted):
  - `cache-control: public, max-age=…`
  - `deco-cache-vary-cookies: deco_matcher_…, deco_segment`
  - NO `set-cookie: deco_matcher_*`, NO `set-cookie: deco_segment`
  - `<script>document.cookie="deco_matcher_…";…</script>` in HTML before `</head>`
- [ ] Browser test: `document.cookie` lists framework cookies (set via the script).
- [ ] CDN team flips torra rule from `override_origin` to `respect_origin`. Confirm cold curl shows `cf-cache-status: MISS` (cache populating) then second cold curl → `HIT`.

## Out of scope (filed for follow-up)

- **Torra PLP `no-store` regression** (Issue B in the CDN team's brief). Framework gate is working correctly. Root cause is likely a personalizing loader on torra's PLP Header/Footer (e.g. VTEX `getCurrentProfile`/`cart`) declared `cache: "no-store"` per the @deco/apps PR, flipping `vary.shouldCache=false` → no-store. Or VTEX middleware not setting `PAGE_CACHE_ALLOWED_KEY` on PLP routes. Needs torra-specific debugging on the apps side.
- **`X-Cache-Profile` response header** (Issue C). `@decocms/start` already emits it; the Fresh runtime doesn't. Future framework enhancement; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips framework Set-Cookie headers on cacheable HTML 200 responses when the inline cookie script is injected, so CDNs using respect_origin can cache cold visits. Non-HTML and non-200 responses are unchanged.

- New Features
  - Added `stripFrameworkSetCookies(headers)` to remove `deco_matcher_*` and `deco_segment` while keeping other cookies.
  - Middleware runs it after `buildClientCookieScript` and before creating the final response; preserves `Deco-Cache-Vary-Cookies`.
  - Unlocks caching for first-time visitors under respect_origin by removing the personalization signal from Set-Cookie.
  - Trade-off: no-JS clients lose matcher stickiness.

<sup>Written for commit c47ddcd2be8ae12999c61020f2219d21354706b3. Summary will update on new commits. <a href="https://cubic.dev/pr/deco-cx/deco/pull/1205?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved cookie management to better support response caching by handling framework-managed and application cookies separately.

* **Tests**
  * Added comprehensive test coverage for cookie handling and middleware integration scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deco-cx/deco/pull/1205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->