### PR TITLE
feat(preview): infer <site>.deco.site as an allowed draft preview host

### DIFF
--- a/engine/decofile/draft.test.ts
+++ b/engine/decofile/draft.test.ts
@@ -398,6 +398,33 @@ Deno.test("deco-hosted preview domain (setDecoSiteHost)", async (t) => {
       setDecoSiteHost(null);
     }
   });
+
+  await t.step("undefined (the random dev fallback) registers no host", () => {
+    // runtime/mod.ts passes `resolvedSite` (undefined when the site name falls
+    // back to randomSiteName) straight through — an unnamed site is not armed.
+    setDecoSiteHost(undefined);
+    try {
+      assertEquals(isDraftPreviewEnabled({}), false);
+    } finally {
+      setDecoSiteHost(null);
+    }
+  });
+
+  await t.step("DECO_ALLOWED_PREVIEW_HOSTS=none kills the inferred host", () => {
+    setDraftPreviewHosts(["fila.vtex.app"]);
+    setDecoSiteHost("als-storefront");
+    try {
+      // The kill switch wins over the inferred host AND the site block, so a
+      // bad rollout can be stopped without a deploy.
+      const env = { DECO_ALLOWED_PREVIEW_HOSTS: "none" };
+      assertEquals(isDraftPreviewEnabled(env), false);
+      assertEquals(isDraftHostAllowed("als-storefront.deco.site", env), false);
+      assertEquals(isDraftHostAllowed("fila.vtex.app", env), false);
+    } finally {
+      setDraftPreviewHosts([]);
+      setDecoSiteHost(null);
+    }
+  });
 });
 
 Deno.test("draftPointerFromRequest", async (t) => {

--- a/engine/decofile/draft.test.ts
+++ b/engine/decofile/draft.test.ts
@@ -10,6 +10,7 @@ import {
   previewApiOriginForHost,
   resolveDraftDecofile,
   resolveDraftForRequest,
+  setDecoSiteHost,
   setDraftPreviewHosts,
 } from "./draft.ts";
 
@@ -348,6 +349,53 @@ Deno.test("site-block preview hosts", async (t) => {
       assertEquals(isDraftHostAllowed("fila.vtex.app", env), false);
     } finally {
       setDraftPreviewHosts([]);
+    }
+  });
+});
+
+Deno.test("deco-hosted preview domain (setDecoSiteHost)", async (t) => {
+  await t.step("infers <site>.deco.site and enables the feature", () => {
+    setDecoSiteHost("als-storefront");
+    try {
+      assertEquals(isDraftPreviewEnabled({}), true);
+      assertEquals(isDraftHostAllowed("als-storefront.deco.site", {}), true);
+      assertEquals(isDraftHostAllowed("other.deco.site", {}), false);
+      // A custom production domain is never inferred.
+      assertEquals(isDraftHostAllowed("www.als-storefront.com", {}), false);
+    } finally {
+      setDecoSiteHost(null);
+    }
+  });
+
+  await t.step("is merged ON TOP of the site block, not replacing it", () => {
+    setDraftPreviewHosts(["fila.vtex.app"]);
+    setDecoSiteHost("als-storefront");
+    try {
+      assertEquals(isDraftHostAllowed("fila.vtex.app", {}), true);
+      assertEquals(isDraftHostAllowed("als-storefront.deco.site", {}), true);
+    } finally {
+      setDraftPreviewHosts([]);
+      setDecoSiteHost(null);
+    }
+  });
+
+  await t.step("is merged ON TOP of the env escape hatch too", () => {
+    setDecoSiteHost("als-storefront");
+    try {
+      const env = { DECO_ALLOWED_PREVIEW_HOSTS: "other.example" };
+      assertEquals(isDraftHostAllowed("other.example", env), true);
+      assertEquals(isDraftHostAllowed("als-storefront.deco.site", env), true);
+    } finally {
+      setDecoSiteHost(null);
+    }
+  });
+
+  await t.step("a blank/null site name registers no host", () => {
+    setDecoSiteHost("   ");
+    try {
+      assertEquals(isDraftPreviewEnabled({}), false);
+    } finally {
+      setDecoSiteHost(null);
     }
   });
 });

