### PR TITLE
fix(engine): drop never-gated hidden array items instead of null holes

### DIFF
--- a/engine/core/mod.test.ts
+++ b/engine/core/mod.test.ts
@@ -153,6 +153,39 @@ Deno.test("resolve", async (t) => {
     });
   });
 
+  await t.step(
+    "drops hidden array items (resolver -> undefined) but keeps null",
+    async () => {
+      // A hidden array item is a multivariate flag gated by a `never` matcher;
+      // flag.ts returns `undefined` when no variant matched. Such items must be
+      // dropped from the array, not left as holes (which serialize to `null`
+      // and render as empty cards). A resolver returning `null` is a legitimate
+      // value and is kept.
+      const resolverMap = {
+        resolve: (data: unknown) => context.resolve(data),
+        hiddenFlag: (): unknown => undefined,
+        nullFlag: (): unknown => null,
+        keep: (p: { label: string }) => p,
+      };
+      const result = await resolve<{ items: unknown[] }>(
+        {
+          items: [
+            { label: "A", __resolveType: "keep" },
+            { __resolveType: "hiddenFlag" },
+            { label: "B", __resolveType: "keep" },
+            { __resolveType: "nullFlag" },
+            { __resolveType: "hiddenFlag" },
+          ],
+          __resolveType: "resolve",
+        },
+        { ...context, resolvers: resolverMap as unknown as ResolverMap },
+      );
+      assertEquals(result, {
+        items: [{ label: "A" }, { label: "B" }, null],
+      });
+    },
+  );
+
   await t.step("resolves object with no resolvable fields", async () => {
     type TestType = {
       foo: string;

--- a/engine/core/mod.test.ts
+++ b/engine/core/mod.test.ts
@@ -186,6 +186,54 @@ Deno.test("resolve", async (t) => {
     },
   );
 
+  await t.step(
+    "an array where every item is hidden becomes empty (not a hole array)",
+    async () => {
+      const resolverMap = {
+        resolve: (data: unknown) => context.resolve(data),
+        hiddenFlag: (): unknown => undefined,
+      };
+      const result = await resolve<{ items: unknown[] }>(
+        {
+          items: [
+            { __resolveType: "hiddenFlag" },
+            { __resolveType: "hiddenFlag" },
+          ],
+          __resolveType: "resolve",
+        },
+        { ...context, resolvers: resolverMap as unknown as ResolverMap },
+      );
+      assertEquals(result, { items: [] });
+    },
+  );
+
+  await t.step(
+    "hidden items are dropped at every array depth (nested arrays)",
+    async () => {
+      // The fix relies on the filter firing at each array level via recursion,
+      // and on ordering being preserved when the first element is dropped.
+      const resolverMap = {
+        resolve: (data: unknown) => context.resolve(data),
+        hiddenFlag: (): unknown => undefined,
+        keep: (p: { label: string }) => p,
+      };
+      const result = await resolve<{ groups: unknown[][] }>(
+        {
+          groups: [
+            [
+              { __resolveType: "hiddenFlag" },
+              { label: "A", __resolveType: "keep" },
+            ],
+            [{ __resolveType: "hiddenFlag" }],
+          ],
+          __resolveType: "resolve",
+        },
+        { ...context, resolvers: resolverMap as unknown as ResolverMap },
+      );
+      assertEquals(result, { groups: [[{ label: "A" }], []] });
+    },
+  );
+
   await t.step("resolves object with no resolvable fields", async () => {
     type TestType = {
       foo: string;

--- a/engine/core/resolver.ts
+++ b/engine/core/resolver.ts
@@ -424,6 +424,15 @@ const resolvePropsWithHints = async <
   }
 
   if (!type) {
+    // Drop array items that resolved to `undefined` — a hidden array item is a
+    // multivariate flag gated by a `never` matcher, and flag.ts returns
+    // `undefined` when no variant matched. Left in place it survives as a hole
+    // (and serializes to `null` in JSON), which the consuming section renders
+    // as an empty card. A `null` from a resolver is a legitimate value and is
+    // kept — only the `undefined` "not present" sentinel is filtered.
+    if (Array.isArray(mutableProps)) {
+      return mutableProps.filter((item) => item !== undefined) as T;
+    }
     return mutableProps;
   }
 

--- a/engine/core/resolver.ts
+++ b/engine/core/resolver.ts
@@ -424,13 +424,17 @@ const resolvePropsWithHints = async <
   }
 
   if (!type) {
-    // Drop array items that resolved to `undefined` — a hidden array item is a
-    // multivariate flag gated by a `never` matcher, and flag.ts returns
-    // `undefined` when no variant matched. Left in place it survives as a hole
-    // (and serializes to `null` in JSON), which the consuming section renders
-    // as an empty card. A `null` from a resolver is a legitimate value and is
-    // kept — only the `undefined` "not present" sentinel is filtered.
-    if (Array.isArray(mutableProps)) {
+    // Compact `undefined` out of resolved arrays. An array element that resolved
+    // to `undefined` is a "not present" value (the motivating case: a hidden
+    // item — a multivariate flag gated by a `never` matcher, which flag.ts
+    // resolves to `undefined` when no variant matched). Object properties that
+    // resolve to `undefined` already vanish under `JSON.stringify`, but an
+    // `undefined` array element serializes to a `null` hole that the consuming
+    // section renders as an empty card — so filter it, making arrays consistent
+    // with object props. A resolver returning `null` is a legitimate value and
+    // is kept. `includes` first so the common (nothing-to-drop) case skips the
+    // reallocation the surrounding hot path deliberately avoids.
+    if (Array.isArray(mutableProps) && mutableProps.includes(undefined)) {
       return mutableProps.filter((item) => item !== undefined) as T;
     }
     return mutableProps;


### PR DESCRIPTION
## Summary

Same fix as the blocks runtime, ported to the deco engine.

Hiding an array item wraps it in a multivariate flag gated by a `never` matcher. `blocks/flag.ts` returns `match?.value` → **`undefined`** when no variant matched. The engine's `resolvePropsWithHints` wrote that `undefined` back into the resolved array (`mutableProps[index] = undefined`), leaving a hole that serializes to `null` in JSON and renders as an empty card (blank benefit rows, empty banners, etc.).

## Fix (`engine/core/resolver.ts`)

Compact `undefined` out of resolved arrays before returning. A resolver returning `null` is a legitimate value and is kept — only the `undefined` "not present" sentinel is filtered.

## Testing

Reproduced empirically first (array with a resolver returning `undefined` → serialized to `[...,null,null]`), then confirmed the fix drops the holes.

Added a regression step to `engine/core/mod.test.ts` (`drops hidden array items (resolver -> undefined) but keeps null`). Full `resolve` suite: **8/8 steps pass**. `deno fmt`/`deno lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drop hidden array items in the engine instead of leaving null holes. Prevents empty cards from `undefined` entries and skips extra work when arrays have no hidden items.

- **Bug Fixes**
  - Compact `undefined` from resolved arrays; only reallocate if the array contains `undefined`. Preserve `null`.
  - Broadened tests: all-hidden arrays resolve to `[]`, nested arrays drop hidden items, and `null` is kept.

<sup>Written for commit a6f2afde6d733d20ea77b48e3136927b0765bc6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/deco/pull/1217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed array property resolution to drop elements that resolve to `undefined`, avoiding empty slots in results.
  * Preserved explicitly resolved `null` values so they remain intact in array outputs.

* **Tests**
  * Added additional test coverage for hidden/omitted items within arrays, including nested arrays and the case where all elements are hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->