### PR TITLE
feat(preview): serve the editor bridge on Fast Preview draft renders

### DIFF
--- a/runtime/editorBridge.test.ts
+++ b/runtime/editorBridge.test.ts
@@ -1,0 +1,67 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  buildEditorBridge,
+  isEditorParentOriginAllowed,
+} from "./editorBridge.ts";
+
+Deno.test("isEditorParentOriginAllowed", async (t) => {
+  const allowed = ["https://studio.decocms.com", "https://admin.deco.cx"];
+
+  await t.step("admits an exact allowlisted origin", () => {
+    assert(isEditorParentOriginAllowed("https://studio.decocms.com", allowed));
+    assert(isEditorParentOriginAllowed("https://admin.deco.cx", allowed));
+  });
+
+  await t.step("admits local dev origins by shape, any port", () => {
+    assert(isEditorParentOriginAllowed("http://localhost:4000", allowed));
+    assert(isEditorParentOriginAllowed("http://127.0.0.1:8080", allowed));
+    assert(isEditorParentOriginAllowed("https://app.localhost:3000", allowed));
+    assert(
+      isEditorParentOriginAllowed("https://local.studio.decocms.com", allowed),
+    );
+  });
+
+  await t.step("rejects unknown, empty, and malformed origins", () => {
+    assert(!isEditorParentOriginAllowed("https://evil.example", allowed));
+    // Suffix confusion must not pass: evil-decocms.com is not decocms.com.
+    assert(!isEditorParentOriginAllowed("https://evil-localhost.com", allowed));
+    assert(!isEditorParentOriginAllowed("null", allowed)); // sandboxed iframe origin
+    assert(!isEditorParentOriginAllowed("", allowed));
+    assert(!isEditorParentOriginAllowed(null, allowed));
+    assert(!isEditorParentOriginAllowed(undefined, allowed));
+  });
+});
+
+Deno.test("buildEditorBridge", async (t) => {
+  await t.step("registers a message listener gated to framed contexts", () => {
+    const out = buildEditorBridge();
+    assertStringIncludes(out, "<script>");
+    assertStringIncludes(out, 'addEventListener("message"');
+    // Only inside a frame — the inverse of the draft badge.
+    assertStringIncludes(out, "window.top===window.self");
+  });
+
+  await t.step("bakes in the origin allowlist and the check", () => {
+    const out = buildEditorBridge();
+    assertStringIncludes(out, "https://studio.decocms.com");
+    // The pure predicate is serialised in, not re-implemented as a string.
+    assertStringIncludes(out, "isEditorParentOriginAllowed");
+    assertStringIncludes(out, "ok(e.origin,ALLOWED)");
+  });
+
+  await t.step("accepts both the studio and legacy admin protocols", () => {
+    const out = buildEditorBridge();
+    assertStringIncludes(out, "visual-editor::activate");
+    assertStringIncludes(out, "editor::inject");
+    assertStringIncludes(out, "new Function(s)()");
+  });
+
+  await t.step("evaluates nothing before the origin gate", () => {
+    const out = buildEditorBridge();
+    // The origin check must precede reading the payload / eval.
+    assertEquals(
+      out.indexOf("ok(e.origin,ALLOWED)") < out.indexOf("new Function(s)()"),
+      true,
+    );
+  });
+});

