### PR TITLE
fix(daemon): robust sandbox cold-start (eager warm + fast-503 + optional warmup)

### DIFF
--- a/blocks/loader.bench.ts
+++ b/blocks/loader.bench.ts
@@ -1,4 +1,8 @@
-import hash from "https://esm.sh/v135/object-hash@3.0.0";
+// `?no-dts` skips esm.sh's bundled type definitions. Upstream `@types/object-hash`
+// uses a CommonJS `export =` with no synthetic default, which makes Deno's
+// type-check fail with TS1192 ("no default export") on a fresh fetch. The types
+// aren't needed in this benchmark, so dropping them keeps CI deterministic.
+import hash from "https://esm.sh/v135/object-hash@3.0.0?no-dts";
 
 const props = {
   randomObject: {

--- a/daemon/main.ts
+++ b/daemon/main.ts
@@ -38,6 +38,8 @@ import { register, type TunnelConnection } from "./tunnel.ts";
 import {
   createWorker,
   resetWorkerState,
+  WARMUP_HEADER,
+  WARMUP_TOKEN,
   worker,
   type WorkerOptions,
 } from "./worker.ts";
@@ -619,15 +621,17 @@ if (SANDBOX_MODE) {
       // entry route before the first real user request arrives — otherwise that
       // compile + render is paid inline on the user's first hit. Off by default
       // because it triggers one synthetic homepage render (and any server-side
-      // analytics it fires); the x-deco-warmup header lets the site opt out of
-      // side effects. Enable with DECO_SANDBOX_WARMUP=true.
+      // analytics it fires); the x-deco-warmup header (carrying the per-process
+      // token) marks it as our internal warmup so it bypasses the fast-503 gate
+      // and the site can opt out of side effects. Enable with
+      // DECO_SANDBOX_WARMUP=true.
       if (Deno.env.get("DECO_SANDBOX_WARMUP") === "true") {
         const { app: siteApp, gitReady } = currentSite;
         gitReady
           .then(() =>
             siteApp.fetch(
               new Request("http://localhost/", {
-                headers: { "x-deco-warmup": "1" },
+                headers: { [WARMUP_HEADER]: WARMUP_TOKEN },
               }),
             )
           )

--- a/daemon/main.ts
+++ b/daemon/main.ts
@@ -614,6 +614,29 @@ if (SANDBOX_MODE) {
       // below still awaits gitReady without re-triggering init.
       currentSite.ensureStarted();
 
+      // Optional deep warmup: once the repo is cloned, issue a single internal
+      // request to the site root so the dev server JIT-compiles and renders the
+      // entry route before the first real user request arrives — otherwise that
+      // compile + render is paid inline on the user's first hit. Off by default
+      // because it triggers one synthetic homepage render (and any server-side
+      // analytics it fires); the x-deco-warmup header lets the site opt out of
+      // side effects. Enable with DECO_SANDBOX_WARMUP=true.
+      if (Deno.env.get("DECO_SANDBOX_WARMUP") === "true") {
+        const { app: siteApp, gitReady } = currentSite;
+        gitReady
+          .then(() =>
+            siteApp.fetch(
+              new Request("http://localhost/", {
+                headers: { "x-deco-warmup": "1" },
+              }),
+            )
+          )
+          .then(() => console.log("[sandbox] warmup request completed"))
+          .catch((err) =>
+            console.error("[sandbox] warmup request failed:", err)
+          );
+      }
+
       // Always create AI handlers — OAuth can be used when no API key is set
       aiHandlers = createAIHandlers({
         cwd: Deno.cwd(),

--- a/daemon/main.ts
+++ b/daemon/main.ts
@@ -604,6 +604,16 @@ if (SANDBOX_MODE) {
         branch,
       });
 
+      // Eagerly kick off deps init (git clone, build-cache download, manifest
+      // + blocks generation) as soon as the env is assigned, instead of
+      // waiting for the first HTTP request to trigger it lazily. On a freshly
+      // claimed sandbox this cold-start work can take tens of seconds; paying
+      // it inline on the first request risks exceeding the CDN origin timeout
+      // and surfacing to the user as a 504 (the client abort is logged as a
+      // 499 at the ingress). ensureStarted() is idempotent — the AI-task path
+      // below still awaits gitReady without re-triggering init.
+      currentSite.ensureStarted();
+
       // Always create AI handlers — OAuth can be used when no API key is set
       aiHandlers = createAIHandlers({
         cwd: Deno.cwd(),
@@ -630,9 +640,6 @@ if (SANDBOX_MODE) {
           Boolean(envs?.ANTHROPIC_PROXY_URL);
         if (hasApiKey) {
           const handlers = aiHandlers;
-          // Eagerly trigger deps init (git clone, etc.) so the task doesn't wait
-          // for the first HTTP request to arrive
-          currentSite.ensureStarted();
           // Wait for git clone to finish before starting the AI task,
           // since the task needs a valid repo (git rev-parse HEAD, etc.)
           currentSite.gitReady.then(async () => {

--- a/daemon/worker.ts
+++ b/daemon/worker.ts
@@ -1,6 +1,14 @@
 import { Hono } from "@hono/hono";
 import { broadcast } from "./sse/channel.ts";
+import { SANDBOX_MODE } from "./daemon.ts";
+import { delay } from "../utils/async.ts";
 import { DenoRun } from "./workers/denoRun.ts";
+
+// How long a request waits for a cold dev server to come up before we stop
+// holding the connection open and reply 503 (SANDBOX_MODE only). Kept well
+// under the CDN origin timeout so the env ingress can bounce to the activator
+// and retry, instead of the request hanging until the CDN returns a 504.
+const SANDBOX_READY_GATE_MS = 5_000;
 
 export interface WorkerOptions {
   persist: () => void;
@@ -97,7 +105,29 @@ export const createWorker = (optionsProvider: WorkerOptionsProvider) => {
   // ensure isolate is up and running
   app.use("/*", async (c, next) => {
     try {
-      await worker();
+      if (SANDBOX_MODE) {
+        // worker() boots the dev server (idempotent) and resolves once it is
+        // listening. On a cold sandbox that can take a while; rather than hold
+        // the request open the whole time — which lets the CDN time out as a
+        // 504 — we fail fast with 503 after SANDBOX_READY_GATE_MS. The env
+        // ingress (error_page 502 503 -> @admin) then bounces the client to
+        // the activator and retries. The boot keeps running in the background
+        // (watchMeta also drives it), so a retry lands on a warm worker.
+        const ready = worker().then(() => true, () => false);
+        const isReady = await Promise.race([
+          ready,
+          delay(SANDBOX_READY_GATE_MS).then(() => false),
+        ]);
+        if (!isReady) {
+          c.res = new Response("Sandbox environment is starting", {
+            status: 503,
+            headers: { "retry-after": "2" },
+          });
+          return;
+        }
+      } else {
+        await worker();
+      }
       await next();
     } catch (error) {
       console.error(error);

--- a/daemon/worker.ts
+++ b/daemon/worker.ts
@@ -105,7 +105,12 @@ export const createWorker = (optionsProvider: WorkerOptionsProvider) => {
   // ensure isolate is up and running
   app.use("/*", async (c, next) => {
     try {
-      if (SANDBOX_MODE) {
+      // Warmup requests (and normal, non-sandbox mode) keep the original
+      // blocking behavior: wait for the worker to be fully ready, then proxy.
+      // This is what lets the warmup request actually JIT-compile and render
+      // the entry route — a fast-503 gate would skip the render entirely.
+      const isWarmup = c.req.header("x-deco-warmup") === "1";
+      if (SANDBOX_MODE && !isWarmup) {
         // worker() boots the dev server (idempotent) and resolves once it is
         // listening. On a cold sandbox that can take a while; rather than hold
         // the request open the whole time — which lets the CDN time out as a
@@ -119,6 +124,15 @@ export const createWorker = (optionsProvider: WorkerOptionsProvider) => {
           delay(SANDBOX_READY_GATE_MS).then(() => false),
         ]);
         if (!isReady) {
+          // A permanent init failure (e.g. no dev.ts) keeps returning 424 as
+          // before: bouncing it to the activator would loop forever, since the
+          // env can never become ready. Only a still-booting worker gets 503.
+          if (isWorkerDisabled()) {
+            c.res = new Response(`Error while starting worker`, {
+              status: 424,
+            });
+            return;
+          }
           c.res = new Response("Sandbox environment is starting", {
             status: 503,
             headers: { "retry-after": "2" },

--- a/daemon/worker.ts
+++ b/daemon/worker.ts
@@ -10,6 +10,14 @@ import { DenoRun } from "./workers/denoRun.ts";
 // and retry, instead of the request hanging until the CDN returns a 504.
 const SANDBOX_READY_GATE_MS = 5_000;
 
+// Header + per-process token used by the daemon's own internal warmup request
+// to bypass the fast-503 gate (it must block until the worker is ready so it
+// can actually render the entry route). The token is random per process so a
+// forged `x-deco-warmup` header on public traffic can't match and is treated
+// as a normal request.
+export const WARMUP_HEADER = "x-deco-warmup";
+export const WARMUP_TOKEN: string = crypto.randomUUID();
+
 export interface WorkerOptions {
   persist: () => void;
   command: Deno.Command;
@@ -109,34 +117,38 @@ export const createWorker = (optionsProvider: WorkerOptionsProvider) => {
       // blocking behavior: wait for the worker to be fully ready, then proxy.
       // This is what lets the warmup request actually JIT-compile and render
       // the entry route — a fast-503 gate would skip the render entirely.
-      const isWarmup = c.req.header("x-deco-warmup") === "1";
+      const isWarmup = c.req.header(WARMUP_HEADER) === WARMUP_TOKEN;
       if (SANDBOX_MODE && !isWarmup) {
         // worker() boots the dev server (idempotent) and resolves once it is
-        // listening. On a cold sandbox that can take a while; rather than hold
-        // the request open the whole time — which lets the CDN time out as a
-        // 504 — we fail fast with 503 after SANDBOX_READY_GATE_MS. The env
-        // ingress (error_page 502 503 -> @admin) then bounces the client to
-        // the activator and retries. The boot keeps running in the background
-        // (watchMeta also drives it), so a retry lands on a warm worker.
-        const ready = worker().then(() => true, () => false);
-        const isReady = await Promise.race([
-          ready,
-          delay(SANDBOX_READY_GATE_MS).then(() => false),
+        // listening; it rejects if the boot fails (missing dev.ts, crash, ...).
+        // On a cold sandbox the boot can take a while, so rather than hold the
+        // request open the whole time — which lets the CDN time out as a 504 —
+        // we race it against a short gate:
+        //   - still booting at the gate  -> 503 (retryable): the env ingress
+        //     (error_page 502 503 -> @admin) bounces to the activator and the
+        //     boot keeps running in the background, so the retry lands warm.
+        //   - boot rejected              -> 424 (non-retryable): a real failure
+        //     that won't fix itself, so we don't loop the activator forever.
+        // Mapping the rejection inline (not throwing) keeps the loser of the
+        // race from surfacing as an unhandled rejection once we've replied.
+        const boot = worker().then(
+          () => "ready" as const,
+          (err: unknown) => ({ err }),
+        );
+        const outcome = await Promise.race([
+          boot,
+          delay(SANDBOX_READY_GATE_MS).then(() => "timeout" as const),
         ]);
-        if (!isReady) {
-          // A permanent init failure (e.g. no dev.ts) keeps returning 424 as
-          // before: bouncing it to the activator would loop forever, since the
-          // env can never become ready. Only a still-booting worker gets 503.
-          if (isWorkerDisabled()) {
-            c.res = new Response(`Error while starting worker`, {
-              status: 424,
-            });
-            return;
-          }
+        if (outcome === "timeout") {
           c.res = new Response("Sandbox environment is starting", {
             status: 503,
             headers: { "retry-after": "2" },
           });
+          return;
+        }
+        if (typeof outcome === "object") {
+          console.error(outcome.err);
+          c.res = new Response(`Error while starting worker`, { status: 424 });
           return;
         }
       } else {


### PR DESCRIPTION
## Problem

Sandbox/preview environments (`eks-envs`) intermittently return **504** to the user even though the pod is healthy. Concrete case: `envs-farmrio--s3a7o0.decocdn.com` — slow to open, then 504 before finishing; the nginx metric shows **499** (client closed the connection).

### Diagnosis

- The `eks-envs` nginx has `proxy-read-timeout: 3600` (intentional, for SSE/HMR and the daemon `/watch` endpoints), so **nginx is not the one timing out**. The cut happens at **Cloudflare** (`decocdn.com`) on the origin timeout (~100s) → **504** to the browser, **499** at the ingress.
- The env is served in **dev mode**; on a cold/idle pod the cold-start work is paid **inline on the first request**, and the daemon **holds the connection open** for the whole boot (`worker()` → `waitUntilReady`, default 60s), so a slow boot/render runs straight past the CDN timeout.
- For a plain env deploy, `currentSite.ensureStarted()` (git clone, build-cache download, manifest + blocks generation — and, via `watchMeta`, the dev-server boot) was only triggered when the deploy carried an AI task. Otherwise it ran lazily on the first request.

## Change — three coordinated pieces (all `SANDBOX_MODE`-scoped)

1. **Eager warm on deploy** — hoist `currentSite.ensureStarted()` to run unconditionally right after the site is assigned. This moves git clone / cache / manifest **and the dev-server boot** (`watchMeta` calls `worker()`) off the first request's critical path. Idempotent; the AI-task path is unchanged.

2. **Fast-503 while the worker boots** (`worker.ts`) — instead of holding the request open for the entire cold boot (which lets the CDN time out as a 504), reply **503** after 5s. The env ingress (`error_page 502 503 -> @admin`) then bounces the client to the activator and retries; the boot keeps running in the background, so the retry lands on a warm worker. **Normal (non-sandbox) mode keeps awaiting `worker()` as before** — no behavior change outside sandboxes.

3. **Optional deep warmup** (`DECO_SANDBOX_WARMUP=true`, **off by default**) — after git clone, fire one internal `GET /` so the dev server JIT-compiles and renders the entry route before the first real request. Carries an `x-deco-warmup` header so the site can skip side effects. Off by default because it triggers one synthetic homepage render (and any server-side analytics it fires).

### How they combine

```
deploy/claim ─▶ ensureStarted()  → deps + dev-server boot start eagerly
              ─▶ (optional) warmup GET / → entry route compiled before user
first request ─▶ if worker not ready in 5s → 503 → activator bounce → retry warm
```

(1)+(2) make the common case robust without holding connections open; (3) closes the remaining first-render gap when enabled.

## Caveats / follow-ups

- Even with all three, a deep uncached route whose legitimate render exceeds ~100s (e.g. slow VTEX upstream) can still time out — that's an app/upstream concern (cache/SWR), not infra cold-start.
- Requires an image release of `ghcr.io/deco-cx/deco/ai` and a tag bump in `infra_applications` (the `eks-envs` SandboxTemplate) to take effect in production. `DECO_SANDBOX_WARMUP` would be set there to enable piece 3.

### Ruled out during diagnosis
- A readinessProbe on the SandboxTemplate would break the warmpool — free (unclaimed) pods serve a legitimate 503 until claimed, so the pool would never reach `readyReplicas`.
- Lowering `proxy-read-timeout` would break SSE/HMR (it is 3600 on purpose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional sandbox warmup that issues an internal request at startup to prepare JIT/first-render and logs success/failure.

* **Improvements**
  * Eager startup initialization to run git/setup, manifest and metadata generation, and start file watching sooner.
  * Sandbox readiness gate that returns HTTP 503 with retry-after when startup is delayed; warmup requests bypass the gate and continue to wait.

* **Chores**
  * Benchmark import adjusted to avoid type-check issues on fresh fetch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->