### PR TITLE
feat(preview): sandbox-less Fast Preview via pull-based draft decofile

### DIFF
--- a/engine/decofile/draft.test.ts
+++ b/engine/decofile/draft.test.ts
@@ -1,0 +1,493 @@
+import { assert, assertEquals } from "@std/assert";
+import {
+  applyDraftCookie,
+  clearDraftCache,
+  DEFAULT_PREVIEW_API_DOMAINS,
+  draftPointerFromRequest,
+  isDraftHostAllowed,
+  isDraftPreviewEnabled,
+  parseDraftPointer,
+  previewApiOriginForHost,
+  resolveDraftDecofile,
+  resolveDraftForRequest,
+  setDraftPreviewHosts,
+} from "./draft.ts";
+
+const ENV_ON = { DECO_ALLOWED_PREVIEW_HOSTS: "preview.example" };
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+// Canonical Studio decofile-API pointer prefix (authority + path, no version).
+const P = "studio.decocms.com/api/fila/decofile/vm-1/main?token=tok.abc";
+
+Deno.test("parseDraftPointer", async (t) => {
+  await t.step(
+    "parses <authority><path>@<version>, lowercasing authority",
+    () => {
+      assertEquals(
+        parseDraftPointer(
+          "Studio.decocms.com/api/fila/decofile/vm-1/main?token=Tok.abc@8c1d44e",
+        ),
+        {
+          host: "studio.decocms.com",
+          path: "/api/fila/decofile/vm-1/main?token=Tok.abc",
+          version: "8c1d44e",
+        },
+      );
+    },
+  );
+
+  await t.step("keeps an explicit port, incl. bare localhost", () => {
+    assertEquals(parseDraftPointer("localhost:4000/api/o/decofile/m/b@v1"), {
+      host: "localhost:4000",
+      path: "/api/o/decofile/m/b",
+      version: "v1",
+    });
+  });
+
+  await t.step(
+    "splits on the LAST @ — earlier @ fails, never half-reads",
+    () => {
+      assertEquals(parseDraftPointer("a.example/x@y/z@v1"), null);
+      assertEquals(parseDraftPointer("a@b@c"), null);
+    },
+  );
+
+  await t.step(
+    "requires a rooted path — authority-only tokens are gone",
+    () => {
+      assertEquals(
+        parseDraftPointer("abc.preview-studio.decocms.com@v1"),
+        null,
+      );
+      assertEquals(parseDraftPointer("a.example@v1"), null);
+    },
+  );
+
+  await t.step("rejects anything escaping the authority or path", () => {
+    assertEquals(parseDraftPointer("https://evil.example/x@v1"), null);
+    assertEquals(parseDraftPointer("a.example:80:80/x@v1"), null);
+    assertEquals(parseDraftPointer("a.example:abc/x@v1"), null);
+    assertEquals(parseDraftPointer(".leading.dot/x@v1"), null);
+    assertEquals(parseDraftPointer("a.example/x#frag@v1"), null);
+    assertEquals(parseDraftPointer("a.example/x y@v1"), null);
+  });
+
+  await t.step("validates the version charset — it becomes a cache key", () => {
+    assertEquals(parseDraftPointer("a.example/x@"), null);
+    assertEquals(parseDraftPointer(`a.example/x@${"x".repeat(65)}`), null);
+    assertEquals(parseDraftPointer("a.example/x@v 1"), null);
+    assertEquals(parseDraftPointer(null), null);
+  });
+});
+
+Deno.test("previewApiOriginForHost", async (t) => {
+  await t.step("admits authorities under the default deco domains", () => {
+    assertEquals(
+      previewApiOriginForHost("studio.decocms.com", {}),
+      "https://studio.decocms.com",
+    );
+    assertEquals(
+      previewApiOriginForHost("abc.preview-studio.decocms.com", {}),
+      "https://abc.preview-studio.decocms.com",
+    );
+    assertEquals(
+      previewApiOriginForHost("localhost:4000", {}),
+      "http://localhost:4000",
+    );
+    assertEquals(
+      previewApiOriginForHost("local.studio.decocms.com:4420", {}),
+      "https://local.studio.decocms.com:4420",
+    );
+    assertEquals(
+      previewApiOriginForHost("abc.localhost:60534", {}),
+      "http://abc.localhost:60534",
+    );
+  });
+
+  await t.step("rejects hosts outside the domains", () => {
+    assertEquals(previewApiOriginForHost("evil.example", {}), null);
+    assertEquals(previewApiOriginForHost("evil-decocms.com", {}), null);
+    assertEquals(previewApiOriginForHost("decocms.com", {}), null);
+  });
+
+  await t.step("allows an explicit port only for local entries", () => {
+    assertEquals(previewApiOriginForHost("studio.decocms.com:8500", {}), null);
+    assertEquals(
+      previewApiOriginForHost("abc.preview-studio.decocms.com:8500", {}),
+      null,
+    );
+  });
+
+  await t.step("honours a configured override instead of the defaults", () => {
+    const env = { DECO_PREVIEW_API_DOMAINS: ".staging.example" };
+    assertEquals(
+      previewApiOriginForHost("abc.staging.example", env),
+      "https://abc.staging.example",
+    );
+    assertEquals(previewApiOriginForHost("studio.decocms.com", env), null);
+  });
+});
+
+Deno.test("gating", async (t) => {
+  await t.step("on iff an allowed host is configured", () => {
+    assertEquals(isDraftPreviewEnabled(ENV_ON), true);
+    assertEquals(isDraftPreviewEnabled({}), false);
+  });
+
+  await t.step("matches request hosts verbatim, port + case", () => {
+    const env = { DECO_ALLOWED_PREVIEW_HOSTS: "fila.vtex.app, localhost:3100" };
+    assertEquals(isDraftHostAllowed("FILA.VTEX.APP", env), true);
+    assertEquals(isDraftHostAllowed("localhost:3100", env), true);
+    assertEquals(isDraftHostAllowed("fila.com.br", env), false);
+    assertEquals(isDraftHostAllowed("localhost", env), false);
+    assertEquals(isDraftHostAllowed(null, env), false);
+    assertEquals(isDraftHostAllowed("fila.vtex.app", {}), false);
+  });
+});
+
+Deno.test("resolveDraftDecofile", async (t) => {
+  await t.step("fetches the token's path on its validated origin", async () => {
+    clearDraftCache();
+    const calls: string[] = [];
+    const blocks = await resolveDraftDecofile({
+      pointer: `${P}@v1`,
+      env: ENV_ON,
+      fetchImpl: ((url: string) => {
+        calls.push(String(url));
+        return Promise.resolve(
+          jsonResponse({ "pages-home": { title: "draft" } }),
+        );
+      }) as unknown as typeof fetch,
+    });
+    assertEquals(blocks, { "pages-home": { title: "draft" } });
+    assertEquals(calls, [
+      "https://studio.decocms.com/api/fila/decofile/vm-1/main?token=tok.abc&v=v1",
+    ]);
+  });
+
+  await t.step("is inert without a host allowlist — no fetch", async () => {
+    clearDraftCache();
+    let called = false;
+    const blocks = await resolveDraftDecofile({
+      pointer: `${P}@v1`,
+      env: {},
+      fetchImpl: (() => {
+        called = true;
+        return Promise.resolve(jsonResponse({}));
+      }) as unknown as typeof fetch,
+    });
+    assertEquals(blocks, null);
+    assertEquals(called, false);
+  });
+
+  await t.step("origin validation runs before the cache", async () => {
+    clearDraftCache();
+    let called = false;
+    const fetchImpl = (() => {
+      called = true;
+      return Promise.resolve(jsonResponse({}));
+    }) as unknown as typeof fetch;
+    assertEquals(
+      await resolveDraftDecofile({
+        pointer: "abc.evil.example/x@v1",
+        env: ENV_ON,
+        fetchImpl,
+      }),
+      null,
+    );
+    assertEquals(called, false);
+    await resolveDraftDecofile({ pointer: `${P}@vX`, env: ENV_ON, fetchImpl });
+    assertEquals(called, true);
+    assertEquals(
+      await resolveDraftDecofile({
+        pointer: "abc.evil.example/x@vX",
+        env: ENV_ON,
+        fetchImpl,
+      }),
+      null,
+    );
+  });
+
+  await t.step("caches by version — one fetch per version", async () => {
+    clearDraftCache();
+    let fetches = 0;
+    const fetchImpl = (() => {
+      fetches++;
+      return Promise.resolve(jsonResponse({ n: fetches }));
+    }) as unknown as typeof fetch;
+    const a = await resolveDraftDecofile({
+      pointer: `${P}@v1`,
+      env: ENV_ON,
+      fetchImpl,
+    });
+    const b = await resolveDraftDecofile({
+      pointer: `${P}@v1`,
+      env: ENV_ON,
+      fetchImpl,
+    });
+    assertEquals(fetches, 1);
+    assert(b === a);
+    await resolveDraftDecofile({ pointer: `${P}@v2`, env: ENV_ON, fetchImpl });
+    assertEquals(fetches, 2);
+  });
+
+  await t.step("bounds the cache (cap 3)", async () => {
+    clearDraftCache();
+    let fetches = 0;
+    const fetchImpl = (() => {
+      fetches++;
+      return Promise.resolve(jsonResponse({ n: fetches }));
+    }) as unknown as typeof fetch;
+    for (const v of ["v1", "v2", "v3", "v4"]) {
+      await resolveDraftDecofile({
+        pointer: `${P}@${v}`,
+        env: ENV_ON,
+        fetchImpl,
+      });
+    }
+    assertEquals(fetches, 4);
+    await resolveDraftDecofile({ pointer: `${P}@v1`, env: ENV_ON, fetchImpl });
+    assertEquals(fetches, 5); // v1 evicted — re-fetch, never stale
+    await resolveDraftDecofile({ pointer: `${P}@v4`, env: ENV_ON, fetchImpl });
+    assertEquals(fetches, 5); // v4 resident
+  });
+
+  await t.step(
+    "degrades to published on unreachable / non-2xx / bad json",
+    async () => {
+      for (
+        const fetchImpl of [
+          () => Promise.reject(new Error("ECONNREFUSED")),
+          () => Promise.resolve(new Response("nope", { status: 404 })),
+          () =>
+            Promise.resolve(
+              new Response("<html>not json</html>", {
+                status: 200,
+                headers: { "content-type": "text/html" },
+              }),
+            ),
+        ]
+      ) {
+        clearDraftCache();
+        assertEquals(
+          await resolveDraftDecofile({
+            pointer: `${P}@v1`,
+            env: ENV_ON,
+            fetchImpl: fetchImpl as unknown as typeof fetch,
+          }),
+          null,
+        );
+      }
+    },
+  );
+});
+
+Deno.test("DEFAULT_PREVIEW_API_DOMAINS is pinned", () => {
+  assertEquals(DEFAULT_PREVIEW_API_DOMAINS, [
+    "local.studio.decocms.com",
+    "localhost",
+    "127.0.0.1",
+    ".localhost",
+    ".decocms.com",
+  ]);
+});
+
+Deno.test("site-block preview hosts", async (t) => {
+  await t.step("enables the feature from the site block alone", () => {
+    setDraftPreviewHosts(["fila.vtex.app", "LOCALHOST:3100", 42, "  "]);
+    try {
+      assertEquals(isDraftPreviewEnabled({}), true);
+      assertEquals(isDraftHostAllowed("fila.vtex.app", {}), true);
+      assertEquals(isDraftHostAllowed("localhost:3100", {}), true);
+      assertEquals(isDraftHostAllowed("evil.example", {}), false);
+    } finally {
+      setDraftPreviewHosts([]);
+    }
+  });
+
+  await t.step("env REPLACES the block hosts when set", () => {
+    setDraftPreviewHosts(["fila.vtex.app"]);
+    try {
+      const env = { DECO_ALLOWED_PREVIEW_HOSTS: "other.example" };
+      assertEquals(isDraftHostAllowed("other.example", env), true);
+      assertEquals(isDraftHostAllowed("fila.vtex.app", env), false);
+    } finally {
+      setDraftPreviewHosts([]);
+    }
+  });
+});
+
+Deno.test("draftPointerFromRequest", async (t) => {
+  await t.step("reads the __deco_draft cookie", () => {
+    const req = new Request(
+      "https://preview.example/deco/invoke/site/loaders/x.ts",
+      {
+        headers: {
+          cookie: "a=1; __deco_draft=abc.preview-studio.decocms.com@v1; b=2",
+        },
+      },
+    );
+    assertEquals(
+      draftPointerFromRequest(req),
+      "abc.preview-studio.decocms.com@v1",
+    );
+  });
+
+  await t.step("lets ?__draft= win over the cookie", () => {
+    const req = new Request("https://preview.example/p?__draft=h@v2", {
+      headers: { cookie: "__deco_draft=h@v1" },
+    });
+    assertEquals(draftPointerFromRequest(req), "h@v2");
+  });
+
+  await t.step("returns null on ?__draft=off even with a cookie", () => {
+    const req = new Request("https://preview.example/p?__draft=off", {
+      headers: { cookie: "__deco_draft=h@v1" },
+    });
+    assertEquals(draftPointerFromRequest(req), null);
+  });
+
+  await t.step("returns null with neither param nor cookie", () => {
+    assertEquals(
+      draftPointerFromRequest(new Request("https://preview.example/p")),
+      null,
+    );
+  });
+});
+
+Deno.test("resolveDraftForRequest", async (t) => {
+  const ENV = { DECO_ALLOWED_PREVIEW_HOSTS: "preview.example" };
+  function invokeReq(host = "preview.example"): Request {
+    return new Request(
+      "https://preview.example/deco/invoke/site/loaders/x.ts",
+      {
+        method: "POST",
+        headers: {
+          "x-forwarded-host": host,
+          cookie: `__deco_draft=${encodeURIComponent(`${P}@v1`)}`,
+        },
+      },
+    );
+  }
+
+  await t.step(
+    "binds the draft when host allowed and pointer resolves",
+    async () => {
+      clearDraftCache();
+      const fetchImpl = (() =>
+        Promise.resolve(
+          jsonResponse({ "site/x": { value: "draft" } }),
+        )) as unknown as typeof fetch;
+      assertEquals(
+        await resolveDraftForRequest(invokeReq(), { env: ENV, fetchImpl }),
+        {
+          "site/x": { value: "draft" },
+        },
+      );
+    },
+  );
+
+  await t.step(
+    "is inert with no allowlist — never touches the network",
+    async () => {
+      clearDraftCache();
+      let called = false;
+      const fetchImpl = (() => {
+        called = true;
+        return Promise.resolve(jsonResponse({}));
+      }) as unknown as typeof fetch;
+      assertEquals(
+        await resolveDraftForRequest(invokeReq(), { env: {}, fetchImpl }),
+        null,
+      );
+      assertEquals(called, false);
+    },
+  );
+
+  await t.step("refuses a disallowed request host", async () => {
+    clearDraftCache();
+    let called = false;
+    const fetchImpl = (() => {
+      called = true;
+      return Promise.resolve(jsonResponse({}));
+    }) as unknown as typeof fetch;
+    assertEquals(
+      await resolveDraftForRequest(invokeReq("evil.example"), {
+        env: ENV,
+        fetchImpl,
+      }),
+      null,
+    );
+    assertEquals(called, false);
+  });
+});
+
+Deno.test("applyDraftCookie", async (t) => {
+  await t.step("sets the __deco_draft cookie for an allowed host", () => {
+    const headers = new Headers();
+    applyDraftCookie(
+      new Request(
+        `https://preview.example/p?__draft=${encodeURIComponent(`${P}@v1`)}`,
+        {
+          headers: { host: "preview.example" },
+        },
+      ),
+      headers,
+      ENV_ON,
+    );
+    const setCookie = headers.get("set-cookie") ?? "";
+    assert(setCookie.includes("__deco_draft="));
+    assert(setCookie.includes("HttpOnly"));
+  });
+
+  await t.step("clears the cookie on ?__draft=off, on any host", () => {
+    const headers = new Headers();
+    applyDraftCookie(
+      new Request("https://prod.example/p?__draft=off", {
+        headers: { host: "prod.example" },
+      }),
+      headers,
+      ENV_ON,
+    );
+    const setCookie = headers.get("set-cookie") ?? "";
+    assert(setCookie.includes("__deco_draft="));
+    assert(
+      setCookie.toLowerCase().includes("max-age=0") ||
+        setCookie.includes("Expires"),
+    );
+  });
+
+  await t.step("does nothing without a __draft param", () => {
+    const headers = new Headers();
+    applyDraftCookie(
+      new Request("https://preview.example/p", {
+        headers: { host: "preview.example" },
+      }),
+      headers,
+      ENV_ON,
+    );
+    assertEquals(headers.get("set-cookie"), null);
+  });
+
+  await t.step("does not set a cookie on a non-allowed host", () => {
+    const headers = new Headers();
+    applyDraftCookie(
+      new Request(
+        `https://evil.example/p?__draft=${encodeURIComponent(`${P}@v1`)}`,
+        {
+          headers: { host: "evil.example" },
+        },
+      ),
+      headers,
+      ENV_ON,
+    );
+    assertEquals(headers.get("set-cookie"), null);
+  });
+});

