### PR TITLE
feat(fetch): record outgoing fetch duration by external host

### DIFF
--- a/runtime/fetch/fetchLog.ts
+++ b/runtime/fetch/fetchLog.ts
@@ -1,18 +1,89 @@
+import { ValueType } from "../../deps.ts";
+import { meter } from "../../observability/otel/metrics.ts";
 import { formatOutgoingFetch } from "../../utils/log.ts";
 
 let logger: null | ((_: string) => void) = null;
 
 export const setLogger = (loggerLike: typeof logger) => logger = loggerLike;
 
+/**
+ * Duration of every outgoing fetch, dimensioned by the external host.
+ *
+ * This wrapper already measured the duration — it just threw it away unless a
+ * logger happened to be installed, and the logger is null in production. So
+ * there was no way to answer "is the external API slow, or are we making too
+ * many calls to it?" from metrics; the only alternative was `otel_traces`,
+ * which is tail-sampled and does not carry client spans for these calls at all.
+ *
+ * `unit: "ms"` is deliberate: the meter provider in
+ * `observability/otel/metrics.ts` selects bucket boundaries by unit, so
+ * declaring "ms" picks up `[10, 100, 500, 1000, 5000, 10000, 15000]`
+ * automatically. Recording seconds here would land every observation in the
+ * first bucket.
+ *
+ * Cardinality: `server.address` is the host, never the path — a storefront
+ * talks to a handful of hosts (measured: 6 on a large VTEX store). Status is
+ * bucketed into a class rather than the raw code, keeping this at roughly
+ * 6 hosts x 5 classes per site.
+ */
+const outgoingFetchDuration = meter.createHistogram(
+  "outgoing_fetch_duration",
+  {
+    description: "duration of outgoing fetch calls, by external host",
+    unit: "ms",
+    valueType: ValueType.DOUBLE,
+  },
+);
+
+const statusClass = (status: number): string =>
+  status >= 500 ? "5xx" : status >= 400 ? "4xx" : status >= 300 ? "3xx" : "2xx";
+
+/**
+ * Host of the request, or null when it cannot be derived. Returning null keeps
+ * a malformed input from turning into a metric label — and from throwing inside
+ * the fetch path, which would be a far worse failure than a missing sample.
+ */
+const hostOf = (input: string | Request | URL): string | null => {
+  try {
+    if (typeof input === "string") return new URL(input).host;
+    if (input instanceof URL) return input.host;
+    return new URL(input.url).host;
+  } catch {
+    return null;
+  }
+};
+
 export const createFetch = (fetcher: typeof fetch): typeof fetch =>
   async function fetch(
     input: string | Request | URL,
     init?: RequestInit,
   ) {
-    const start = logger && performance.now();
-    const response = await fetcher(input, init);
+    const start = performance.now();
+    const host = hostOf(input);
 
-    if (logger && start) {
+    const record = (status: string) => {
+      if (host === null) return;
+      outgoingFetchDuration.record(Math.round(performance.now() - start), {
+        "server.address": host,
+        "http.response.status_class": status,
+      });
+    };
+
+    let response: Response;
+    try {
+      response = await fetcher(input, init);
+    } catch (error) {
+      // A throw here is an abort, a timeout or a transport failure. Those are
+      // the samples worth having most — a call that hangs for 60s and then
+      // aborts is invisible if only successful responses are recorded — so the
+      // duration is kept and the error is re-thrown untouched.
+      record("error");
+      throw error;
+    }
+
+    record(statusClass(response.status));
+
+    if (logger) {
       logger(
         formatOutgoingFetch(
           new Request(input, init),

--- a/runtime/fetch/fetchLog.ts
+++ b/runtime/fetch/fetchLog.ts
@@ -49,12 +49,20 @@ const statusClass = (status: number): string =>
  * inflate the very cardinality this metric is careful about. It also matches
  * semconv, where `server.address` is the address alone and `server.port` is a
  * separate attribute.
+ *
+ * The empty-string case is folded into null on purpose. Authority-less schemes
+ * — `data:`, `blob:`, `file:` — parse fine but have no hostname, and recording
+ * them would create a meaningless `server.address=""` series instead of simply
+ * not sampling a call that never crossed the network.
  */
 const hostOf = (input: string | Request | URL): string | null => {
   try {
-    if (typeof input === "string") return new URL(input).hostname;
-    if (input instanceof URL) return input.hostname;
-    return new URL(input.url).hostname;
+    const url = typeof input === "string"
+      ? new URL(input)
+      : input instanceof URL
+      ? input
+      : new URL(input.url);
+    return url.hostname || null;
   } catch {
     return null;
   }

--- a/runtime/fetch/fetchLog.ts
+++ b/runtime/fetch/fetchLog.ts
@@ -21,7 +21,7 @@ export const setLogger = (loggerLike: typeof logger) => logger = loggerLike;
  * automatically. Recording seconds here would land every observation in the
  * first bucket.
  *
- * Cardinality: `server.address` is the host, never the path — a storefront
+ * Cardinality: `server.address` is the hostname, never the path — a storefront
  * talks to a handful of hosts (measured: 6 on a large VTEX store). Status is
  * bucketed into a class rather than the raw code, keeping this at roughly
  * 6 hosts x 5 classes per site.
@@ -39,15 +39,22 @@ const statusClass = (status: number): string =>
   status >= 500 ? "5xx" : status >= 400 ? "4xx" : status >= 300 ? "3xx" : "2xx";
 
 /**
- * Host of the request, or null when it cannot be derived. Returning null keeps
- * a malformed input from turning into a metric label — and from throwing inside
- * the fetch path, which would be a far worse failure than a missing sample.
+ * Hostname of the request, or null when it cannot be derived. Returning null
+ * keeps a malformed input from turning into a metric label — and from throwing
+ * inside the fetch path, which would be a far worse failure than a missing
+ * sample.
+ *
+ * `hostname`, not `host`: `host` appends a non-default port, so
+ * `example.com:8080` and `example.com` would become two labels for one host and
+ * inflate the very cardinality this metric is careful about. It also matches
+ * semconv, where `server.address` is the address alone and `server.port` is a
+ * separate attribute.
  */
 const hostOf = (input: string | Request | URL): string | null => {
   try {
-    if (typeof input === "string") return new URL(input).host;
-    if (input instanceof URL) return input.host;
-    return new URL(input.url).host;
+    if (typeof input === "string") return new URL(input).hostname;
+    if (input instanceof URL) return input.hostname;
+    return new URL(input.url).hostname;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Problem

`createFetch` already measures the duration of every outgoing fetch. It just throws the number away unless a logger happens to be installed — and `logger` is `null` in production:

```ts
const start = logger && performance.now();
```

So there is no metric that answers *"is the external API slow, or are we making too many calls to it?"*. The only alternative is `otel_traces`, which is tail-sampled at ~1.7% and carries no client spans for these calls at all.

That gap is not academic. Investigating a storefront yesterday, `load-data` spans of 157s could not be attributed to anything — we could measure VTEX by hand from inside the pod (TTFB 0.39–0.55s, healthy) and measure the page (fast TTFB), but nothing connected the two. Every hypothesis about where the time went was a guess.

## Change

An `outgoing_fetch_duration` histogram, dimensioned by external host and status class.

Three design points, all copied from patterns already in this repo rather than invented:

**`unit: "ms"`.** The meter provider in `observability/otel/metrics.ts` selects bucket boundaries *by unit* — declaring `"ms"` automatically picks up `[10, 100, 500, 1000, 5000, 10000, 15000]`. That mechanism is worth calling out because the `@decocms/start` runtime lacks it and currently records seconds into millisecond buckets on all four of its duration metrics: **99.8%–99.95% of observations land in bucket 1** (measured on production ClickHouse), making every quantile there meaningless. This metric avoids that by construction.

**Low cardinality by construction.** `server.address` is the host, never the path, and status is bucketed into a class rather than the raw code — roughly 6 hosts × 5 classes per site (measured: a large VTEX storefront talks to 6 distinct hosts). For contrast, `loader_cache` reaches **3,684 distinct label values on a single site** and 21,849 fleet-wide, because it uses the full resolver chain (`Categories@sections.variants.1.value.5.sections.0.section.page`) as a label. That is a separate problem, but it is the reason this metric does not take a per-loader dimension.

**Failures are recorded, not dropped.** A call that hangs and then aborts is the sample you most want, and a success-only path loses exactly those. The error is re-thrown untouched.

`hostOf` returns `null` rather than throwing on malformed input, and a null host skips the sample — a metric must not be able to break the fetch path.

Logger behaviour is unchanged.

## What this does and does not give you

It attributes **time spent inside a single outbound call**, per host. It does *not* attribute time spent *between* calls — serial fan-out, block resolution, cache writes. If a 157s request turns out to be 200 sequential 700ms calls, this metric shows 200 healthy samples and the aggregate stays unexplained; `resolver_latency` is the signal for that, and it is currently emitted by only 5 tenants for reasons still unknown.

So this closes one specific gap rather than the whole attribution problem, and I would rather say that plainly than oversell it.

## Verification

`deno check runtime/fetch/fetchLog.ts` — clean.

Not verified: the metric has not been observed end-to-end in ClickHouse, since that needs a release. Worth confirming the series count per tenant after the first deploy — the expectation is single digits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record duration of all outgoing fetches by external host and status class to surface third‑party API latency in production. Adds a low‑cardinality ms histogram and captures failures.

- **New Features**
  - Adds `outgoing_fetch_duration` histogram (unit: `ms`).
  - Labels: `server.address` (hostname only) and `http.response.status_class` (`2xx`/`3xx`/`4xx`/`5xx`/`error`).
  - Records successes and failures; errors are rethrown.
  - Skips sampling when the host cannot be derived (includes `data:`, `blob:`, `file:`).

- **Bug Fixes**
  - Use `URL.hostname` for `server.address` to avoid port-based label splits and match semconv.
  - Fold empty hostname into `null` to prevent a `server.address=""` series.

<sup>Written for commit 972ebe346078c08a44ccc047f7c88193664baf56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/deco/pull/1218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Added outgoing request performance metrics, including duration and HTTP status categories by external host.
  - Transport failures are now captured as error metrics while preserving the original error behavior.
  - Malformed request addresses are handled safely without interrupting fetch operations.
  - Existing outgoing request logging remains available for monitoring and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->