--- a/runtime/editorBridge.ts
+++ b/runtime/editorBridge.ts
@@ -1,0 +1,98 @@
+/**
+ * Editor bridge — the in-preview hook that lets Studio drive the visual/CMS
+ * editor over a Fast Preview draft render.
+ *
+ * Fast Preview renders the site's OWN real pages (not the `/live/previews`
+ * showcase route) against an unpublished draft. Those real pages do not carry
+ * the `<LiveControls>` script the showcase route emits, so Studio's admin frame
+ * has no `message` listener to talk to — the hover-to-select overlay silently
+ * never activates. This snippet restores that listener on the real page, so the
+ * same `postMessage` handshake the sandbox daemon proxy provides also works
+ * against a production draft render.
+ *
+ * Delivery mirrors {@link buildDraftBadge}: a self-contained inline `<script>`
+ * injected right before `</body>` by the request middleware, ONLY on a
+ * draft-bound request (the pointer is stashed in the bag by `prepareState`, and
+ * that only happens for a `?__draft=` from a host the preview allowlist admits
+ * — see `engine/decofile/draft.ts`). So it is inert on ordinary traffic exactly
+ * like the badge, and upgrading the package alone never turns it on.
+ *
+ * Two gates keep the `eval` hook safe, because a real page is reachable by URL
+ * (unlike the sandbox proxy, whose whole origin is ephemeral and isolated):
+ *   1. FRAMED-ONLY — the listener is registered only when the page is embedded
+ *      (`window.top !== window.self`). A top-level draft view ("Open in new
+ *      tab") has no Studio parent to drive it, so it never exposes the hook.
+ *      This is the inverse of the draft badge, which reveals only when unframed.
+ *   2. ORIGIN-ALLOWLISTED — the message is evaluated only when `event.origin`
+ *      is a known Studio/admin origin ({@link adminDomains}) or a local dev
+ *      origin. `frame-ancestors` (see `utils/http.ts`) already bounds WHO may
+ *      embed the page; this bounds WHO may inject, closing the
+ *      `window.open` + `postMessage` vector that framing alone does not.
+ *
+ * The injected script is Studio's own overlay (`CMS_EDITOR_SCRIPT` /
+ * `visual-editor::activate`); the framework only provides the origin-gated
+ * evaluation hook and the `section[data-manifest-key]` markers the overlay
+ * reads. The legacy admin `editor::inject` shape is accepted too, so this one
+ * listener serves both surfaces.
+ */
+
+import { adminDomains } from "../utils/admin.ts";
+
+/**
+ * Whether a parent-frame `origin` may inject the editor overlay.
+ *
+ * `allowed` is the baked Studio/admin origin list. Local dev origins
+ * (`localhost`, loopback, `*.localhost`, the native app's `local.studio.decocms.com`)
+ * are admitted by shape so a dev Studio on an arbitrary port still works without
+ * being hardcoded. Exported for unit testing; the same function is serialised
+ * into the injected script via `.toString()`, so it MUST stay self-contained
+ * (no module-scope references) to survive `eval` inside the iframe.
+ */
+export function isEditorParentOriginAllowed(
+  origin: string | null | undefined,
+  allowed: readonly string[],
+): boolean {
+  if (!origin) return false;
+  if (allowed.indexOf(origin) !== -1) return true;
+  try {
+    const h = new URL(origin).hostname;
+    return (
+      h === "localhost" ||
+      h === "127.0.0.1" ||
+      h.endsWith(".localhost") ||
+      h === "local.studio.decocms.com"
+    );
+  } catch (_e) {
+    return false;
+  }
+}
+
+/**
+ * Build the injectable editor-bridge markup for a draft-bound request.
+ *
+ * No per-request input: the only dynamic value is the static
+ * {@link adminDomains} allowlist, embedded as a JSON literal. The origin check
+ * is serialised from {@link isEditorParentOriginAllowed} so it is exercised by
+ * unit tests rather than duplicated as an untested string.
+ */
+export const buildEditorBridge = (): string => {
+  const allowed = JSON.stringify(adminDomains);
+  return (
+    `<script>(function(){try{` +
+    // Only inside Studio's frame — a top-level draft view has no editor parent.
+    `if(window.top===window.self)return;` +
+    `var ALLOWED=${allowed};` +
+    `var ok=${isEditorParentOriginAllowed.toString()};` +
+    `window.addEventListener("message",function(e){try{` +
+    `if(!ok(e.origin,ALLOWED))return;` +
+    `var d=e.data;if(!d)return;` +
+    // Studio/daemon protocol: {type:"visual-editor::activate", script}.
+    // Legacy admin protocol: {type:"editor::inject", args:{script}}.
+    `var s=(d.type==="visual-editor::activate"||d.type==="editor::inject")` +
+    `?(d.script||(d.args&&d.args.script)):null;` +
+    `if(!s)return;` +
+    `new Function(s)();` +
+    `}catch(err){console.error("[deco-editor] injection failed",err);}});` +
+    `}catch(e){}})();</script>`
+  );
+};

--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -38,6 +38,7 @@ import {
   DRAFT_PREVIEW_KEY,
   injectBeforeBodyEnd,
 } from "./draftBadge.ts";
+import { buildEditorBridge } from "./editorBridge.ts";
 import { setLogger } from "./fetch/fetchLog.ts";
 import { liveness } from "./middlewares/liveness.ts";
 import type { Deco, State } from "./mod.ts";
