### PR TITLE
feat(observability): align metrics with OTel semantic conventions

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -89,14 +89,10 @@ export {
   ATTR_USER_AGENT_ORIGINAL,
   METRIC_HTTP_SERVER_REQUEST_DURATION,
 } from "npm:@opentelemetry/semantic-conventions@1.37.0";
-// Incubating (not yet stable) semantic conventions.
-export {
-  ATTR_CLOUD_PROVIDER,
-  ATTR_CLOUD_REGION,
-  ATTR_DEPLOYMENT_ENVIRONMENT_NAME,
-  ATTR_HTTP_REQUEST_BODY_SIZE,
-  ATTR_SERVICE_INSTANCE_ID,
-} from "npm:@opentelemetry/semantic-conventions@1.37.0/incubating";
+// Incubating (experimental) semconv names are NOT re-exported here — OTel
+// advises libraries against depending on the unstable `/incubating` entry
+// point. The few we need are vendored as plain constants in
+// observability/otel/conventions.ts.
 
 export {
   ExplicitBucketHistogramAggregation,

--- a/deps.ts
+++ b/deps.ts
@@ -73,9 +73,30 @@ export type {
   SamplingResult,
 } from "npm:@opentelemetry/sdk-trace-base@1.25.1";
 export { NodeTracerProvider } from "npm:@opentelemetry/sdk-trace-node@1.25.1";
+// Stable semantic conventions (OTel semconv) — use these instead of hardcoded
+// attribute/metric name strings.
 export {
-  SemanticResourceAttributes,
-} from "npm:@opentelemetry/semantic-conventions@1.25.1";
+  ATTR_ERROR_TYPE,
+  ATTR_HTTP_REQUEST_METHOD,
+  ATTR_HTTP_RESPONSE_STATUS_CODE,
+  ATTR_HTTP_ROUTE,
+  ATTR_SERVER_ADDRESS,
+  ATTR_SERVICE_NAME,
+  ATTR_SERVICE_VERSION,
+  ATTR_URL_PATH,
+  ATTR_URL_QUERY,
+  ATTR_URL_SCHEME,
+  ATTR_USER_AGENT_ORIGINAL,
+  METRIC_HTTP_SERVER_REQUEST_DURATION,
+} from "npm:@opentelemetry/semantic-conventions@1.37.0";
+// Incubating (not yet stable) semantic conventions.
+export {
+  ATTR_CLOUD_PROVIDER,
+  ATTR_CLOUD_REGION,
+  ATTR_DEPLOYMENT_ENVIRONMENT_NAME,
+  ATTR_HTTP_REQUEST_BODY_SIZE,
+  ATTR_SERVICE_INSTANCE_ID,
+} from "npm:@opentelemetry/semantic-conventions@1.37.0/incubating";
 
 export {
   ExplicitBucketHistogramAggregation,

--- a/observability/http.ts
+++ b/observability/http.ts
@@ -1,9 +1,16 @@
-import { ValueType } from "../deps.ts";
+import {
+  ATTR_HTTP_REQUEST_METHOD,
+  ATTR_HTTP_RESPONSE_STATUS_CODE,
+  ATTR_HTTP_ROUTE,
+  METRIC_HTTP_SERVER_REQUEST_DURATION,
+  ValueType,
+} from "../deps.ts";
 import { meter } from "./otel/metrics.ts";
 
-const httpDuration = meter.createHistogram("http_request_duration", {
-  description: "http request duration",
-  unit: "ms",
+// OTel semconv: name `http.server.request.duration`, unit seconds.
+const httpDuration = meter.createHistogram(METRIC_HTTP_SERVER_REQUEST_DURATION, {
+  description: "Duration of HTTP server requests.",
+  unit: "s",
   valueType: ValueType.DOUBLE,
 });
 /**
@@ -12,10 +19,10 @@ const httpDuration = meter.createHistogram("http_request_duration", {
 export const startObserve = () => {
   const start = performance.now();
   return (method: string, path: string, status: number) => {
-    httpDuration.record(Math.round(performance.now() - start), {
-      "http.method": method,
-      "http.route": path,
-      "http.response.status": `${status}`,
+    httpDuration.record((performance.now() - start) / 1000, {
+      [ATTR_HTTP_REQUEST_METHOD]: method,
+      [ATTR_HTTP_ROUTE]: path,
+      [ATTR_HTTP_RESPONSE_STATUS_CODE]: status,
     });
   };
 };

--- a/observability/observe.ts
+++ b/observability/observe.ts
@@ -1,12 +1,20 @@
 import { isWrappedError } from "../blocks/loader.ts";
 import { ValueType } from "../deps.ts";
 import { meter, OTEL_ENABLE_EXTRA_METRICS } from "./otel/metrics.ts";
+import {
+  ATTR_DECO_OPERATION_ERROR,
+  ATTR_DECO_OPERATION_NAME,
+  METRIC_DECO_BLOCK_OPERATION_DURATION,
+} from "./otel/conventions.ts";
 
-const operationDuration = meter.createHistogram("block_op_duration", {
-  description: "operation duration",
-  unit: "ms",
-  valueType: ValueType.DOUBLE,
-});
+const operationDuration = meter.createHistogram(
+  METRIC_DECO_BLOCK_OPERATION_DURATION,
+  {
+    description: "Duration of deco block operations.",
+    unit: "s",
+    valueType: ValueType.DOUBLE,
+  },
+);
 
 /**
  * Observe function durations based on the provided labels
@@ -16,21 +24,21 @@ export const observe = async <T>(
   f: () => Promise<T>,
 ): Promise<T> => {
   const start = performance.now();
-  let isError = "false";
+  let isError = false;
   try {
     const result = await f();
     if (isWrappedError(result)) {
-      isError = "true";
+      isError = true;
     }
     return result;
   } catch (error) {
-    isError = "true";
+    isError = true;
     throw error;
   } finally {
     if (OTEL_ENABLE_EXTRA_METRICS) {
-      operationDuration.record(performance.now() - start, {
-        "operation.name": op,
-        "operation.is_error": isError,
+      operationDuration.record((performance.now() - start) / 1000, {
+        [ATTR_DECO_OPERATION_NAME]: op,
+        [ATTR_DECO_OPERATION_ERROR]: isError,
       });
     }
   }

--- a/observability/otel/config.ts
+++ b/observability/otel/config.ts
@@ -3,10 +3,6 @@ import { Logger } from "@std/log/logger";
 import { Context, context } from "../../deco.ts";
 import denoJSON from "../../deno.json" with { type: "json" };
 import {
-  ATTR_CLOUD_PROVIDER,
-  ATTR_CLOUD_REGION,
-  ATTR_DEPLOYMENT_ENVIRONMENT_NAME,
-  ATTR_SERVICE_INSTANCE_ID,
   ATTR_SERVICE_NAME,
   ATTR_SERVICE_VERSION,
   BatchSpanProcessor,
@@ -18,6 +14,12 @@ import {
   registerInstrumentations,
   Resource,
 } from "../../deps.ts";
+import {
+  ATTR_CLOUD_PROVIDER,
+  ATTR_CLOUD_REGION,
+  ATTR_DEPLOYMENT_ENVIRONMENT_NAME,
+  ATTR_SERVICE_INSTANCE_ID,
+} from "./conventions.ts";
 import { DenoRuntimeInstrumentation } from "./instrumentation/deno-runtime.ts";
 import { DebugSampler } from "./samplers/debug.ts";
 import { type SamplingOptions, URLBasedSampler } from "./samplers/urlBased.ts";
@@ -40,7 +42,9 @@ const apps_ver = tryGetVersionOf("apps/") ??
 export const resource = Resource.default().merge(
   new Resource({
     [ATTR_SERVICE_NAME]: Deno.env.get(ENV_SITE_NAME) ?? "deco",
-    [ATTR_SERVICE_VERSION]: Context.active().deploymentId ?? Deno.hostname(),
+    // Version of the deployed artifact (the deployment revision), falling back
+    // to the framework version — NOT the hostname (that is instance identity).
+    [ATTR_SERVICE_VERSION]: Context.active().deploymentId ?? denoJSON.version,
     [ATTR_SERVICE_INSTANCE_ID]: crypto.randomUUID(),
     [ATTR_CLOUD_PROVIDER]: context.platform,
     "deco.runtime.version": denoJSON.version,

--- a/observability/otel/config.ts
+++ b/observability/otel/config.ts
@@ -3,6 +3,12 @@ import { Logger } from "@std/log/logger";
 import { Context, context } from "../../deco.ts";
 import denoJSON from "../../deno.json" with { type: "json" };
 import {
+  ATTR_CLOUD_PROVIDER,
+  ATTR_CLOUD_REGION,
+  ATTR_DEPLOYMENT_ENVIRONMENT_NAME,
+  ATTR_SERVICE_INSTANCE_ID,
+  ATTR_SERVICE_NAME,
+  ATTR_SERVICE_VERSION,
   BatchSpanProcessor,
   FetchInstrumentation,
   NodeTracerProvider,
@@ -11,7 +17,6 @@ import {
   ParentBasedSampler,
   registerInstrumentations,
   Resource,
-  SemanticResourceAttributes,
 } from "../../deps.ts";
 import { DenoRuntimeInstrumentation } from "./instrumentation/deno-runtime.ts";
 import { DebugSampler } from "./samplers/debug.ts";
@@ -34,20 +39,14 @@ const apps_ver = tryGetVersionOf("apps/") ??
 
 export const resource = Resource.default().merge(
   new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: Deno.env.get(ENV_SITE_NAME) ??
-      "deco",
-    [SemanticResourceAttributes.SERVICE_VERSION]:
-      Context.active().deploymentId ??
-        Deno.hostname(),
-    [SemanticResourceAttributes.SERVICE_INSTANCE_ID]: crypto.randomUUID(),
-    [SemanticResourceAttributes.CLOUD_PROVIDER]: context.platform,
+    [ATTR_SERVICE_NAME]: Deno.env.get(ENV_SITE_NAME) ?? "deco",
+    [ATTR_SERVICE_VERSION]: Context.active().deploymentId ?? Deno.hostname(),
+    [ATTR_SERVICE_INSTANCE_ID]: crypto.randomUUID(),
+    [ATTR_CLOUD_PROVIDER]: context.platform,
     "deco.runtime.version": denoJSON.version,
     "deco.apps.version": apps_ver,
-    [SemanticResourceAttributes.CLOUD_REGION]: Deno.env.get("DENO_REGION") ??
-      "unknown",
-    [SemanticResourceAttributes.DEPLOYMENT_ENVIRONMENT]: Deno.env.get(
-        "DECO_ENV_NAME",
-      )
+    [ATTR_CLOUD_REGION]: Deno.env.get("DENO_REGION") ?? "unknown",
+    [ATTR_DEPLOYMENT_ENVIRONMENT_NAME]: Deno.env.get("DECO_ENV_NAME")
       ? `env-${Deno.env.get("DECO_ENV_NAME")}`
       : "production",
   }),

--- a/observability/otel/conventions.ts
+++ b/observability/otel/conventions.ts
@@ -6,9 +6,10 @@
 // Metrics
 export const METRIC_DECO_BLOCK_OPERATION_DURATION =
   "deco.block.operation.duration";
-// Single cache counter dimensioned by `deco.cache.result` — unified with
-// @decocms/start (avoids a `deco.cache.hits` name/semantics collision).
-export const METRIC_DECO_CACHE_LOOKUPS = "deco.cache.lookups";
+// Cache counters, dimensioned by `deco.cache.result` — names match
+// @decocms/start (tanstack) so both frameworks aggregate on the same metrics.
+export const METRIC_DECO_CACHE_HITS = "deco.cache.hits";
+export const METRIC_DECO_CACHE_MISSES = "deco.cache.misses";
 
 // Attributes
 export const ATTR_DECO_OPERATION_NAME = "deco.operation.name";

--- a/observability/otel/conventions.ts
+++ b/observability/otel/conventions.ts
@@ -6,7 +6,9 @@
 // Metrics
 export const METRIC_DECO_BLOCK_OPERATION_DURATION =
   "deco.block.operation.duration";
-export const METRIC_DECO_CACHE_HITS = "deco.cache.hits";
+// Single cache counter dimensioned by `deco.cache.result` — unified with
+// @decocms/start (avoids a `deco.cache.hits` name/semantics collision).
+export const METRIC_DECO_CACHE_LOOKUPS = "deco.cache.lookups";
 
 // Attributes
 export const ATTR_DECO_OPERATION_NAME = "deco.operation.name";

--- a/observability/otel/conventions.ts
+++ b/observability/otel/conventions.ts
@@ -6,14 +6,15 @@
 // Metrics
 export const METRIC_DECO_BLOCK_OPERATION_DURATION =
   "deco.block.operation.duration";
-// Cache counters, dimensioned by `deco.cache.result` — names match
-// @decocms/start (tanstack) so both frameworks aggregate on the same metrics.
-export const METRIC_DECO_CACHE_HITS = "deco.cache.hits";
-export const METRIC_DECO_CACHE_MISSES = "deco.cache.misses";
+// Single cache counter dimensioned by `deco.cache.status` — follows the OTel
+// semconv pattern (cf. nfs.server.repcache.requests + .status) and the general
+// guidance to prefer attributes over separate metrics. Unified with
+// @decocms/start so both frameworks aggregate on the same series.
+export const METRIC_DECO_CACHE_REQUESTS = "deco.cache.requests";
 
 // Attributes
 export const ATTR_DECO_OPERATION_NAME = "deco.operation.name";
 export const ATTR_DECO_OPERATION_ERROR = "deco.operation.error";
-export const ATTR_DECO_CACHE_RESULT = "deco.cache.result";
 export const ATTR_DECO_CACHE_ENGINE = "deco.cache.engine";
+// Cache outcome: hit | stale | miss (| bypass). Same key on span + metric.
 export const ATTR_DECO_CACHE_STATUS = "deco.cache.status";

--- a/observability/otel/conventions.ts
+++ b/observability/otel/conventions.ts
@@ -18,3 +18,12 @@ export const ATTR_DECO_OPERATION_ERROR = "deco.operation.error";
 export const ATTR_DECO_CACHE_ENGINE = "deco.cache.engine";
 // Cache outcome: hit | stale | miss (| bypass). Same key on span + metric.
 export const ATTR_DECO_CACHE_STATUS = "deco.cache.status";
+
+// Vendored copies of EXPERIMENTAL (incubating) OTel semconv attribute names.
+// OTel recommends libraries NOT import from `@opentelemetry/.../incubating`
+// (the entry point is unstable across versions); copy the values instead.
+// Sourced from @opentelemetry/semantic-conventions 1.37.0/incubating.
+export const ATTR_CLOUD_PROVIDER = "cloud.provider";
+export const ATTR_CLOUD_REGION = "cloud.region";
+export const ATTR_DEPLOYMENT_ENVIRONMENT_NAME = "deployment.environment.name";
+export const ATTR_SERVICE_INSTANCE_ID = "service.instance.id";

--- a/observability/otel/conventions.ts
+++ b/observability/otel/conventions.ts
@@ -1,0 +1,16 @@
+// deco-proprietary telemetry conventions, for signals that have no OTel
+// semantic-conventions equivalent. Standard signals (HTTP, URL, service,
+// cloud, gen_ai, ...) MUST use the official @opentelemetry/semantic-conventions
+// constants re-exported from deps.ts — do not hardcode those names here.
+
+// Metrics
+export const METRIC_DECO_BLOCK_OPERATION_DURATION =
+  "deco.block.operation.duration";
+export const METRIC_DECO_CACHE_HITS = "deco.cache.hits";
+
+// Attributes
+export const ATTR_DECO_OPERATION_NAME = "deco.operation.name";
+export const ATTR_DECO_OPERATION_ERROR = "deco.operation.error";
+export const ATTR_DECO_CACHE_RESULT = "deco.cache.result";
+export const ATTR_DECO_CACHE_ENGINE = "deco.cache.engine";
+export const ATTR_DECO_CACHE_STATUS = "deco.cache.status";

--- a/observability/otel/metrics.ts
+++ b/observability/otel/metrics.ts
@@ -28,9 +28,25 @@ const headersStringToObject = (headersString: string | undefined | null) => {
   return Object.fromEntries(splitByComma);
 };
 
-// Add views with different boundaries for each unit.
+// Add views with different boundaries for each unit. Now that durations are
+// recorded in seconds (OTel semconv), the `s` buckets must cover both
+// sub-second HTTP latencies and multi-second gen_ai/block operations.
 const msBoundaries = [10, 100, 500, 1000, 5000, 10000, 15000];
-const sBoundaries = [1, 5, 10, 50];
+const sBoundaries = [
+  0.005,
+  0.01,
+  0.025,
+  0.05,
+  0.1,
+  0.25,
+  0.5,
+  1,
+  2.5,
+  5,
+  10,
+  30,
+  60,
+];
 
 type IMeter = ReturnType<MeterProvider["getMeter"]>;
 const meterProvider: MeterProvider = new MeterProvider({

--- a/runtime/caches/common.ts
+++ b/runtime/caches/common.ts
@@ -1,6 +1,12 @@
 import { type Exception, ValueType } from "../../deps.ts";
 import { tracer } from "../../observability/otel/config.ts";
 import { meter } from "../../observability/otel/metrics.ts";
+import {
+  ATTR_DECO_CACHE_ENGINE,
+  ATTR_DECO_CACHE_RESULT,
+  ATTR_DECO_CACHE_STATUS,
+  METRIC_DECO_CACHE_HITS,
+} from "../../observability/otel/conventions.ts";
 import { inFuture } from "./utils.ts";
 
 export interface CacheMetrics {
@@ -8,7 +14,7 @@ export interface CacheMetrics {
   total: number;
   hits: number;
 }
-const cacheHit = meter.createCounter("cache_hit", {
+const cacheHit = meter.createCounter(METRIC_DECO_CACHE_HITS, {
   unit: "1",
   valueType: ValueType.DOUBLE,
 });
@@ -38,17 +44,17 @@ export const withInstrumentation = (
         put: cacheImpl.put.bind(cacheImpl),
         match: async (req, opts) => {
           const span = tracer.startSpan("cache-match", {
-            attributes: { engine },
+            attributes: { [ATTR_DECO_CACHE_ENGINE]: engine },
           });
           try {
             const isMatch = await cacheImpl.match(req, opts);
             //there is an edge case where there is no expires header, but technically our loader always sets it
             const result = getCacheStatus(isMatch);
 
-            span.setAttribute("cache_status", result);
+            span.setAttribute(ATTR_DECO_CACHE_STATUS, result);
             cacheHit.add(1, {
-              result,
-              engine,
+              [ATTR_DECO_CACHE_RESULT]: result,
+              [ATTR_DECO_CACHE_ENGINE]: engine,
             });
             return isMatch;
           } catch (err) {

--- a/runtime/caches/common.ts
+++ b/runtime/caches/common.ts
@@ -5,7 +5,8 @@ import {
   ATTR_DECO_CACHE_ENGINE,
   ATTR_DECO_CACHE_RESULT,
   ATTR_DECO_CACHE_STATUS,
-  METRIC_DECO_CACHE_LOOKUPS,
+  METRIC_DECO_CACHE_HITS,
+  METRIC_DECO_CACHE_MISSES,
 } from "../../observability/otel/conventions.ts";
 import { inFuture } from "./utils.ts";
 
@@ -14,7 +15,13 @@ export interface CacheMetrics {
   total: number;
   hits: number;
 }
-const cacheHit = meter.createCounter(METRIC_DECO_CACHE_LOOKUPS, {
+// Two counters (names match @decocms/start); `deco.cache.result` carries the
+// outcome (hit/stale/miss) for both.
+const cacheHits = meter.createCounter(METRIC_DECO_CACHE_HITS, {
+  unit: "1",
+  valueType: ValueType.DOUBLE,
+});
+const cacheMisses = meter.createCounter(METRIC_DECO_CACHE_MISSES, {
   unit: "1",
   valueType: ValueType.DOUBLE,
 });
@@ -52,7 +59,8 @@ export const withInstrumentation = (
             const result = getCacheStatus(isMatch);
 
             span.setAttribute(ATTR_DECO_CACHE_STATUS, result);
-            cacheHit.add(1, {
+            const counter = result === "miss" ? cacheMisses : cacheHits;
+            counter.add(1, {
               [ATTR_DECO_CACHE_RESULT]: result,
               [ATTR_DECO_CACHE_ENGINE]: engine,
             });

--- a/runtime/caches/common.ts
+++ b/runtime/caches/common.ts
@@ -5,7 +5,7 @@ import {
   ATTR_DECO_CACHE_ENGINE,
   ATTR_DECO_CACHE_RESULT,
   ATTR_DECO_CACHE_STATUS,
-  METRIC_DECO_CACHE_HITS,
+  METRIC_DECO_CACHE_LOOKUPS,
 } from "../../observability/otel/conventions.ts";
 import { inFuture } from "./utils.ts";
 
@@ -14,7 +14,7 @@ export interface CacheMetrics {
   total: number;
   hits: number;
 }
-const cacheHit = meter.createCounter(METRIC_DECO_CACHE_HITS, {
+const cacheHit = meter.createCounter(METRIC_DECO_CACHE_LOOKUPS, {
   unit: "1",
   valueType: ValueType.DOUBLE,
 });

--- a/runtime/caches/common.ts
+++ b/runtime/caches/common.ts
@@ -3,10 +3,8 @@ import { tracer } from "../../observability/otel/config.ts";
 import { meter } from "../../observability/otel/metrics.ts";
 import {
   ATTR_DECO_CACHE_ENGINE,
-  ATTR_DECO_CACHE_RESULT,
   ATTR_DECO_CACHE_STATUS,
-  METRIC_DECO_CACHE_HITS,
-  METRIC_DECO_CACHE_MISSES,
+  METRIC_DECO_CACHE_REQUESTS,
 } from "../../observability/otel/conventions.ts";
 import { inFuture } from "./utils.ts";
 
@@ -15,14 +13,9 @@ export interface CacheMetrics {
   total: number;
   hits: number;
 }
-// Two counters (names match @decocms/start); `deco.cache.result` carries the
-// outcome (hit/stale/miss) for both.
-const cacheHits = meter.createCounter(METRIC_DECO_CACHE_HITS, {
-  unit: "1",
-  valueType: ValueType.DOUBLE,
-});
-const cacheMisses = meter.createCounter(METRIC_DECO_CACHE_MISSES, {
-  unit: "1",
+// Single cache counter; `deco.cache.status` carries the outcome.
+const cacheRequests = meter.createCounter(METRIC_DECO_CACHE_REQUESTS, {
+  unit: "{request}",
   valueType: ValueType.DOUBLE,
 });
 
@@ -59,9 +52,8 @@ export const withInstrumentation = (
             const result = getCacheStatus(isMatch);
 
             span.setAttribute(ATTR_DECO_CACHE_STATUS, result);
-            const counter = result === "miss" ? cacheMisses : cacheHits;
-            counter.add(1, {
-              [ATTR_DECO_CACHE_RESULT]: result,
+            cacheRequests.add(1, {
+              [ATTR_DECO_CACHE_STATUS]: result,
               [ATTR_DECO_CACHE_ENGINE]: engine,
             });
             return isMatch;


### PR DESCRIPTION
## What

Bring the framework's telemetry in line with OpenTelemetry semantic conventions, using the official `@opentelemetry/semantic-conventions` constants (no hardcoded name strings).

### Metrics renamed + retyped
| Before | After |
|---|---|
| `http_request_duration` (ms) | `http.server.request.duration` (**seconds**) |
| attrs `http.method` / `http.response.status` (string) | `http.request.method` / `http.response.status_code` (int) |
| `block_op_duration` (ms) | `deco.block.operation.duration` (seconds) |
| `cache_hit` | `deco.cache.hits` (attrs under `deco.cache.*`) |

### Resource attributes
- Migrated off the **deprecated** `SemanticResourceAttributes` to `ATTR_*` constants (`@opentelemetry/semantic-conventions` 1.25.1 → 1.37.0, stable + `/incubating`).
- `deployment.environment` → `deployment.environment.name`.

### Notes
- Spans were already semconv-compliant (`http.request.method`, `http.response.status_code`, `http.route`, `url.*`, `server.address`) — unchanged.
- Seconds histogram buckets widened to cover sub-second HTTP through multi-second operations.
- deco-proprietary names (no semconv equivalent) centralized in `observability/otel/conventions.ts`.
- **Clean rename, no dual-emit** — ClickStack is a fresh backend; legacy HyperDX dashboards are being retired.
- `deno check` passes on all touched files.

Part of the HyperDX → ClickStack migration (normalize at source: semconv + seconds). Companion PR aligns `deco-cx/apps` ai-assistants to `gen_ai.*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns our metrics and resource attributes with OpenTelemetry semantic conventions, switches duration units to seconds using `@opentelemetry/semantic-conventions` constants, and corrects service.version to use the deployment revision. Standardizes HTTP, block operation, and cache telemetry for ClickStack; no dual-emit.

- **Refactors**
  - Renamed http_request_duration (ms) → http.server.request.duration (s); attributes now use http.request.method, http.route, http.response.status_code (int).
  - Renamed block_op_duration (ms) → deco.block.operation.duration (s); attributes now use deco.operation.name and deco.operation.error (bool); proprietary names centralized in observability/otel/conventions.ts.
  - Replaced cache_hit with a single counter: deco.cache.requests; dimensioned by deco.cache.status and deco.cache.engine; same key on spans and metrics.
  - Resource attributes now use stable ATTR_* constants; deployment.environment → deployment.environment.name; service.version now uses the deployment revision (fallback: framework version).
  - Updated seconds histogram buckets for sub-second through multi-second operations.

- **Dependencies**
  - Bumped `@opentelemetry/semantic-conventions` to 1.37.0 and stopped importing from `/incubating`; vendored the few incubating attribute names in observability/otel/conventions.ts and replaced deprecated SemanticResourceAttributes usage.

<sup>Written for commit 8f9a96021d82a83fac708ce6fabe4806670d5bcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/deco/pull/1211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized observability metrics and attributes using shared OpenTelemetry convention constants, including consistent cache telemetry and operation duration dimensions.
  * Added deco-specific convention constants for block operation and cache request signals.
* **Bug Fixes**
  * Improved duration metric accuracy by recording in seconds, removing premature rounding, and refining histogram buckets for sub-second precision.
  * Standardized span/metric attribute keys and error flags (boolean), including cache hit/miss/stale outcomes.
  * Updated OpenTelemetry resource attributes and service version fallback for more reliable metadata.
* **Documentation**
  * Documented deco-specific telemetry conventions and explicit handling of non-re-exported incubating semantic names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->