### PR TITLE
observability: per-route response-bytes histogram

### DIFF
--- a/observability/http.ts
+++ b/observability/http.ts
@@ -6,6 +6,30 @@ const httpDuration = meter.createHistogram("http_request_duration", {
   unit: "ms",
   valueType: ValueType.DOUBLE,
 });
+
+const httpResponseBytes = meter.createHistogram("http_response_bytes", {
+  description: "http response body size in bytes (per route)",
+  unit: "By",
+  valueType: ValueType.INT,
+});
+
+/**
+ * Records the response body size for a route. Egress per route is otherwise
+ * unobservable: istio byte metrics carry no path label. Call after the body
+ * has been fully counted (see the counting stream in runtime/middleware.ts).
+ */
+export const recordResponseBytes = (
+  bytes: number,
+  method: string,
+  path: string,
+  status: number,
+) => {
+  httpResponseBytes.record(bytes, {
+    "http.method": method,
+    "http.route": path,
+    "http.response.status": `${status}`,
+  });
+};
 /**
  * @returns a end function that when gets called observe the duration of the operation.
  */

--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -9,7 +9,7 @@ import {
   getSetCookies,
   SpanStatusCode,
 } from "../deps.ts";
-import { startObserve } from "../observability/http.ts";
+import { recordResponseBytes, startObserve } from "../observability/http.ts";
 import { logger } from "../observability/mod.ts";
 import { HttpError } from "../runtime/errors.ts";
 import type { AppManifest } from "../types.ts";
@@ -301,6 +301,29 @@ export const middlewareFor = <TAppManifest extends AppManifest = AppManifest>(
                 ctx?.var?.pathTemplate,
                 ctx.res?.status ?? 500,
               );
+              // Per-route egress: responses are transfer-encoding: chunked, so
+              // content-length is absent. Tally bytes through a pass-through
+              // stream and record on flush (after the body finishes streaming).
+              const res = ctx.res;
+              if (res?.body) {
+                let bytes = 0;
+                const method = ctx.req.raw.method;
+                const pathTemplate = ctx.var.pathTemplate;
+                const counter = new TransformStream<Uint8Array, Uint8Array>({
+                  transform(chunk, controller) {
+                    bytes += chunk.byteLength;
+                    controller.enqueue(chunk);
+                  },
+                  flush() {
+                    recordResponseBytes(bytes, method, pathTemplate, res.status);
+                  },
+                });
+                ctx.res = new Response(res.body.pipeThrough(counter), {
+                  status: res.status,
+                  statusText: res.statusText,
+                  headers: res.headers,
+                });
+              }
             } else {
               span.updateName(`${ctx.req.raw.method} ${ctx.req.raw.url}`);
             }


### PR DESCRIPTION
## Why

Per-route egress is currently **unobservable**. istio byte metrics carry no path label, and HyperDX spans report response size `0`. So when a site's egress dominates its cost (e.g. FARM Rio: ~13 TiB/mo, ~40% of the cluster's total egress, ~4× its compute), there's no way to attribute the bytes to a route and decide what to trim.

## What

Adds an `http_response_bytes` histogram labeled by `http.route` (low cardinality — it's `pathTemplate`, not the full URL), sitting next to the existing `http_request_duration` histogram and flowing through the same OTEL meter/exporter.

Responses are `transfer-encoding: chunked`, so `content-length` is absent — bytes are tallied through a pass-through `TransformStream` on the body and recorded on `flush()` (after the body finishes streaming). Scoped to requests that already resolved a `pathTemplate`.

Unlocks:
```promql
sum by (http_route) (rate(http_response_bytes_sum[1h]))
```

## Tested

- Multi-chunk body: exact byte count, body delivered byte-identical, status/headers survive the Response rewrap.
- Null body (204/304/HEAD): skipped, no crash.
- Hono `ctx.res` reassignment in the observability middleware's `finally{}` propagates the wrapped body through the nested middleware onion (verified against the same Hono 4.x major).
- `deno check` introduces no new type errors.

## Caveats

- **Aborted connections undercount**: a client disconnect mid-stream errors the stream rather than flushing, so that response isn't recorded (slight undercount on aborts).
- **One extra stream hop per routed response**: negligible per request but on the hot path. Happy to gate behind an env flag (à la `SHOULD_USE_ASYNC_RENDER_SINGLE_FLIGHT`) if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an `http_response_bytes` histogram labeled by `http.route` to make per-route egress observable. Bytes are counted for streamed responses and recorded after the body finishes.

- **New Features**
  - New `http_response_bytes` histogram (unit: bytes) with `http.method`, `http.route`, and `http.response.status` labels.
  - Counts bytes via a pass-through stream; preserves status and headers; skips null bodies (204/304/HEAD).
  - Only records when `pathTemplate` is resolved to keep label cardinality low.
  - Exported through the existing OTEL meter alongside `http_request_duration`.

- **Caveats**
  - Aborted client connections are not recorded (no flush).
  - Adds one extra stream hop per routed response.

<sup>Written for commit 10681fc4bafccc6d3f2308b41012d2189e432c86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/deco/pull/1210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP response size metrics for per-route payload size tracking, organized by request method and response status code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->