### PR TITLE
fix(cache): pin ioredis to exact version 5.10.1

### DIFF
--- a/runtime/caches/redis.ts
+++ b/runtime/caches/redis.ts
@@ -6,7 +6,7 @@ import {
   withCacheNamespace,
 } from "./utils.ts";
 import { Buffer } from "node:buffer";
-import { Redis } from "npm:ioredis@^5.10.1";
+import { Redis } from "npm:ioredis@5.10.1";
 import { compress as lz4Compress, decompress as lz4Decompress } from "jsr:@denosaurs/lz4@^0.1.4";
 import {
   compress as zstdCompress,


### PR DESCRIPTION
## Summary
- Pin `ioredis` dependency from `^5.10.1` to `5.10.1` to avoid unexpected upgrades that could introduce breaking changes in the Redis cache layer.

## Test plan
- [ ] Verify Redis cache operations work correctly with the pinned version
- [ ] Confirm no regressions in cache read/write flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `ioredis` to `5.10.1` to avoid unexpected upgrades that could break the Redis cache. This ensures consistent cache behavior across builds.

<sup>Written for commit 242f0c46fd4f9d0bd953e9a4ab04cae373fc752b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/deco/pull/1207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency configuration to ensure more consistent and reliable cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->