### PR TITLE
fix(preview): carry draft pointer through lazy /deco/render inside iframe

### DIFF
--- a/hooks/useSection.test.tsx
+++ b/hooks/useSection.test.tsx
@@ -1,0 +1,65 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+import { assertEquals } from "@std/assert";
+import { renderToString } from "preact-render-to-string";
+import { SectionContext } from "../components/section.tsx";
+import { DRAFT_PREVIEW_KEY } from "../runtime/draftBadge.ts";
+import { useSection } from "./useSection.ts";
+
+const POINTER =
+  "studio.decocms.com/api/fila/decofile/vm-1/main?token=tok.abc@v1";
+
+// Minimal SectionContext double — only the fields `useSection` reads.
+// deno-lint-ignore no-explicit-any
+const makeCtx = (bag: WeakMap<any, any>): SectionContext =>
+  ({
+    revision: "rev-1",
+    renderSalt: "salt-1",
+    deploymentId: "dep-1",
+    resolveChain: [],
+    request: new Request("https://shop.example.com/"),
+    context: {
+      state: {
+        vary: { build: () => "" },
+        pathTemplate: "/",
+        bag,
+      },
+    },
+  }) as unknown as SectionContext;
+
+// Render a probe that captures the URL `useSection` builds under `ctx`.
+// deno-lint-ignore no-explicit-any
+const renderUrl = (bag: WeakMap<any, any>): string => {
+  let url = "";
+  const Probe = () => {
+    url = useSection({ props: { __resolveType: "site/sections/X.tsx" } });
+    return null;
+  };
+  renderToString(
+    <SectionContext.Provider value={makeCtx(bag)}>
+      <Probe />
+    </SectionContext.Provider>,
+  );
+  return url;
+};
+
+Deno.test("useSection draft pointer propagation", async (t) => {
+  await t.step(
+    "carries the active pointer as a top-level ?__draft= when a draft is bound",
+    () => {
+      const bag = new WeakMap();
+      bag.set(DRAFT_PREVIEW_KEY, POINTER);
+      const url = renderUrl(bag);
+      const params = new URL(url, "http://localhost").searchParams;
+      // Read off the top-level param (what the server actually resolves from),
+      // not nested inside `href` — that is the whole point of the fix.
+      assertEquals(params.get("__draft"), POINTER);
+    },
+  );
+
+  await t.step("omits __draft on ordinary (non-draft) traffic", () => {
+    const url = renderUrl(new WeakMap());
+    const params = new URL(url, "http://localhost").searchParams;
+    assertEquals(params.get("__draft"), null);
+  });
+});

--- a/hooks/useSection.ts
+++ b/hooks/useSection.ts
@@ -2,6 +2,8 @@ import type { ComponentType } from "preact";
 import { useContext } from "preact/hooks";
 import { SectionContext } from "../components/section.tsx";
 import { FieldResolver } from "../engine/core/resolver.ts";
+import { DRAFT_QUERY_PARAM } from "../engine/decofile/draft.ts";
+import { DRAFT_PREVIEW_KEY } from "../runtime/draftBadge.ts";
 
 import { Murmurhash3 } from "../deps.ts";
 
