### PR TITLE
feat(render): section-controlled JSON output via renderJson export

### DIFF
--- a/hooks/mod.ts
+++ b/hooks/mod.ts
@@ -8,6 +8,7 @@ export {
   addAllowedQS,
   addBlockedQS,
   addBlockedQS as unstable_blockUseSectionHrefQueryStrings,
+  computeRenderCb,
   useSection,
 } from "./useSection.ts";
 export { useSetEarlyHints } from "./useSetEarlyHints.ts";

--- a/hooks/useSection.ts
+++ b/hooks/useSection.ts
@@ -94,6 +94,36 @@ const createStableHref = (href: string): string => {
   return hrefUrl.href;
 };
 
+export interface RenderCbInput {
+  revision: unknown;
+  vary: unknown;
+  href: string;
+  deploymentId?: string;
+}
+
+/**
+ * Cache-bust value for `/deco/render` URLs. Single source of truth shared by
+ * `useSection` (web partials) and JSON serialization consumers (e.g. the
+ * website app's ?renderJson handler) — both sides MUST produce identical
+ * values or web/JSON cache invalidation diverges.
+ *
+ * `revision`/`vary` join as-is (undefined → "undefined") to preserve the
+ * historical recipe byte-for-byte. Shared `hasher` is safe ONLY because this
+ * function is fully synchronous — no await between hash() and reset().
+ */
+export const computeRenderCb = (input: RenderCbInput): string => {
+  const cbString = [
+    input.revision,
+    input.vary,
+    createStableHref(input.href),
+    input.deploymentId,
+  ].join("|");
+  hasher.hash(cbString);
+  const cb = `${hasher.result()}`;
+  hasher.reset();
+  return cb;
+};
+
 export type Options<P> = {
   /** Section props partially applied */
   props?: Partial<P extends ComponentType<infer K> ? K : P>;
@@ -119,15 +149,12 @@ export const useSection = <P>(
 
   const hrefParam = href ?? request.url;
   const stableHref = createStableHref(hrefParam);
-  const cbString = [
-    revisionId,
+  const cb = computeRenderCb({
+    revision: revisionId,
     vary,
-    stableHref,
-    ctx?.deploymentId,
-  ].join("|");
-  hasher.hash(cbString);
-  const cb = hasher.result();
-  hasher.reset();
+    href: hrefParam,
+    deploymentId: ctx?.deploymentId,
+  });
 
   const params = new URLSearchParams([
     ["props", JSON.stringify(props)],

--- a/mod.ts
+++ b/mod.ts
@@ -45,6 +45,16 @@ export { type DecoRouteState } from "./runtime/middleware.ts";
 export * from "./runtime/mod.ts";
 export { Deco } from "./runtime/mod.ts";
 export type { PageData } from "./runtime/mod.ts";
+export {
+  buildLazyUrl,
+  serializeResolvedSection,
+} from "./runtime/routes/serialize-section.ts";
+export type {
+  LazyUrlContext,
+  ResolvedSection,
+  SerializedSection,
+} from "./runtime/routes/serialize-section.ts";
+export { Murmurhash3 } from "./deps.ts";
 export * from "./types.ts";
 export { allowCorsFor } from "./utils/http.ts";
 export type { StreamProps } from "./utils/invoke.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -47,11 +47,15 @@ export { Deco } from "./runtime/mod.ts";
 export type { PageData } from "./runtime/mod.ts";
 export {
   buildLazyUrl,
+  sectionModuleLookup,
   serializeResolvedSection,
 } from "./runtime/routes/serialize-section.ts";
 export type {
   LazyUrlContext,
+  RenderJson,
   ResolvedSection,
+  SectionJsonModule,
+  SerializeContext,
   SerializedSection,
 } from "./runtime/routes/serialize-section.ts";
 export { Murmurhash3 } from "./deps.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -60,7 +60,6 @@ export type {
   SerializeContext,
   SerializedSection,
 } from "./runtime/routes/serialize-section.ts";
-export { Murmurhash3 } from "./deps.ts";
 export * from "./types.ts";
 export { allowCorsFor } from "./utils/http.ts";
 export type { StreamProps } from "./utils/invoke.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -50,6 +50,8 @@ export {
   sectionModuleLookup,
   serializeResolvedSection,
 } from "./runtime/routes/serialize-section.ts";
+export { computeRenderCb } from "./hooks/useSection.ts";
+export type { RenderCbInput } from "./hooks/useSection.ts";
 export type {
   LazyUrlContext,
   RenderJson,

--- a/runtime/routes/render.tsx
+++ b/runtime/routes/render.tsx
@@ -8,6 +8,11 @@ import { singleFlight } from "../../utils/mod.ts";
 import { createHandler, DEBUG_QS } from "../middleware.ts";
 import type { PageParams } from "../mod.ts";
 import Render, { type PageData } from "./entrypoint.tsx";
+import {
+  type LazyUrlContext,
+  type ResolvedSection,
+  serializeResolvedSection,
+} from "./serialize-section.ts";
 
 interface Options {
   resolveChain?: FieldResolver[];
@@ -91,6 +96,29 @@ export const handler = createHandler(async (
   if (isDebugRequest) {
     return Response.json({ debugData: state.vary.debug.build() });
   }
+
+  if (opts.searchParams.get("format") === "json") {
+    const lazyCtx: LazyUrlContext = {
+      href: opts.href,
+      pathTemplate: opts.pathTemplate,
+      renderSalt: opts.renderSalt,
+      cb: opts.searchParams.get("__cb") ?? undefined,
+    };
+    const serialized = serializeResolvedSection(
+      page as ResolvedSection,
+      lazyCtx,
+    );
+    const jsonResponse = Response.json(serialized);
+    const shouldCacheFromVary = ctx?.var?.vary?.shouldCache === true;
+    jsonResponse.headers.set(
+      "cache-control",
+      shouldCache && shouldCacheFromVary
+        ? DECO_RENDER_CACHE_CONTROL
+        : "no-store, no-cache, must-revalidate",
+    );
+    return jsonResponse;
+  }
+
   const props = {
     params: ctx.req.param(),
     url: ctx.var.url,

--- a/runtime/routes/render.tsx
+++ b/runtime/routes/render.tsx
@@ -9,8 +9,9 @@ import { createHandler, DEBUG_QS } from "../middleware.ts";
 import type { PageParams } from "../mod.ts";
 import Render, { type PageData } from "./entrypoint.tsx";
 import {
-  type LazyUrlContext,
   type ResolvedSection,
+  sectionModuleLookup,
+  type SerializeContext,
   serializeResolvedSection,
 } from "./serialize-section.ts";
 
@@ -98,15 +99,16 @@ export const handler = createHandler(async (
   }
 
   if (opts.searchParams.get("format") === "json") {
-    const lazyCtx: LazyUrlContext = {
+    const serializeCtx: SerializeContext = {
       href: opts.href,
       pathTemplate: opts.pathTemplate,
       renderSalt: opts.renderSalt,
       cb: opts.searchParams.get("__cb") ?? undefined,
+      getSectionModule: await sectionModuleLookup(),
     };
     const serialized = serializeResolvedSection(
       page as ResolvedSection,
-      lazyCtx,
+      serializeCtx,
     );
     const jsonResponse = Response.json(serialized);
     const shouldCacheFromVary = ctx?.var?.vary?.shouldCache === true;

--- a/runtime/routes/serialize-section.ts
+++ b/runtime/routes/serialize-section.ts
@@ -1,0 +1,110 @@
+import { FieldResolver } from "../../engine/core/resolver.ts";
+
+const LAZY_SECTION_PATH = "/Rendering/Lazy.tsx";
+
+export interface ResolvedSection {
+  Component?: unknown;
+  props?: Record<string, unknown>;
+  metadata?: {
+    component?: string;
+    resolveChain?: FieldResolver[];
+  };
+}
+
+export type SerializedSection =
+  | { component: string; props: Record<string, unknown> }
+  | { component: string; lazyUrl: string };
+
+export interface LazyUrlContext {
+  href: string;
+  pathTemplate: string;
+  renderSalt?: string;
+  cb?: string;
+}
+
+export function buildLazyUrl(
+  resolveChain: FieldResolver[],
+  ctx: LazyUrlContext,
+): string {
+  const params = new URLSearchParams([
+    ["format", "json"],
+    ["props", JSON.stringify({ loading: "eager" })],
+    ["href", ctx.href],
+    ["pathTemplate", ctx.pathTemplate],
+    [
+      "resolveChain",
+      JSON.stringify(FieldResolver.minify(resolveChain.slice(0, -1))),
+    ],
+  ]);
+  if (ctx.renderSalt) params.set("renderSalt", ctx.renderSalt);
+  if (ctx.cb) params.set("__cb", ctx.cb);
+  return `/deco/render?${params}`;
+}
+
+function isSectionShape(value: unknown): value is ResolvedSection {
+  if (!value || typeof value !== "object") return false;
+  const meta = (value as ResolvedSection).metadata;
+  return typeof meta?.component === "string";
+}
+
+function isLazyComponent(component: string | undefined): boolean {
+  return !!component?.endsWith(LAZY_SECTION_PATH);
+}
+
+function getInnerSection(node: ResolvedSection): ResolvedSection | undefined {
+  const inner = (node.props as { section?: unknown } | undefined)?.section;
+  return isSectionShape(inner) ? inner : undefined;
+}
+
+function getLoading(node: ResolvedSection): string | undefined {
+  return (node.props as { loading?: string } | undefined)?.loading;
+}
+
+export function serializeResolvedSection(
+  node: ResolvedSection,
+  ctx: LazyUrlContext,
+): SerializedSection {
+  let current = node;
+  while (
+    isLazyComponent(current.metadata?.component) &&
+    getLoading(current) === "eager"
+  ) {
+    const inner = getInnerSection(current);
+    if (!inner) break;
+    current = inner;
+  }
+
+  if (
+    isLazyComponent(current.metadata?.component) &&
+    getLoading(current) === "lazy"
+  ) {
+    const inner = getInnerSection(current);
+    return {
+      component: inner?.metadata?.component ?? current.metadata!.component!,
+      lazyUrl: buildLazyUrl(current.metadata!.resolveChain ?? [], ctx),
+    };
+  }
+
+  return {
+    component: current.metadata!.component!,
+    props: walkValue(current.props ?? {}, ctx) as Record<string, unknown>,
+  };
+}
+
+function walkValue(value: unknown, ctx: LazyUrlContext): unknown {
+  if (Array.isArray(value)) {
+    return value.map((v) => walkValue(v, ctx));
+  }
+  if (value && typeof value === "object") {
+    if (isSectionShape(value)) {
+      return serializeResolvedSection(value, ctx);
+    }
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (k === "Component" && typeof v === "function") continue;
+      out[k] = walkValue(v, ctx);
+    }
+    return out;
+  }
+  return value;
+}

--- a/runtime/routes/serialize-section.ts
+++ b/runtime/routes/serialize-section.ts
@@ -1,3 +1,4 @@
+import { Context } from "../../deco.ts";
 import { FieldResolver } from "../../engine/core/resolver.ts";
 
 const LAZY_SECTION_PATH = "/Rendering/Lazy.tsx";
@@ -15,12 +16,61 @@ export type SerializedSection =
   | { component: string; props: Record<string, unknown> }
   | { component: string; lazyUrl: string };
 
+/**
+ * Module-level control of how a section renders to JSON.
+ *
+ * - `false` — the section has no JSON rendering; it is dropped from the
+ *   serialized output entirely.
+ * - function — a projection applied to the resolved props before
+ *   serialization. Annotate the parameter with `SectionProps<typeof loader>`
+ *   (or the section's own Props) to keep it compile-checked.
+ *
+ * ```ts
+ * export const renderJson = false;
+ *
+ * export const renderJson = (
+ *   { internalOnly, ...rest }: SectionProps<typeof loader>,
+ * ) => rest;
+ * ```
+ */
+export type RenderJson =
+  // deno-lint-ignore no-explicit-any
+  | ((props: any) => unknown)
+  | false;
+
+export interface SectionJsonModule {
+  renderJson?: RenderJson;
+}
+
 export interface LazyUrlContext {
   href: string;
   pathTemplate: string;
   renderSalt?: string;
   cb?: string;
 }
+
+export interface SerializeContext extends LazyUrlContext {
+  /**
+   * Resolves a section module by its component name (resolveType) so the
+   * serializer can honor its `renderJson` export. When omitted, every
+   * section serializes with its full resolved props.
+   */
+  getSectionModule?: (component: string) => SectionJsonModule | undefined;
+}
+
+/**
+ * Builds a `getSectionModule` lookup over the active context's merged
+ * manifest (site + apps), keyed by resolveType.
+ */
+export const sectionModuleLookup = async (): Promise<
+  (component: string) => SectionJsonModule | undefined
+> => {
+  const runtime = await Context.active().runtime;
+  const sections = (runtime?.manifest as unknown as {
+    sections?: Record<string, SectionJsonModule>;
+  })?.sections ?? {};
+  return (component) => sections[component];
+};
 
 export function buildLazyUrl(
   resolveChain: FieldResolver[],
@@ -60,10 +110,26 @@ function getLoading(node: ResolvedSection): string | undefined {
   return (node.props as { loading?: string } | undefined)?.loading;
 }
 
+function renderJsonOf(
+  ctx: SerializeContext,
+  component: string,
+): RenderJson | undefined {
+  return ctx.getSectionModule?.(component)?.renderJson;
+}
+
+/**
+ * Serializes a resolved section honoring its `renderJson` export.
+ * Returns `null` when the section opted out (`renderJson === false`) —
+ * callers must drop it from the output.
+ *
+ * A `renderJson` projection cannot run for lazy placeholders (their props
+ * are not resolved yet); it applies on the lazy fetch itself, when
+ * `/deco/render?format=json` serializes the resolved section.
+ */
 export function serializeResolvedSection(
   node: ResolvedSection,
-  ctx: LazyUrlContext,
-): SerializedSection {
+  ctx: SerializeContext,
+): SerializedSection | null {
   let current = node;
   while (
     isLazyComponent(current.metadata?.component) &&
@@ -79,21 +145,43 @@ export function serializeResolvedSection(
     getLoading(current) === "lazy"
   ) {
     const inner = getInnerSection(current);
+    const component = inner?.metadata?.component ??
+      current.metadata!.component!;
+    if (renderJsonOf(ctx, component) === false) return null;
     return {
-      component: inner?.metadata?.component ?? current.metadata!.component!,
+      component,
       lazyUrl: buildLazyUrl(current.metadata!.resolveChain ?? [], ctx),
     };
   }
 
+  const component = current.metadata!.component!;
+  const renderJson = renderJsonOf(ctx, component);
+  if (renderJson === false) return null;
+
+  const props = typeof renderJson === "function"
+    ? renderJson(current.props ?? {})
+    : current.props ?? {};
+
   return {
-    component: current.metadata!.component!,
-    props: walkValue(current.props ?? {}, ctx) as Record<string, unknown>,
+    component,
+    props: walkValue(props, ctx) as Record<string, unknown>,
   };
 }
 
-function walkValue(value: unknown, ctx: LazyUrlContext): unknown {
+function walkValue(value: unknown, ctx: SerializeContext): unknown {
   if (Array.isArray(value)) {
-    return value.map((v) => walkValue(v, ctx));
+    // Dropped sections (renderJson === false) are removed from arrays so
+    // consumers iterate a dense list; non-section nulls pass through.
+    const out: unknown[] = [];
+    for (const v of value) {
+      if (isSectionShape(v)) {
+        const serialized = serializeResolvedSection(v, ctx);
+        if (serialized !== null) out.push(serialized);
+      } else {
+        out.push(walkValue(v, ctx));
+      }
+    }
+    return out;
   }
   if (value && typeof value === "object") {
     if (isSectionShape(value)) {

--- a/runtime/routes/serialize-section.ts
+++ b/runtime/routes/serialize-section.ts
@@ -35,7 +35,7 @@ export type SerializedSection =
  */
 export type RenderJson =
   // deno-lint-ignore no-explicit-any
-  | ((props: any) => unknown)
+  | ((props: any) => Record<string, unknown>)
   | false;
 
 export interface SectionJsonModule {
@@ -150,6 +150,10 @@ export function serializeResolvedSection(
     if (renderJsonOf(ctx, component) === false) return null;
     return {
       component,
+      // The wrapper's resolveChain is what reconstructs this slot on the lazy
+      // fetch — it re-resolves the inner section and applies the inner's
+      // renderJson there. The inner is not independently resolvable, so its own
+      // chain would not rebuild this position; the wrapper's chain is correct.
       lazyUrl: buildLazyUrl(current.metadata!.resolveChain ?? [], ctx),
     };
   }

--- a/utils/mod.ts
+++ b/utils/mod.ts
@@ -12,7 +12,7 @@ export { adminUrlFor, isAdmin, resolvable } from "./admin.ts";
  */
 export { readFromStream } from "./http.ts";
 export { metabasePreview } from "./metabase.tsx";
-export { tryOrDefault } from "./object.ts";
+export { deepOmit, tryOrDefault } from "./object.ts";
 export type { DotNestedKeys } from "./object.ts";
 export { createServerTimings } from "./timings.ts";
 export type { Device } from "./userAgent.ts";

--- a/utils/object.ts
+++ b/utils/object.ts
@@ -146,3 +146,56 @@ export const tryOrDefault = <R>(fn: () => R, defaultValue: R): R => {
     return defaultValue;
   }
 };
+
+const omitAtPath = (obj: unknown, parts: string[]): unknown => {
+  if (!obj || typeof obj !== "object" || parts.length === 0) return obj;
+
+  const [key, ...rest] = parts;
+
+  // `*` fans the remaining path out over every array element / record value.
+  if (key === "*") {
+    if (Array.isArray(obj)) {
+      return obj.map((v) => omitAtPath(v, rest));
+    }
+    return Object.fromEntries(
+      Object.entries(obj as Record<string, unknown>).map(([k, v]) => [
+        k,
+        omitAtPath(v, rest),
+      ]),
+    );
+  }
+
+  // Preserve array shape: apply the same path to each element.
+  if (Array.isArray(obj)) {
+    return obj.map((v) => omitAtPath(v, parts));
+  }
+
+  const current = obj as Record<string, unknown>;
+
+  if (rest.length === 0) {
+    const copy = { ...current };
+    delete copy[key];
+    return copy;
+  }
+
+  return {
+    ...current,
+    [key]: omitAtPath(current[key], rest),
+  };
+};
+
+/**
+ * Removes properties from `obj` by path, immutably.
+ *
+ * Supports top-level keys (`"seoProps"`), nested dot-notation paths
+ * (`"page.seo"`), and the `*` wildcard over record/array values
+ * (`"page.productsMap.*.internalFlag"`). Prefer typed rest-destructuring
+ * for top-level keys; reach for deepOmit on deep paths and dynamic keys.
+ */
+export const deepOmit = <T extends object>(obj: T, ...paths: string[]): T => {
+  let result: unknown = obj;
+  for (const path of paths) {
+    result = omitAtPath(result, path.split("."));
+  }
+  return result as T;
+};

--- a/utils/object.ts
+++ b/utils/object.ts
@@ -178,6 +178,9 @@ const omitAtPath = (obj: unknown, parts: string[]): unknown => {
     return copy;
   }
 
+  // Omit is a no-op when the path is absent — never create `undefined` branches.
+  if (!(key in current)) return current;
+
   return {
     ...current,
     [key]: omitAtPath(current[key], rest),


### PR DESCRIPTION
## Summary

Adds a `renderJson` section export that lets each section control its own JSON serialization, surfaced through a `?format=json` render branch:

- **`renderJson` export** on a section module:
  - `false` → the section is dropped from the JSON payload (its prop-loaders short-circuit, see `engine/core/resolver.ts`).
  - a function → a typed projection of the resolved props (typed via `SectionProps<typeof loader>` — no new type to declare).
- **`?format=json`** render branch + `serializeResolvedSection` (new `runtime/routes/serialize-section.ts`) that walks the resolved section tree and applies each section's `renderJson`.
- **`computeRenderCb` lifted out of `hooks/useSection`** so the lazy-section URL builder and the JSON serializer share one cache-bust recipe instead of drifting.
- `deepOmit` helper in `utils/object.ts` for ergonomic projections.

## Why

Headless / app consumers need a stable JSON projection of a page's sections without scraping rendered HTML. The alternatives are over-fetching the full resolved tree or maintaining a parallel serializer that drifts from the render path. Co-locating a `renderJson` contract with each section keeps the JSON shape next to the section and reuses the real render + cache machinery — one source of truth for the cache-bust recipe.

## How it works

```
GET /page?format=json
  └─ render path resolves the section tree (identical to HTML)
       └─ serializeResolvedSection walks it
            ├─ renderJson === false → omit the section
            ├─ renderJson is a fn   → project resolved props (typed)
            └─ default              → serialize resolved props
```

`computeRenderCb` is exported from `useSection` so the lazy-section URL builder and the serializer compute the same render callback.

## Test plan

- [x] `deno fmt --check` clean on touched files
- [x] `deno check mod.ts` passes against `main`
- [x] Dogfooded on a real deco storefront (oficina-reserva): HTML and `?asJson` byte-identical to baseline; `?format=json` matches the resolved render tree; lazy fetch applies the projection

## Companion PR

Native `?renderJson` support in the Fresh handler lands in `deco-cx/apps` as a separate PR that depends on this one being published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a JSON render path for pages via `?format=json`, letting each section control its JSON with an optional `renderJson` export. Tightens typing and utils for predictable output and exposes a shared `computeRenderCb` for consistent cache-busting.

- **New Features**
  - `?format=json` on `/deco/render` returns a JSON-safe section tree with proper cache-control.
  - Section-level `renderJson`: `false` to omit; function to project resolved props (must return an object); defaults to full props.
  - Lazy handling: eager lazies unwrapped; deferred lazies emit `{ component, lazyUrl }`; omitted sections are removed from arrays and become `null` in object fields.
  - Exports: `serializeResolvedSection`, `sectionModuleLookup`, `buildLazyUrl`, `computeRenderCb`, and `deepOmit`.

- **Bug Fixes**
  - `deepOmit` no longer creates `undefined` branches when a path is missing.
  - Stricter `renderJson` return type (object) prevents unsafe projections.

<sup>Written for commit b409595e23cf11caf13285fd092ec81b670c8e96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/deco/pull/1209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `format=json` support for section render requests, including cache headers tuned to variant behavior.
  * Implemented section serialization with lazy-loading URLs for optimized delivery and nested section handling.
  * Added a deep object omission utility that supports dot-paths and `*` wildcards.
* **Refactor**
  * Centralized render cache-buster callback computation into a shared reusable helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->