@@ -515,8 +516,8 @@ export const middlewareFor = <TAppManifest extends AppManifest = AppManifest>(
 
       const contentType = newHeaders.get("Content-Type") ?? "";
       const isHtmlResponse = contentType.includes("text/html");
-      const isPageCacheAllowed = ctx.var.bag?.has(PAGE_CACHE_ALLOWED_KEY) ===
-          true && isHtmlResponse;
+      const isPageCacheAllowed =
+        ctx.var.bag?.has(PAGE_CACHE_ALLOWED_KEY) === true && isHtmlResponse;
       applyPageCacheDecision(newHeaders, {
         flags: ctx.var?.flags ?? [],
         isPageCacheAllowed,
@@ -542,12 +543,17 @@ export const middlewareFor = <TAppManifest extends AppManifest = AppManifest>(
       const draftBadge = typeof draftPointer === "string"
         ? buildDraftBadge(draftPointer)
         : null;
+      // Editor bridge: the origin-gated `postMessage` hook Studio uses to inject
+      // its visual/CMS overlay into a Fast Preview draft render on the site's
+      // real pages. Same gate as the badge (draft-bound request only); active
+      // only inside Studio's frame. See runtime/editorBridge.ts.
+      const editorBridge = draftBadge ? buildEditorBridge() : null;
 
       // for some reason hono deletes content-type when response is not fresh.
       // which means that sometimes it will fail as headers are immutable.
       // so I'm first setting it to undefined and just then set the entire response again
       ctx.res = undefined;
-      if (cookieScript || draftBadge) {
+      if (cookieScript || draftBadge || editorBridge) {
         let html = await initialResponse.text();
         if (cookieScript) {
           // Script captured the framework cookies; remove the now-redundant
@@ -560,6 +566,7 @@ export const middlewareFor = <TAppManifest extends AppManifest = AppManifest>(
           html = injectScriptIntoHtml(html, cookieScript);
         }
         if (draftBadge) html = injectBeforeBodyEnd(html, draftBadge);
+        if (editorBridge) html = injectBeforeBodyEnd(html, editorBridge);
         ctx.res = new Response(html, {
           status: responseStatus,
           headers: newHeaders,


### PR DESCRIPTION
## Summary

With the CMS open over a **Fast Preview**, the hover-to-select section overlay silently never activates. This restores it.

**Why it was broken:** Fast Preview renders the site's *own real pages* against an unpublished draft (not the `/live/previews` showcase route), so those pages never carry the `<LiveControls>` script whose `message` listener the visual/CMS overlay relies on. The sandbox path works only because its daemon proxy injects that listener into every proxied HTML — Fast Preview has no proxy in the middle.

**The fix:** inject a small self-contained `editor bridge` snippet right before `</body>`, using the **exact same delivery + gate as the draft badge** — emitted *only* on a draft-bound request (the pointer the `?__draft=` host allowlist stashed in the bag by `prepareState`). So it is inert on ordinary traffic, and upgrading the package alone never turns it on. It runs on the site's real routes, which is what Fast Preview renders.

The injected code is **Studio's own overlay** (`visual-editor::activate` / `CMS_EDITOR_SCRIPT`); the framework only provides the origin-gated evaluation hook and the `section[data-manifest-key]` markers the overlay reads.

## Security

A real page is reachable by URL (unlike the ephemeral sandbox proxy origin), so the `eval` hook has two gates:

1. **Framed-only** — the listener is registered only when embedded (`window.top !== window.self`), the inverse of the draft badge. A top-level draft view ("Open in new tab") has no Studio parent to drive it, so it never exposes the hook.
2. **Origin-allowlisted** — a payload is evaluated only when `event.origin` is a known Studio/admin origin (`adminDomains`) or a local dev origin. `frame-ancestors` already bounds *who may embed*; this bounds *who may inject*, closing the `window.open` + `postMessage` vector that framing alone does not.

Accepts both the Studio/daemon protocol (`visual-editor::activate`) and the legacy admin one (`editor::inject`), so one listener serves both surfaces.

## Changes

- `runtime/editorBridge.ts` (new) — `buildEditorBridge()` + the pure, unit-tested `isEditorParentOriginAllowed()` (serialised into the snippet via `.toString()`, so the origin check is exercised by tests rather than duplicated as an untested string).
- `runtime/middleware.ts` — inject the bridge alongside the draft badge, under the same `DRAFT_PREVIEW_KEY` gate.
- `runtime/editorBridge.test.ts` (new).

## Testing

- `deno test runtime/editorBridge.test.ts runtime/draftBadge.test.ts` ✅ (4 passed / 14 steps)
- `deno fmt` / `deno lint` / `deno check` on touched files ✅
- Verified the generated `.toString()` snippet is clean browser JS (no TS annotations).

## Follow-up (Studio side, separate repo/PR)

`apps/web` `preview.tsx` needs the matching client changes so it actually injects over the production frame: allow injection when `display.mode !== "sandbox"`, target/accept the production iframe origin (`display.iframeBase`) in the `postMessage` + `cms-editor::section-clicked` handler, and stop force-downgrading `blocks` mode off the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the CMS/visual overlay on Fast Preview draft renders by serving a gated editor bridge on real pages. Previously, Fast Preview pages lacked the `<LiveControls>` listener and the hover-to-select overlay never activated; now Studio can inject the overlay via a guarded postMessage hook without affecting ordinary traffic.

- Injects a self-contained inline script right before </body> only on draft-bound requests (same gate as the draft badge). No change on non-draft traffic.
- Secures the eval hook with two gates: framed-only registration and an origin allowlist (`adminDomains` plus local dev shapes). Accepts both `visual-editor::activate` and legacy `editor::inject`.
- Adds `runtime/editorBridge.ts` (`buildEditorBridge()`, `isEditorParentOriginAllowed()`) and unit tests; wires injection in `runtime/middleware.ts`.
- Rollout: no config changes required; package upgrades alone do not enable the bridge. Studio must update its preview client to target the production iframe and send `visual-editor::activate` outside the sandbox for this to take effect.

<sup>Written for commit e6ab2b8f4fee2d58038079ee5b1586c1b14d6549. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/deco/pull/1228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for embedded Studio editing in draft pages.
  - Draft pages can receive editor updates from approved administrative and local-development origins.
  - Supports current and legacy editor message formats.

- **Bug Fixes**
  - Invalid origins, missing data, top-level contexts, and injection errors are safely ignored or logged.

- **Tests**
  - Added coverage for origin validation, supported protocols, framed contexts, and message-processing safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->