--- a/engine/decofile/draft.ts
+++ b/engine/decofile/draft.ts
@@ -182,7 +182,7 @@ export function previewApiOriginForHost(
  * (possibly drafted) release: an allowlist readable through the draft could be
  * rewritten by the very draft it gates.
  */
-const G = globalThis as { __decoDraftHosts?: string[] };
+const G = globalThis as { __decoDraftHosts?: string[]; __decoSiteHost?: string };
 
 /** Install the site-declared preview hosts. Called at setup by the site app. */
 export function setDraftPreviewHosts(hosts: readonly unknown[]): void {
@@ -193,19 +193,42 @@ export function setDraftPreviewHosts(hosts: readonly unknown[]): void {
 }
 
 /**
+ * Register the deco-hosted preview domain, derived from the resolved site name
+ * (`opts.site ?? DECO_SITE_NAME ?? …`, resolved by the runtime at setup).
+ *
+ * Always allowed to render drafts and MERGED with the site-block/env list
+ * rather than replacing it: `<site>.deco.site` is deco-operated infra, so a
+ * signed draft grant can preview there out of the box, while a custom
+ * production domain — never inferred here — stays inert. Fed from the trusted
+ * setup-time site name, never from the request or a draft.
+ */
+export function setDecoSiteHost(site: string | null | undefined): void {
+  const s = (site ?? "").trim().toLowerCase();
+  G.__decoSiteHost = s ? `${s}.deco.site` : undefined;
+}
+
+/**
  * Hosts allowed to render drafts.
  *
  * The site block is the expected source — the opt-in lives in the repo,
  * reviewed in a PR, versioned with branches. `DECO_ALLOWED_PREVIEW_HOSTS`
  * REPLACES it when set: an operational escape hatch (kill a bad value without
  * a deploy, add a machine-specific port) — not the primary configuration.
+ *
+ * The deco-hosted preview domain (`<site>.deco.site`, via `setDecoSiteHost`)
+ * is always ADDED on top, so a signed draft grant can preview on deco-operated
+ * infra without any per-site config.
  */
 function readAllowedHosts(env: EnvLike): string[] {
   const fromEnv = (env.DECO_ALLOWED_PREVIEW_HOSTS ?? "")
     .split(",")
     .map((s) => s.trim().toLowerCase())
     .filter(Boolean);
-  return fromEnv.length > 0 ? fromEnv : (G.__decoDraftHosts ?? []);
+  const configured = fromEnv.length > 0 ? fromEnv : (G.__decoDraftHosts ?? []);
+  const siteHost = G.__decoSiteHost;
+  return siteHost && !configured.includes(siteHost)
+    ? [...configured, siteHost]
+    : configured;
 }
 
 /**

--- a/engine/decofile/draft.ts
+++ b/engine/decofile/draft.ts
@@ -196,11 +196,17 @@ export function setDraftPreviewHosts(hosts: readonly unknown[]): void {
  * Register the deco-hosted preview domain, derived from the resolved site name
  * (`opts.site ?? DECO_SITE_NAME ?? …`, resolved by the runtime at setup).
  *
- * Always allowed to render drafts and MERGED with the site-block/env list
- * rather than replacing it: `<site>.deco.site` is deco-operated infra, so a
- * signed draft grant can preview there out of the box, while a custom
- * production domain — never inferred here — stays inert. Fed from the trusted
- * setup-time site name, never from the request or a draft.
+ * MERGED with the site-block/env list rather than replacing it: `<site>.deco.site`
+ * is deco-operated infra, so a signed draft grant can preview there out of the
+ * box, while a custom production domain — never inferred here — stays inert.
+ * Fed from the trusted setup-time site name, never from the request or a draft.
+ *
+ * Threat model, now that a named site is no longer inert by default: the
+ * request host is spoofable on a direct-to-origin request (the edge is trusted
+ * to set `x-forwarded-host`), so for a named site the SIGNED `?__draft=` grant
+ * is the sole remaining gate — host-scoping only bounds blast radius. Set
+ * `DECO_ALLOWED_PREVIEW_HOSTS=none` to kill preview entirely, including this
+ * inferred host, without a deploy.
  */
 export function setDecoSiteHost(site: string | null | undefined): void {
   const s = (site ?? "").trim().toLowerCase();
@@ -218,12 +224,17 @@ export function setDecoSiteHost(site: string | null | undefined): void {
  * The deco-hosted preview domain (`<site>.deco.site`, via `setDecoSiteHost`)
  * is always ADDED on top, so a signed draft grant can preview on deco-operated
  * infra without any per-site config.
+ *
+ * The sentinel `DECO_ALLOWED_PREVIEW_HOSTS=none` is a KILL SWITCH: it disables
+ * preview entirely — including the inferred host and the site block — so a bad
+ * rollout can be stopped without a deploy. It must win over every other source.
  */
 function readAllowedHosts(env: EnvLike): string[] {
   const fromEnv = (env.DECO_ALLOWED_PREVIEW_HOSTS ?? "")
     .split(",")
     .map((s) => s.trim().toLowerCase())
     .filter(Boolean);
+  if (fromEnv.includes("none")) return [];
   const configured = fromEnv.length > 0 ? fromEnv : (G.__decoDraftHosts ?? []);
   const siteHost = G.__decoSiteHost;
   return siteHost && !configured.includes(siteHost)
@@ -249,8 +260,10 @@ export function isDraftHostAllowed(
 
 /**
  * True when any host is allowed to preview. A cheap read callers use to gate
- * BEFORE touching the network, so an unconfigured site is fully inert. The
- * per-request host match happens later, in `isDraftHostAllowed`.
+ * BEFORE touching the network. A site with no config but a resolved name is now
+ * enabled here (its inferred `<site>.deco.site` host); `DECO_ALLOWED_PREVIEW_HOSTS=none`
+ * forces it back to fully inert. The per-request host match happens later, in
+ * `isDraftHostAllowed`.
  */
 export function isDraftPreviewEnabled(env?: EnvLike): boolean {
   return readAllowedHosts(envOrDeno(env)).length > 0;

--- a/engine/mod.ts
+++ b/engine/mod.ts
@@ -22,5 +22,6 @@ export {
   previewApiOriginForHost,
   resolveDraftDecofile,
   resolveDraftForRequest,
+  setDecoSiteHost,
   setDraftPreviewHosts,
 } from "./decofile/draft.ts";

--- a/runtime/mod.ts
+++ b/runtime/mod.ts
@@ -16,6 +16,7 @@ import {
   DRAFT_QUERY_PARAM,
   draftPointerFromRequest,
   resolveDraftForRequest,
+  setDecoSiteHost,
 } from "../engine/decofile/draft.ts";
 import { fromJSON } from "../engine/decofile/fetcher.ts";
 import { DRAFT_PREVIEW_KEY } from "./draftBadge.ts";
@@ -86,7 +87,12 @@ export class Deco<TAppManifest extends AppManifest = AppManifest> {
   static async init<TAppManifest extends AppManifest = AppManifest>(
     opts?: DecoOptions<TAppManifest>,
   ): Promise<Deco<TAppManifest>> {
-    const site = opts?.site ?? siteNameFromEnv() ?? randomSiteName();
+    const resolvedSite = opts?.site ?? siteNameFromEnv();
+    const site = resolvedSite ?? randomSiteName();
+    // Allow drafts to preview on the deco-hosted `<site>.deco.site` domain out
+    // of the box. Skipped for the random dev fallback (an unnamed site is not a
+    // preview host); a custom production domain is never inferred.
+    setDecoSiteHost(resolvedSite);
     const decofile = opts?.decofile ?? (await getProvider());
     const manifest = opts?.manifest ??
       (await import(toFileUrl(join(Deno.cwd(), "manifest.gen.ts")).href).then(


### PR DESCRIPTION
## Problema

O allowlist de draft-preview (`DECO_ALLOWED_PREVIEW_HOSTS` ou `previewHosts` do site-block) exige opt-in **por site**. A ideia de inferir de dentro do `draft.ts` via `DECO_SITE_NAME` não funciona porque **o env nem sempre está setado**.

## Solução

O runtime já resolve o nome do site de forma robusta em `Deco.init`:

```ts
const site = opts?.site ?? siteNameFromEnv() ?? randomSiteName();
```

Usamos essa mesma resolução (sem o fallback random) para registrar `<site>.deco.site` como preview host, via um novo `setDecoSiteHost`.

- `als-storefront` → `als-storefront.deco.site` allowed **automaticamente**, funcione o env ou não.
- **Merge, não replace**: o host inferido é adicionado *por cima* do env/site-block, nunca substitui.
- O fallback random de dev **não registra nada** (site sem nome não vira preview host).
- O **domínio custom de produção nunca é inferido** — continua inerte.

## Tradeoff de segurança

O módulo deixa de ser "inert by default" para todo site com nome resolvido: passa a habilitar preview no host `.deco.site`. A capability real continua sendo o **grant assinado** do `?__draft=` — o host-allowlist só limita o blast radius, e `.deco.site` é infra operada pela deco. Produção (domínio custom) segue inerte.

## Testes

Novos steps em `engine/decofile/draft.test.ts` cobrindo: inferência de `<site>.deco.site`, merge sobre site-block e sobre env, e site name em branco não registrando host. Suíte completa passando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically allows draft previews on `<site>.deco.site` by resolving the site name at `Deco.init`, so previews work on deco-operated infra without per-site opt-in. Previously, sites had to declare hosts via `DECO_ALLOWED_PREVIEW_HOSTS` or the `previewHosts` site block.

- Adds `setDecoSiteHost(site)` and calls it with the resolved site name; merges `<site>.deco.site` on top of env/site-block hosts. `DECO_ALLOWED_PREVIEW_HOSTS=none` now kills preview entirely (inferred host + site block).
- Never infers a custom production domain; the random dev fallback registers no host.
- Security: named sites are no longer inert by default on `.deco.site`; draft rendering still requires a signed `?__draft=` grant. Tests cover inference, merging, kill switch, and the “unnamed site” noop path.

<sup>Written for commit 2cdf6510db256993f0583feaf0ff419f3e3a9ac8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/deco/pull/1224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview domains now automatically support configured Deco-hosted sites using the corresponding `<site>.deco.site` address.
  * Preview host allowlisting combines Deco-hosted domains with environment and site-specific settings without duplicates.
  * Environment overrides and custom production domains continue to be handled correctly.
  * Setting `DECO_ALLOWED_PREVIEW_HOSTS` to `none` disables all preview domains.
* **Bug Fixes**
  * Blank or unspecified site names no longer register invalid preview hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->