@@ -117,6 +119,20 @@ export const useSection = <P>(
   const vary = ctx?.context.state.vary.build();
   const { request, renderSalt, context: { state: { pathTemplate } } } = ctx;
 
+  // Fast Preview: a deferred section is lazy-loaded client-side via a separate
+  // `/deco/render` fetch, which resolves its draft from the `__deco_draft`
+  // cookie. That cookie is `SameSite=Lax`, so inside Studio's cross-site
+  // preview iframe the browser does NOT attach it to the subrequest — the
+  // section would render against the PUBLISHED release while the page shell
+  // rendered the draft, producing duplicated/stale sections. If this render is
+  // bound to a draft (the runtime stashed the active pointer in the bag during
+  // prepareState), carry it forward as an explicit `?__draft=` param: the
+  // server prefers the param over the cookie, so lazy rendering stays on the
+  // draft regardless of frame context. Absent on ordinary (non-draft) traffic.
+  const draftPointer = ctx?.context.state.bag?.get(DRAFT_PREVIEW_KEY) as
+    | string
+    | undefined;
+
   const hrefParam = href ?? request.url;
   const stableHref = createStableHref(hrefParam);
   const cbString = [
@@ -142,6 +158,10 @@ export const useSection = <P>(
       "resolveChain",
       JSON.stringify(FieldResolver.minify(ctx.resolveChain.slice(0, -1))),
     );
+  }
+
+  if (draftPointer) {
+    params.set(DRAFT_QUERY_PARAM, draftPointer);
   }
 
   return `/deco/render?${params}`;


### PR DESCRIPTION
## Problema

Dentro do iframe de preview do Studio, o lazy loading de sections via `/deco/render` bugava: sections apareciam **duplicadas** ou uma section removida no draft **não sumia**. Abrindo a mesma URL em outra aba funcionava normalmente.

![duplicated header inside the editor iframe](https://github.com/deco-cx/deco/assets/placeholder)

## Causa raiz

Fast Preview renderiza o **shell da página** contra o draft (o `?__draft=` está na URL do documento). Mas cada section deferida é buscada client-side por um `fetch("/deco/render?...")` separado, e esse request resolve o draft a partir do cookie `__deco_draft`.

Esse cookie é `SameSite=Lax` (`engine/decofile/draft.ts:416`). O editor do Studio embute o site num iframe **cross-site**, e o browser **não anexa** cookie `Lax` em subrequests de iframe cross-site. Então o `/deco/render` roda contra a **release publicada** enquanto o shell rodou contra o draft:

- section removida no draft → volta (o publicado ainda tem ela) → parece que "não some"
- header/section do publicado + do draft → **duplicado**

Em outra aba funciona porque é contexto first-party → o cookie `Lax` é enviado normalmente.

O valor até viaja embutido no param `href` do `/deco/render`, mas é inerte: `draftPointerFromRequest` lê o `__draft` **top-level** da request crua (ou o cookie), nunca de dentro do `href`.

## Fix

`useSection` roda no SSR e o runtime já guarda o pointer ativo no request bag durante o `prepareState` (`runtime/mod.ts:277`, `DRAFT_PREVIEW_KEY`). Quando há draft bound, anexamos o pointer como um `?__draft=` **top-level** na URL do `/deco/render`. O servidor prioriza o param sobre o cookie, então o lazy rendering fica no draft **independente do contexto de frame** — sem depender de cookie cross-site.

- Só é anexado quando há draft ativo no bag → **tráfego normal (publicado) não muda em nada**.
- Não recorre a `SameSite=None; Secure`, que seria bloqueado por browsers que rejeitam third-party cookies (Safari ITP sempre; Chrome em phase-out).

## Testes

`hooks/useSection.test.tsx`:
- com pointer no bag → a URL do render leva `?__draft=<pointer>` top-level
- sem draft → URL inalterada (nenhum `__draft`)

`deno test hooks/useSection.test.tsx engine/decofile/draft.test.ts runtime/draftBadge.test.ts` → 12 passed. Lint e type-check limpos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Fast Preview in the Studio iframe by ensuring deferred sections render against the active draft. Previously, the page shell used the draft but lazy `/deco/render` requests fell back to the published release in cross-site iframes (due to `SameSite=Lax` cookie), causing duplicates or stale sections; now both render the same draft.

- Implementation: `useSection` reads `DRAFT_PREVIEW_KEY` from the request bag and appends a top-level `?__draft=` (`DRAFT_QUERY_PARAM`) to the `/deco/render` URL when a draft is bound; the server prefers this param over the `__deco_draft` cookie.
- Impact: ordinary traffic is unchanged (param only added when a draft exists). No cookie or config changes required. Tests cover presence/absence of the param in `hooks/useSection.test.tsx`.

<sup>Written for commit c577e928e7ef8816eeb7e93944f1dfa476acf0e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/deco/pull/1225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview and draft render requests now include the active draft context automatically.
  * Standard render requests remain unchanged and do not include draft parameters.

* **Tests**
  * Added coverage verifying draft-aware and standard request URL behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->