--- a/engine/decofile/draft.test.ts
+++ b/engine/decofile/draft.test.ts
@@ -238,6 +238,34 @@ Deno.test("resolveDraftDecofile", async (t) => {
     assertEquals(fetches, 2);
   });
 
+  await t.step(
+    "does not collide two sources sharing a version label",
+    async () => {
+      clearDraftCache();
+      const bodies: Record<string, unknown> = {
+        "studio.decocms.com/api/a/decofile/vm/main": { src: "a" },
+        "studio.decocms.com/api/b/decofile/vm/main": { src: "b" },
+      };
+      const fetchImpl = ((url: string) => {
+        const u = new URL(String(url));
+        return Promise.resolve(jsonResponse(bodies[`${u.host}${u.pathname}`]));
+      }) as unknown as typeof fetch;
+      const a = await resolveDraftDecofile({
+        pointer: "studio.decocms.com/api/a/decofile/vm/main@v1",
+        env: ENV_ON,
+        fetchImpl,
+      });
+      const b = await resolveDraftDecofile({
+        pointer: "studio.decocms.com/api/b/decofile/vm/main@v1",
+        env: ENV_ON,
+        fetchImpl,
+      });
+      // Same version label "v1", different path → must NOT serve a's cache for b.
+      assertEquals(a, { src: "a" });
+      assertEquals(b, { src: "b" });
+    },
+  );
+
   await t.step("bounds the cache (cap 3)", async () => {
     clearDraftCache();
     let fetches = 0;
@@ -360,6 +388,16 @@ Deno.test("draftPointerFromRequest", async (t) => {
       null,
     );
   });
+
+  await t.step(
+    "returns null (never throws) on a malformed cookie value",
+    () => {
+      const req = new Request("https://preview.example/p", {
+        headers: { cookie: "__deco_draft=%E0%A4%A" },
+      });
+      assertEquals(draftPointerFromRequest(req), null);
+    },
+  );
 });
 
 Deno.test("resolveDraftForRequest", async (t) => {

--- a/engine/decofile/draft.ts
+++ b/engine/decofile/draft.ts
@@ -234,26 +234,35 @@ export function isDraftPreviewEnabled(env?: EnvLike): boolean {
 }
 
 /**
- * Version cache. Bounded on purpose: a decofile is routinely multi-megabyte,
- * so an unbounded map keyed by version would grow with every save until the
- * process died. Content-addressed, so a hit is always correct.
+ * Draft cache. Bounded on purpose: a decofile is routinely multi-megabyte, so
+ * an unbounded map would grow with every save until the process died.
+ *
+ * Keyed by the FULL source identity (`<host><path>@<version>`), not the version
+ * alone: `version` is a branch-head sha in production (globally unique), but the
+ * type accepts any short label (`v1`, a branch id) and one runtime can be
+ * pointed at more than one draft source. Keying on host+path+version makes a
+ * hit correct even when two sources reuse a version label.
  */
-const MAX_CACHED_VERSIONS = 3;
-const byVersion = new Map<string, Record<string, unknown>>();
+const MAX_CACHED_DRAFTS = 3;
+const byKey = new Map<string, Record<string, unknown>>();
 
-function cacheDraft(version: string, blocks: Record<string, unknown>): void {
-  byVersion.delete(version);
-  byVersion.set(version, blocks);
-  while (byVersion.size > MAX_CACHED_VERSIONS) {
-    const oldest = byVersion.keys().next().value;
+function draftCacheKey(p: DraftPointer): string {
+  return `${p.host}${p.path}@${p.version}`;
+}
+
+function cacheDraft(key: string, blocks: Record<string, unknown>): void {
+  byKey.delete(key);
+  byKey.set(key, blocks);
+  while (byKey.size > MAX_CACHED_DRAFTS) {
+    const oldest = byKey.keys().next().value;
     if (oldest === undefined) break;
-    byVersion.delete(oldest);
+    byKey.delete(oldest);
   }
 }
 
-/** Test seam — drops every cached version. */
+/** Test seam — drops every cached draft. */
 export function clearDraftCache(): void {
-  byVersion.clear();
+  byKey.clear();
 }
 
 export interface ResolveDraftOptions {
@@ -286,7 +295,8 @@ export async function resolveDraftDecofile(
   const origin = previewApiOriginForHost(parsed.host, env);
   if (!origin) return null;
 
-  const cached = byVersion.get(parsed.version);
+  const key = draftCacheKey(parsed);
+  const cached = byKey.get(key);
   if (cached) return cached;
 
   const doFetch = options.fetchImpl ?? fetch;
@@ -312,7 +322,7 @@ export async function resolveDraftDecofile(
     return null;
   }
 
-  cacheDraft(parsed.version, blocks);
+  cacheDraft(key, blocks);
   return blocks;
 }
 
@@ -339,7 +349,15 @@ function readCookieValue(
     const eq = part.indexOf("=");
     if (eq === -1) continue;
     if (part.slice(0, eq).trim() === name) {
-      return decodeURIComponent(part.slice(eq + 1).trim());
+      const raw = part.slice(eq + 1).trim();
+      // A malformed `%` sequence makes `decodeURIComponent` throw; a bad cookie
+      // must degrade to "no draft", never surface as an error to direct
+      // callers of the exported reader.
+      try {
+        return decodeURIComponent(raw);
+      } catch {
+        return null;
+      }
     }
   }
   return null;

--- a/engine/decofile/draft.ts
+++ b/engine/decofile/draft.ts
@@ -1,0 +1,426 @@
+import { deleteCookie, setCookie } from "@std/http";
+
+/**
+ * Fast Preview — pull-based draft decofile.
+ *
+ * Studio serves the draft decofile (the merged `.deco/blocks/*.json` at the
+ * branch head) from its GitHub-backed decofile API
+ * (`GET <origin>/api/<org>/decofile/<virtualMcpId>/<branch>?token=…`); a
+ * production site pulls it and renders its own real pages against it, as a
+ * request-scoped SNAPSHOT of the release. This replaces the sandbox daemon
+ * that used to sync the draft into a folder the site watched: no separate
+ * process, no `/_sandbox/decofile`, just an HTTP pull.
+ *
+ * This module is the framework-agnostic half: token parsing, origin
+ * validation, fetching, and version caching. Binding a resolved draft to a
+ * request is done by the runtime (see `runtime/mod.ts`'s `prepareState`, which
+ * swaps `state.release` for a `fromJSON`-backed provider of the pulled draft).
+ *
+ * Inert unless `DECO_ALLOWED_PREVIEW_HOSTS` (or the site-declared preview
+ * hosts) names the request's host: upgrading the package must never be enough
+ * to start fetching from the network and rendering unpublished content.
+ * Host-scoping (rather than a boolean) exists because one deployment commonly
+ * serves several domains — the preview domain may render drafts while the
+ * production domain, on the same build, must ignore a `?__draft=` entirely.
+ */
+
+/**
+ * A parsed `?__draft=` token: `<host[:port]><path[?query]>@<version>`.
+ *
+ * The token carries the AUTHORITY + PATH of the draft content API, never a
+ * scheme — a full URL would be an SSRF vector, and the scheme is derived from
+ * the matched domain instead. The path is REQUIRED and typically addresses
+ * Studio's decofile API (`/api/<org>/decofile/<virtualMcpId>/<branch>?token=…`);
+ * its query carries the signed draft grant.
+ */
+export interface DraftPointer {
+  /** Content-API authority, e.g. `studio.decocms.com` or `localhost:4000`. */
+  host: string;
+  /** Path (+ query) on that authority serving the decofile JSON. */
+  path: string;
+  /** Opaque content version (the branch head sha / server ETag). Immutable → safe cache key. */
+  version: string;
+}
+
+/** Lowercase DNS hostname. A single label is allowed — exact-host domain
+ * entries (`localhost`, `local.studio.decocms.com`) can admit it. */
+const HOST_RE =
+  /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
+const PORT_RE = /^[0-9]{1,5}$/;
+const VERSION_RE = /^[A-Za-z0-9._-]{1,64}$/;
+/** Rooted path with an optional query; conservative charset, no `@`/`#`/space. */
+const PATH_RE = /^\/[A-Za-z0-9/_.%~=&?-]*$/;
+
+/**
+ * Parse `<host[:port]><path>@<version>`. Null on anything unexpected — callers
+ * fall back to published content. Splits on the LAST `@` (neither the path
+ * charset nor a signed token may contain one, so a stray `@` fails validation
+ * rather than being half-read).
+ */
+export function parseDraftPointer(
+  raw: string | null | undefined,
+): DraftPointer | null {
+  if (!raw) return null;
+  const at = raw.lastIndexOf("@");
+  if (at <= 0 || at === raw.length - 1) return null;
+  const authorityAndPath = raw.slice(0, at);
+  const version = raw.slice(at + 1);
+  if (!VERSION_RE.test(version)) return null;
+
+  const slash = authorityAndPath.indexOf("/");
+  if (slash === -1) return null;
+  const authority = authorityAndPath.slice(0, slash).toLowerCase();
+  const path = authorityAndPath.slice(slash);
+  if (!PATH_RE.test(path)) return null;
+
+  const [host, port, extra] = authority.split(":");
+  if (extra !== undefined) return null;
+  if (!host || !HOST_RE.test(host)) return null;
+  if (port !== undefined && !PORT_RE.test(port)) return null;
+
+  return {
+    host: port === undefined ? host : `${host}:${port}`,
+    path,
+    version,
+  };
+}
+
+/**
+ * Domains the draft content API may live under — deco-operated, so shipping
+ * them as defaults adds no SSRF surface. `DECO_PREVIEW_API_DOMAINS` overrides
+ * the whole list when set.
+ *
+ * Two entry shapes: a dot-prefixed entry is a suffix match with a guaranteed
+ * label boundary (`evil-decocms.com` cannot pass `.decocms.com`); a bare entry
+ * is an exact-host match (needed for `localhost` and dev origins, which no
+ * suffix can admit). Order matters only for the local/port rule: the first
+ * matching entry decides whether a port and `http` are allowed.
+ */
+export const DEFAULT_PREVIEW_API_DOMAINS = [
+  "local.studio.decocms.com", // native/web dev origin (http, explicit port)
+  "localhost",
+  "127.0.0.1", // loopback dev — `localhost` can resolve to a different (IPv6) server
+  ".localhost",
+  ".decocms.com", // hosted Studio (decofile API) + preview daemons
+];
+
+type EnvLike = Record<string, string | undefined>;
+
+/** Read a single env var, tolerating a missing `--allow-env` permission. */
+function safeEnvGet(name: string): string | undefined {
+  try {
+    return Deno.env.get(name);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the env source: an explicit object (tests / callers) or a lazy view
+ * over the specific `Deno.env` vars this module reads. Materialising only the
+ * keys we need avoids requiring blanket env access.
+ */
+function envOrDeno(env?: EnvLike): EnvLike {
+  if (env) return env;
+  return {
+    DECO_PREVIEW_API_DOMAINS: safeEnvGet("DECO_PREVIEW_API_DOMAINS"),
+    DECO_ALLOWED_PREVIEW_HOSTS: safeEnvGet("DECO_ALLOWED_PREVIEW_HOSTS"),
+  };
+}
+
+function readApiDomains(env: EnvLike): string[] {
+  const configured = (env.DECO_PREVIEW_API_DOMAINS ?? "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  return configured.length > 0 ? configured : DEFAULT_PREVIEW_API_DOMAINS;
+}
+
+/**
+ * Validate the token's authority against the configured domains and derive the
+ * fetch origin, or null if no domain admits it.
+ *
+ * The token proposes, configuration disposes: only the hostname-suffix match
+ * decides, so a caller can steer WHICH label under your domains, never which
+ * domains. Scheme is derived — http for localhost-ish domains, https
+ * otherwise — and an explicit port is allowed only there, so a public-domain
+ * token cannot aim at odd ports.
+ */
+export function previewApiOriginForHost(
+  authority: string,
+  env?: EnvLike,
+): string | null {
+  const [host, port] = authority.toLowerCase().split(":");
+  if (!host) return null;
+  const domain = readApiDomains(envOrDeno(env)).find((d) =>
+    d.startsWith(".") ? host.length > d.length && host.endsWith(d) : host === d
+  );
+  if (!domain) return null;
+  // Local entries may carry an explicit port; public domains may not (a
+  // public-domain token must not steer the fetch at odd ports).
+  const local = domain === "localhost" ||
+    domain === "127.0.0.1" ||
+    domain.endsWith(".localhost") ||
+    domain === "local.studio.decocms.com";
+  if (port !== undefined && !local) return null;
+  // Scheme is derived, never taken from the token. Plain-loopback dev hosts
+  // are http; local.studio.decocms.com is the native app's TLS dev origin
+  // (locally-trusted cert), so it — like every public domain — is https.
+  const insecure = domain === "localhost" ||
+    domain === "127.0.0.1" ||
+    domain.endsWith(".localhost");
+  return `${insecure ? "http" : "https"}://${host}${
+    port === undefined ? "" : `:${port}`
+  }`;
+}
+
+/**
+ * Hosts declared by the site itself (the global `site` block's `previewHosts`),
+ * installed once at setup time.
+ *
+ * MUST be fed from the setup-time base blocks, never from the request-time
+ * (possibly drafted) release: an allowlist readable through the draft could be
+ * rewritten by the very draft it gates.
+ */
+const G = globalThis as { __decoDraftHosts?: string[] };
+
+/** Install the site-declared preview hosts. Called at setup by the site app. */
+export function setDraftPreviewHosts(hosts: readonly unknown[]): void {
+  G.__decoDraftHosts = hosts
+    .filter((h): h is string => typeof h === "string")
+    .map((h) => h.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+/**
+ * Hosts allowed to render drafts.
+ *
+ * The site block is the expected source — the opt-in lives in the repo,
+ * reviewed in a PR, versioned with branches. `DECO_ALLOWED_PREVIEW_HOSTS`
+ * REPLACES it when set: an operational escape hatch (kill a bad value without
+ * a deploy, add a machine-specific port) — not the primary configuration.
+ */
+function readAllowedHosts(env: EnvLike): string[] {
+  const fromEnv = (env.DECO_ALLOWED_PREVIEW_HOSTS ?? "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  return fromEnv.length > 0 ? fromEnv : (G.__decoDraftHosts ?? []);
+}
+
+/**
+ * Whether `host` (as seen on the request) may render drafts.
+ *
+ * Compared verbatim, port included — local dev is `localhost:3100`, not
+ * `localhost`. The header is spoofable by a direct-to-origin request, but the
+ * draft id is the actual capability; host-scoping bounds blast radius
+ * (production domains stay inert), it is not a secret.
+ */
+export function isDraftHostAllowed(
+  host: string | null | undefined,
+  env?: EnvLike,
+): boolean {
+  if (!host) return false;
+  return readAllowedHosts(envOrDeno(env)).includes(host.trim().toLowerCase());
+}
+
+/**
+ * True when any host is allowed to preview. A cheap read callers use to gate
+ * BEFORE touching the network, so an unconfigured site is fully inert. The
+ * per-request host match happens later, in `isDraftHostAllowed`.
+ */
+export function isDraftPreviewEnabled(env?: EnvLike): boolean {
+  return readAllowedHosts(envOrDeno(env)).length > 0;
+}
+
+/**
+ * Version cache. Bounded on purpose: a decofile is routinely multi-megabyte,
+ * so an unbounded map keyed by version would grow with every save until the
+ * process died. Content-addressed, so a hit is always correct.
+ */
+const MAX_CACHED_VERSIONS = 3;
+const byVersion = new Map<string, Record<string, unknown>>();
+
+function cacheDraft(version: string, blocks: Record<string, unknown>): void {
+  byVersion.delete(version);
+  byVersion.set(version, blocks);
+  while (byVersion.size > MAX_CACHED_VERSIONS) {
+    const oldest = byVersion.keys().next().value;
+    if (oldest === undefined) break;
+    byVersion.delete(oldest);
+  }
+}
+
+/** Test seam — drops every cached version. */
+export function clearDraftCache(): void {
+  byVersion.clear();
+}
+
+export interface ResolveDraftOptions {
+  /** Raw `<host[:port]><path>@<version>` token from the request. */
+  pointer: string | null | undefined;
+  /** Defaults to `Deno.env`. */
+  env?: EnvLike;
+  /** Defaults to global `fetch`. Injected in tests. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Resolve a draft token to a decofile, or null to render published content.
+ *
+ * Null on every failure path — disabled, malformed token, disallowed origin,
+ * unreachable, non-2xx — because a draft that cannot be resolved must degrade
+ * to published rather than break the page.
+ */
+export async function resolveDraftDecofile(
+  options: ResolveDraftOptions,
+): Promise<Record<string, unknown> | null> {
+  const env = envOrDeno(options.env);
+  if (readAllowedHosts(env).length === 0) return null;
+
+  const parsed = parseDraftPointer(options.pointer);
+  if (!parsed) return null;
+
+  // Origin validation BEFORE the cache: a cached version must never be served
+  // for a pointer whose authority the configuration would reject.
+  const origin = previewApiOriginForHost(parsed.host, env);
+  if (!origin) return null;
+
+  const cached = byVersion.get(parsed.version);
+  if (cached) return cached;
+
+  const doFetch = options.fetchImpl ?? fetch;
+  // The pointer's version rides along as `v=`, making the fetch URL fully
+  // content-addressed (path + token + version). Today the server serves it
+  // no-store either way — token-protected drafts are deliberately NOT
+  // shared-cacheable. The param still earns its place: version-tagged access
+  // logs, and it is the prerequisite for edge-validated caching later.
+  const url = new URL(parsed.path, origin);
+  url.searchParams.append("v", parsed.version);
+  let res: Response;
+  try {
+    res = await doFetch(url.toString(), { cache: "no-store" });
+  } catch {
+    return null;
+  }
+  if (!res.ok) return null;
+
+  let blocks: Record<string, unknown>;
+  try {
+    blocks = (await res.json()) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  cacheDraft(parsed.version, blocks);
+  return blocks;
+}
+
+// ---------------------------------------------------------------------------
+// Request-level resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Cookie the draft pointer travels in across navigation and secondary requests
+ * (client-fetched sections hitting `/deco/render` / `/deco/invoke`). Set on
+ * entry when a `?__draft=` param arrives; read back off the raw Request here.
+ */
+export const DRAFT_COOKIE_NAME = "__deco_draft";
+/** Query param that enters draft mode; `off` leaves it. */
+export const DRAFT_QUERY_PARAM = "__draft";
+
+/** Read one cookie value out of a raw `Cookie:` header. */
+function readCookieValue(
+  cookieHeader: string | null | undefined,
+  name: string,
+): string | null {
+  if (!cookieHeader) return null;
+  for (const part of cookieHeader.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === name) {
+      return decodeURIComponent(part.slice(eq + 1).trim());
+    }
+  }
+  return null;
+}
+
+/**
+ * The draft pointer a raw Request is carrying: `?__draft=` wins, the cookie
+ * carries navigation, `off` exits.
+ */
+export function draftPointerFromRequest(request: Request): string | null {
+  const url = new URL(request.url);
+  const param = url.searchParams.get(DRAFT_QUERY_PARAM);
+  if (param === "off") return null;
+  if (param) return param;
+  return readCookieValue(request.headers.get("cookie"), DRAFT_COOKIE_NAME);
+}
+
+/** The request host to gate on, honouring the standard forwarding header. */
+export function draftHostFromRequest(request: Request): string | null {
+  return request.headers.get("x-forwarded-host") ??
+    request.headers.get("host");
+}
+
+/**
+ * Persist the draft pointer into the `__deco_draft` cookie so subsequent
+ * navigation and client-fetched sections (`/deco/render`, `/deco/invoke`)
+ * carry the same draft — those are separate HTTP requests and the swap lives
+ * in per-request state that does not travel across the hop.
+ *
+ * `?__draft=off` always clears the cookie (an escape hatch that must work on
+ * any host). Setting the cookie is gated on the same allowlist as rendering:
+ * a stray `?__draft=` on a non-preview host leaves nothing behind.
+ */
+export function applyDraftCookie(
+  request: Request,
+  headers: Headers,
+  env?: EnvLike,
+): void {
+  const url = new URL(request.url);
+  const param = url.searchParams.get(DRAFT_QUERY_PARAM);
+  if (param === null) return; // navigation via cookie — nothing to change.
+  if (param === "off") {
+    deleteCookie(headers, DRAFT_COOKIE_NAME, { path: "/" });
+    return;
+  }
+  const e = envOrDeno(env);
+  if (readAllowedHosts(e).length === 0) return;
+  if (!isDraftHostAllowed(draftHostFromRequest(request), e)) return;
+  setCookie(headers, {
+    name: DRAFT_COOKIE_NAME,
+    // Encoded so `readCookieValue`'s decode round-trips a pointer whose query
+    // carries `&`/`=`; keeps the cookie octet-clean regardless of the grant.
+    value: encodeURIComponent(param),
+    path: "/",
+    httpOnly: true,
+    sameSite: "Lax",
+    secure: url.protocol === "https:",
+  });
+}
+
+export interface ResolveDraftForRequestOptions {
+  env?: EnvLike;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Resolve the draft decofile a raw Request is asking for, or null to fall back
+ * to the published release.
+ *
+ * Applies the full gate — allowlist non-empty, request host allowed, pointer
+ * valid, origin allowed, fetch OK — so the runtime can swap the release for
+ * exactly the draft the request is asking for. Null means "render published".
+ */
+export async function resolveDraftForRequest(
+  request: Request,
+  options: ResolveDraftForRequestOptions = {},
+): Promise<Record<string, unknown> | null> {
+  const env = envOrDeno(options.env);
+  if (readAllowedHosts(env).length === 0) return null;
+  const pointer = draftPointerFromRequest(request);
+  if (!pointer) return null;
+  if (!isDraftHostAllowed(draftHostFromRequest(request), env)) return null;
+  return resolveDraftDecofile({ pointer, env, fetchImpl: options.fetchImpl });
+}

--- a/engine/mod.ts
+++ b/engine/mod.ts
@@ -3,3 +3,24 @@ export type { ImportMapResolver } from "./importmap/builder.ts";
 export type { ParsedSource } from "./schema/deps.ts";
 export { initLoader, parsePath } from "./schema/parser.ts";
 export { fromEndpoint, fromJSON } from "./decofile/fetcher.ts";
+export type {
+  DraftPointer,
+  ResolveDraftForRequestOptions,
+  ResolveDraftOptions,
+} from "./decofile/draft.ts";
+export {
+  applyDraftCookie,
+  clearDraftCache,
+  DEFAULT_PREVIEW_API_DOMAINS,
+  DRAFT_COOKIE_NAME,
+  DRAFT_QUERY_PARAM,
+  draftHostFromRequest,
+  draftPointerFromRequest,
+  isDraftHostAllowed,
+  isDraftPreviewEnabled,
+  parseDraftPointer,
+  previewApiOriginForHost,
+  resolveDraftDecofile,
+  resolveDraftForRequest,
+  setDraftPreviewHosts,
+} from "./decofile/draft.ts";

--- a/runtime/mod.ts
+++ b/runtime/mod.ts
@@ -11,6 +11,12 @@ import {
   type DecofileProvider,
   getProvider,
 } from "../engine/decofile/provider.ts";
+import {
+  applyDraftCookie,
+  DRAFT_QUERY_PARAM,
+  resolveDraftForRequest,
+} from "../engine/decofile/draft.ts";
+import { fromJSON } from "../engine/decofile/fetcher.ts";
 import { siteNameFromEnv } from "../engine/manifest/manifest.ts";
 import { randomSiteName } from "../engine/manifest/utils.ts";
 import { newContext, type PreactComponent, type Resolvable } from "../mod.ts";
@@ -239,7 +245,38 @@ export class Deco<TAppManifest extends AppManifest = AppManifest> {
     state.global = state;
     const { resolver } = await this.ctx.runtime!;
 
-    const ctxResolver = resolver
+    // --- Fast Preview: request-scoped draft snapshot ---------------------
+    // If this request carries a valid `?__draft=` pointer (or the cookie that
+    // carries it across navigation) from an allowed host, pull the draft
+    // decofile from Studio's decofile API and render THIS request against it,
+    // instead of the published release. Replacing the release wholesale gives
+    // snapshot semantics for free: a block the draft omits is gone, not
+    // resurrected by the base. Inert (no network, no allocation) on any
+    // request without a pointer or on a non-preview host.
+    let activeResolver = resolver;
+    const draftDecofile = await resolveDraftForRequest(request).catch(() =>
+      null
+    );
+    if (draftDecofile) {
+      const draftProvider = fromJSON(draftDecofile);
+      state.release = draftProvider;
+      activeResolver = resolver.with({ release: draftProvider });
+      // A draft shares the published URL — it must never be cached or indexed.
+      // `shouldCache = false` drives the framework's cache decision to
+      // `no-store` (see applyPageCacheDecision); noindex keeps a leaked draft
+      // out of search results.
+      state.vary.shouldCache = false;
+      response.headers.set("x-robots-tag", "noindex, nofollow");
+    }
+    // Persist the pointer into a cookie so client-fetched sections
+    // (`/deco/render`, `/deco/invoke`) carry the same draft; `off` clears it.
+    // Only relevant when a `?__draft=` param is present — skip the work (and a
+    // second URL parse) for the vast majority of requests that have none.
+    if (state.url.searchParams.has(DRAFT_QUERY_PARAM)) {
+      applyDraftCookie(request, response.headers);
+    }
+
+    const ctxResolver = activeResolver
       .resolverFor(
         {
           context: new Proxy(context, {
@@ -259,7 +296,7 @@ export class Deco<TAppManifest extends AppManifest = AppManifest> {
           monitoring: state.monitoring,
         },
       )
-      .bind(resolver);
+      .bind(activeResolver);
 
     state.resolve = ctxResolver;
     state.invoke = buildInvokeFunc(


### PR DESCRIPTION
## Summary

Deno port of [decocms/blocks#463](https://github.com/decocms/blocks/pull/463) (Studio's **sandbox-less Fast Preview**). A production site can render a CMS draft by **pulling** the draft decofile from Studio's GitHub-backed decofile API and rendering its own real pages against it, as a **request-scoped snapshot** of the release — no sandbox daemon, no `/_sandbox/decofile`, just an HTTP pull.

### Pointer contract (`?__draft=`)
Grammar: `<authority><path>?token=<grant>@<version>`
- Split on the **last** `@` (draft tokens are base64url, never contain one); `version` is the branch head SHA.
- The runtime validates only the **authority** against the preview API domains (`local.studio.decocms.com`, `localhost`, `127.0.0.1`, `*.localhost`, `*.decocms.com`) and **derives** the scheme (https everywhere except plain loopback) — no SSRF surface, never a caller-controlled full URL.
- Origin validation runs **before** the per-version cache check.
- `off` exits; the `__deco_draft` cookie carries the pointer across navigation; `?__draft=` query wins.

### Snapshot semantics
Replacing `state.release` wholesale with `fromJSON(draft)` gives snapshot semantics for free: a block the draft omits is **gone**, not resurrected by the file-backed base — so **deletions work from day one**.

### Injection point
`runtime/mod.ts`'s `prepareState` is the **single per-request seam** that runs for every route (via the state-builder middleware). When a draft resolves it swaps `state.release` + rebinds the resolver (`resolver.with({ release })`), forces `no-store` (`vary.shouldCache = false`) + `x-robots-tag: noindex`, and persists the pointer cookie. Unlike the Next binding, no per-endpoint re-resolution is needed — `/deco/render` and `/deco/invoke` partials inherit the same draft through the cookie. Inert (no network, no allocation) on any request without a pointer or on a non-preview host.

### Gating
- `DECO_ALLOWED_PREVIEW_HOSTS` (or the site-declared `previewHosts` via `setDraftPreviewHosts()`) — which request hosts may render drafts; env is a kill-switch/override.
- `DECO_PREVIEW_API_DOMAINS` — which origins may serve the decofile.
- Bypasses `assertAllowedAuthority` on purpose: `draft.ts` does its own origin validation (no caller URL, no SSRF).

## Files
- `engine/decofile/draft.ts` — pointer parse/validate/fetch/cache + gating + cookie helper.
- `runtime/mod.ts` — `prepareState` wiring (release swap + resolver rebind + headers/cookie).
- `engine/mod.ts` — public re-exports.
- `engine/decofile/draft.test.ts` — 9 tests / 31 steps, mirroring the Node `draftSource.test.ts`.

## Testing
- Unit: `deno test engine/decofile/draft.test.ts` → **9 passed (31 steps), 0 failed**. `deno fmt --check` + `deno check` clean.
- **End-to-end against a real Fresh site** (`demo-linkedin`, decofile from `.deco/blocks`), with a mock decofile API on `127.0.0.1` serving a modified block:
  - `?__draft=…` on an allowed host → the pulled snapshot renders (verified in-browser: a benefit changed to a unique marker); headers `no-store` + `noindex` + `__deco_draft` cookie.
  - cookie-only navigation → draft still renders (covers `/deco/render` + invoke partials).
  - `?__draft=off` → cookie cleared, published renders.
  - non-allowed request host → inert (published).
  - disallowed origin pointer → inert (anti-SSRF).
  - normal traffic → unchanged (`cache-control: public`).

## Follow-ups (not in this PR)
- Wire `setDraftPreviewHosts()` from the `Site` block's `previewHosts` at setup (today gated via `DECO_ALLOWED_PREVIEW_HOSTS`).
- Confirm the Studio decofile-API response shape matches `Record<string, Resolvable>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds sandbox-less Fast Preview: render a draft by pulling a draft decofile via a `?__draft=` pointer per request instead of relying on a sandbox daemon. Previously preview required a running sandbox; now the runtime swaps in a request-scoped snapshot, disables caching and indexing, and persists state via a cookie on allowed preview hosts.

- Validates `?__draft=` as `<host[:port]><path>@<version>` (split on last `@`), derives scheme, and admits only configured preview API domains (defaults to `.decocms.com` and loopback; override with `DECO_PREVIEW_API_DOMAINS`). Origin validation runs before cache.
- Inert unless the request host is allowlisted via `DECO_ALLOWED_PREVIEW_HOSTS` or `setDraftPreviewHosts()`. Falls back to published content on invalid pointers, disallowed hosts/origins, fetch errors, or non-2xx.
- Resolves and caches the draft decofile by source and version (keyed by `<host><path>@<version>`, cap 3). Fix: cache is no longer keyed by version alone, preventing cross-source collisions.
- `prepareState` replaces `state.release` with `fromJSON(draft)` and rebinds the resolver per request; sets `no-store` and `x-robots-tag: noindex, nofollow`. Persists `__deco_draft`; `?__draft=off` clears it. Fix: malformed cookie values now safely degrade to no draft.

**Rollout and migration**
- No action required to keep current behavior.
- To enable Fast Preview, set `DECO_ALLOWED_PREVIEW_HOSTS=<comma-separated hosts>` or call `setDraftPreviewHosts([...])` during app setup.
- Optionally set `DECO_PREVIEW_API_DOMAINS` to allow non-default preview API domains.
- Preview links must use `?__draft=<authority><path>?token=…@<version>`; use `?__draft=off` to exit preview.

<sup>Written for commit c5ecebac1895465a13e3965060f09c57fd5e9ebc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/deco/pull/1222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added draft preview support for requests with valid draft pointers.
  * Preview access can be restricted to approved hosts and API domains.
  * Preview state is preserved with a cookie and excluded from search indexing.
  * Added public tools for parsing, resolving, and managing draft previews.

* **Bug Fixes**
  * Invalid, blocked, unavailable, or failed draft requests now safely fall back to published content.

* **Tests**
  * Added comprehensive coverage for preview validation, resolution, caching, cookies, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->