### PR TITLE
fix(device): prioritize deviceHint query param over cf-device-type

### DIFF
--- a/utils/userAgent.test.ts
+++ b/utils/userAgent.test.ts
@@ -1,0 +1,60 @@
+import { assertEquals } from "@std/assert";
+import { deviceOf } from "./userAgent.ts";
+
+const MOBILE_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+const DESKTOP_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+const req = ({
+  deviceHint,
+  cf,
+  ua,
+}: {
+  deviceHint?: string;
+  cf?: string;
+  ua?: string;
+}) => {
+  const url = deviceHint
+    ? `https://example.com/?deviceHint=${deviceHint}`
+    : "https://example.com/";
+  const headers = new Headers();
+  if (cf) headers.set("cf-device-type", cf);
+  if (ua) headers.set("user-agent", ua);
+  return new Request(url, { headers });
+};
+
+Deno.test("deviceOf", async (t) => {
+  await t.step("deviceHint overrides cf-device-type (Cloudflare)", () => {
+    // The Studio preview forces `deviceHint=mobile` while the requesting
+    // browser is desktop; behind Cloudflare `cf-device-type` used to win.
+    assertEquals(
+      deviceOf(req({ deviceHint: "mobile", cf: "desktop", ua: DESKTOP_UA })),
+      "mobile",
+    );
+  });
+
+  await t.step("deviceHint overrides the user-agent device", () => {
+    assertEquals(
+      deviceOf(req({ deviceHint: "tablet", ua: MOBILE_UA })),
+      "tablet",
+    );
+  });
+
+  await t.step("falls back to cf-device-type when no deviceHint", () => {
+    assertEquals(deviceOf(req({ cf: "mobile", ua: DESKTOP_UA })), "mobile");
+  });
+
+  await t.step("falls back to user-agent when no deviceHint nor cf", () => {
+    assertEquals(deviceOf(req({ ua: MOBILE_UA })), "mobile");
+  });
+
+  await t.step("defaults to desktop", () => {
+    assertEquals(deviceOf(req({ ua: DESKTOP_UA })), "desktop");
+    assertEquals(deviceOf(req({})), "desktop");
+  });
+
+  await t.step("normalizes unsupported device types to desktop", () => {
+    assertEquals(deviceOf(req({ deviceHint: "smarttv" })), "desktop");
+  });
+});

--- a/utils/userAgent.ts
+++ b/utils/userAgent.ts
@@ -19,12 +19,17 @@ export const deviceOf = (request: Request) => {
   const url = new URL(request.url);
   const ua: string | null = request.headers.get("user-agent") || "";
   // use cf hint at first and then fallback to user-agent parser.
-  const cfDeviceHint: string | null = request.headers.get("cf-device-type") ||
-    "";
+  const cfDeviceHint: string | null =
+    request.headers.get("cf-device-type") || "";
 
-  const device = cfDeviceHint ||
-    (ua && new UAParser(ua).getDevice().type) ||
+  // `deviceHint` is an explicit override, only ever present when a tool (e.g.
+  // the Studio preview) forces a device. Real client traffic never carries it,
+  // so it takes priority: otherwise `cf-device-type` (the requesting browser's
+  // real device) wins behind Cloudflare and the override is silently ignored.
+  const device =
     url.searchParams.get("deviceHint") ||
+    cfDeviceHint ||
+    (ua && new UAParser(ua).getDevice().type) ||
     "desktop"; // console, mobile, tablet, smarttv, wearable, embedded
 
   const normalizedDevice = ideviceToDevice[device] ?? "desktop";


### PR DESCRIPTION
## Summary

`deviceOf` (`utils/userAgent.ts`) resolves the request device for SSR device matchers, section rendering, and flags. It evaluated sources in this order:

```
cf-device-type  →  user-agent  →  deviceHint  →  "desktop"
```

The `deviceHint` query param is an **explicit override** — it's only ever present when a tool forces a device (the Studio preview device toggle injects `?deviceHint=mobile|tablet|desktop`). Real client traffic never carries it.

Because it sat **last**, behind Cloudflare the requesting browser's own `cf-device-type` (desktop) always won and the forced `deviceHint` was silently ignored. This broke the mobile/tablet toggle in both sandbox preview and Fast Preview (the draft request goes to the CF-fronted production site).

## Change

Move `deviceHint` to the **top** of the resolution chain:

```
deviceHint  →  cf-device-type  →  user-agent  →  "desktop"
```

Safe because normal production traffic has no `deviceHint` param, so it keeps falling through to `cf-device-type` / user-agent exactly as before. Only explicit overrides change behavior — which is the intent of a "hint".

## Testing

Added `utils/userAgent.test.ts` covering the priority order (deviceHint over CF, over UA, fallbacks, and normalization). `deno test utils/userAgent.test.ts` — all green.

## Rollout note

Runtime change — needs a `deco` release + site bumps to take effect in production.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prioritizes the deviceHint query param over Cloudflare’s cf-device-type when resolving the request device. Previously cf-device-type → user-agent → deviceHint → desktop; now deviceHint → cf-device-type → user-agent → desktop. This restores Studio preview mobile/tablet toggles behind Cloudflare without changing production behavior when deviceHint is absent.

- Adds tests in utils/userAgent.test.ts covering the new priority, fallbacks, and normalization.
- Runtime change; requires a `deco` release and site bumps to take effect in production.

<sup>Written for commit 8bc07dbd9631194b00d83c7c566f548bc2310158. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/deco/pull/1227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

