### PR TITLE
fix(loader): label loader_cache with the block key, not the resolve chain

### DIFF
--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -188,6 +188,13 @@ const wrapLoader = (
   }: LoaderModule,
   resolveChain: FieldResolver[],
   release: DecofileProvider,
+  /**
+   * The block key — the loader's module path, e.g.
+   * `vtex/loaders/legacy/productListingPage.ts`. Used as the metric label
+   * instead of `ctx.resolverId`, which carries the full resolve chain and is
+   * unbounded. See the `loader` constant below.
+   */
+  blockKey: string,
 ) => {
   const [cacheMaxAge, mode] = typeof cache === "string"
     ? [MAX_AGE_S, cache]
@@ -208,7 +215,21 @@ const wrapLoader = (
       req: Request,
       ctx: FnContext<State, any>,
     ): Promise<ReturnType<typeof handler>> => {
-      const loader = ctx.resolverId || "unknown";
+      // Metric label. Deliberately the block key and NOT `ctx.resolverId`:
+      // resolverId carries the full resolve chain, e.g.
+      // `Categories@sections.variants.1.value.5.sections.0.section.page`, so
+      // every section position of every variant of every page becomes its own
+      // time series. Measured in production that reached 3,684 distinct values
+      // on a single site and 21,849 across the fleet, against a documented
+      // budget of 1,000 per site and 100 fleet-wide — and `loader_cache` alone
+      // became 76.6% of all rows in otel_metrics_sum.
+      //
+      // The block key is bounded by the number of loader modules in the app,
+      // which is what the @decocms/start runtime already uses for the
+      // equivalent metric (13 distinct values fleet-wide). The chain is not
+      // lost: it still travels on error logs, where high cardinality is fine
+      // because they are read by point lookup rather than aggregated.
+      const loader = blockKey || ctx.resolverId || "unknown";
       const start = performance.now();
       let status: "bypass" | "miss" | "stale" | "hit" | undefined;
 
@@ -365,7 +386,7 @@ const loaderBlock: Block<LoaderModule> = {
     wrapCaughtErrors,
     (props: TProps, ctx: HttpContext<{ global: any } & RequestState>) =>
       applyProps(
-        wrapLoader(mod, ctx.resolveChain, ctx.context.state.release),
+        wrapLoader(mod, ctx.resolveChain, ctx.context.state.release, key),
       )(
         props,
         ctx,

--- a/blocks/loader.ts
+++ b/blocks/loader.ts
@@ -230,6 +230,13 @@ const wrapLoader = (
       // lost: it still travels on error logs, where high cardinality is fine
       // because they are read by point lookup rather than aggregated.
       const loader = blockKey || ctx.resolverId || "unknown";
+      // Cache identity, kept as the resolve chain on purpose — this is NOT the
+      // metric label. The default `cacheKey` is `noop`, which returns "", so for
+      // a loader that opts into caching without declaring a `cacheKey` the
+      // resolve chain is the only thing separating two instances of the same
+      // block. Labelling the metric with `blockKey` must not collapse that, or
+      // one section would serve another's cached result.
+      const cacheResolver = ctx.resolverId || "unknown";
       const start = performance.now();
       let status: "bypass" | "miss" | "stale" | "hit" | undefined;
 
@@ -279,7 +286,7 @@ const wrapLoader = (
           return await handler(props, req, ctx);
         }
 
-        ctx.vary?.push(loader, cacheKeyValue);
+        ctx.vary?.push(cacheResolver, cacheKeyValue);
         RequestContext?.signal?.throwIfAborted();
 
         const cache = maybeCache;
@@ -300,7 +307,7 @@ const wrapLoader = (
         timing?.end();
 
         const cacheKeyUrl = `https://localhost/?${new URLSearchParams({
-          resolver: loader,
+          resolver: cacheResolver,
           revision: revisionID,
           cacheKey: cacheKeyValue,
         })}`;


### PR DESCRIPTION
Closes #1219.

## Problem

`loader_cache` and `resolver_latency` are labelled with `ctx.resolverId`, which carries the full resolve chain:

```
Categories@sections.variants.1.value.5.sections.0.section.page
SearchResults Global@sections.0.section.page
Categories@sections.variants.1.value.2.jsonLD
```

Every section position, of every variant, of every page becomes its own time series. That is an identifier, not a dimension.

## Measured

Distinct `loader` values on the production ClickHouse, 3h window:

| site | distinct values |
|---|---|
| fila-store | **3,684** |
| todolivrooficial | 3,478 |
| montecarlo | 2,209 |
| farmrio | 1,469 |
| happybooksoficial | 1,028 |
| **fleet total** | **21,849** |

Our own o11y guide forbids >1,000 distinct values per site as an alert dimension and >100 fleet-wide as a cross-fleet aggregation. Five sites are over; the fleet figure is **218× over**.

The cost is not theoretical: `loader_cache` is **11,485,954 of 14,998,196 rows** in `otel_metrics_sum` over 3h — **76.6% of the whole table** — and that table holds **48.4 GB**.

For contrast, `cache_hit` covers 194 tenants in **9 series**, and the `@decocms/start` runtime does the equivalent job with **13** distinct `deco.cache.profile` values fleet-wide (`vtex/productDetailsPage`, `vtex/relatedProducts`, `site/categoryTree`).

## Fix

Use the block key that `adapt` already receives — the loader's module path, e.g. `vtex/loaders/legacy/productListingPage.ts` — bounded by the number of loader modules in the app. Threaded into `wrapLoader` as a new parameter; `wrapLoader` is module-private with a single call site, so nothing external changes.

`ctx.resolverId` is kept as a fallback, so behaviour is unchanged if a caller ever passes an empty key.

## The trade-off, stated plainly

**This loses the ability to distinguish two instances of the same loader in different sections.** If you are debugging "which section is slow", the metric will no longer answer that — it will tell you which *loader* is slow.

That is deliberate, and it is the line the o11y guide already draws: high-cardinality attributes are fine for filtering and point lookups, forbidden as aggregation keys. The chain still travels on error logs, which are read by point lookup rather than aggregated.

If the per-section breakdown turns out to be load-bearing for someone, the alternative is to keep the chain as a **span** attribute and use the key for the metric — happy to switch to that shape instead.

## Note for reviewers

This changes an existing label's values. Any dashboard or alert currently grouping by `loader` will see its series collapse from thousands to dozens after deploy — better, but not a silent change. Historical data keeps the old labels, so charts spanning the deploy will show both.

## Verification

`deno check blocks/loader.ts` — clean. There is no existing test file for `blocks/loader.ts`; the change is a label substitution with a fallback, exercised by every loader call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Labels `loader_cache` and `resolver_latency` with the loader’s block key (module path) instead of the resolve chain to cut metric cardinality and keep dashboards within our o11y budget. Metrics now group by loader, not per-section instance. Cache identity and `ctx.vary` stay on the resolve chain, so cache behavior is unchanged.

- Uses `blockKey` as the `loader` label; falls back to `ctx.resolverId` if empty.
- Adds `blockKey` param to `wrapLoader`; internal only, no external API changes.
- Splits responsibilities: `loader` (block key) for metric label; `cacheResolver` (resolve chain) for `ctx.vary` and cache-key URL.
- Aligns with `@decocms/start` and reduces series in `otel_metrics_sum`.
- Dashboards grouping by `loader` will collapse from thousands of series to dozens; historical data keeps old labels, so mixed series may appear across the deploy window.

<sup>Written for commit 7868c4edf0c57f4e4652f5a5a3bf3a86e8756e53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/deco/pull/1220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loader performance tracking by using the specific loader identifier when available.
  * Added a fallback label to ensure cache and latency metrics remain available when an identifier is missing.
  * Preserved separate caching for each loader instance, helping maintain consistent behavior across different loading paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->