### PR TITLE
Fix publish workflow to gate Docker on JSR availability

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,19 +12,23 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  RELEASE_TAG: ${{ github.event.inputs.tag_name || github.ref_name }}
 
 jobs:
-  publish:
+  jsr-publish:
     runs-on: ubuntu-latest
 
     permissions:
       contents: read
-      packages: write
-      attestations: write
-      id-token: write
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.4.0
 
       - name: Publish package
         run: npx jsr publish
@@ -34,6 +38,41 @@ jobs:
 
       - name: Publish dev package
         run: cd dev/ && npx jsr publish
+
+      - name: Verify JSR package is resolvable
+        run: |
+          #!/bin/bash
+          set -euo pipefail
+
+          VERSION="${{ env.RELEASE_TAG }}"
+
+          for attempt in $(seq 1 30); do
+            if deno cache "jsr:@deco/deco@${VERSION}/scripts/run"; then
+              echo "JSR version ${VERSION} is resolvable (attempt ${attempt})"
+              exit 0
+            fi
+
+            echo "Waiting for JSR propagation (attempt ${attempt}/30)..."
+            sleep 10
+          done
+
+          echo "JSR version ${VERSION} not resolvable after 5 minutes"
+          exit 1
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: jsr-publish
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -59,7 +98,7 @@ jobs:
           REGISTRY: ${{ env.REGISTRY }}
           REPOSITORY: ${{ env.IMAGE_NAME }}
           IMAGE_TAG_LATEST: latest
-          IMAGE_TAG_COMMIT: ${{ github.event.inputs.tag_name || github.ref_name }}
+          IMAGE_TAG_COMMIT: ${{ env.RELEASE_TAG }}
         run: |
           #!/bin/bash
 
@@ -110,7 +149,7 @@ jobs:
           REGISTRY: ${{ env.REGISTRY }}
           REPOSITORY: ${{ env.IMAGE_NAME }}/deno2
           IMAGE_TAG_LATEST: latest
-          IMAGE_TAG_COMMIT: ${{ github.event.inputs.tag_name || github.ref_name }}
+          IMAGE_TAG_COMMIT: ${{ env.RELEASE_TAG }}
         run: |
           #!/bin/bash
 


### PR DESCRIPTION
## Summary
- Check out the release tag (not `main`) when publishing via `workflow_dispatch`
- Split the workflow into `jsr-publish` and `docker-build` jobs so a Docker failure does not block JSR publication
- Poll JSR after publish until `deno cache jsr:@deco/deco@<version>/scripts/run` succeeds before building images

## Test plan
- [ ] Merge and re-dispatch Publish workflow for `1.202.1` to confirm JSR resolves before Docker starts
- [ ] Verify a tag-triggered release still publishes all three JSR packages and builds Docker images
- [ ] Confirm a Docker build failure leaves the `jsr-publish` job marked as success


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates Docker image builds on JSR availability and uses the release tag for manual publishes. Splits the publish workflow so a Docker failure doesn’t block JSR publication.

- **Bug Fixes**
  - Check out the release tag (`RELEASE_TAG`) on `workflow_dispatch` instead of `main`.
  - Split into `jsr-publish` and `docker-build` jobs; `docker-build` waits on `jsr-publish`.
  - After publishing, poll until `deno cache jsr:@deco/deco@<version>/scripts/run` resolves (up to 5 minutes) before building images.
  - Tag Docker images with `RELEASE_TAG` to keep versions in sync.

<sup>Written for commit 396cab83a6fde63fac6c523b5cd63267e4418f9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/deco/pull/1214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow to use a single consistent release tag across publishing and image builds.
  * Added a verification step to confirm the published package is available before continuing.
  * Split Docker image building into a separate stage that runs after package publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->