### PR TITLE
feat(fetch): opt-in per-call deadline for outgoing fetch

### DIFF
--- a/runtime/fetch/fetchTimeout.test.ts
+++ b/runtime/fetch/fetchTimeout.test.ts
@@ -1,0 +1,91 @@
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStrictEquals,
+} from "@std/assert";
+import { createFetch } from "./fetchTimeout.ts";
+
+/**
+ * `RequestInit` resolves to a union here where only some members carry
+ * `signal`, so reading it needs the same narrowing `utils/patched_fetch.ts`
+ * uses.
+ */
+const signalOf = (init: unknown): AbortSignal | undefined =>
+  init !== null && typeof init === "object" && "signal" in init
+    ? (init as { signal?: AbortSignal }).signal
+    : undefined;
+
+/**
+ * Stands in for a hanging upstream. It has to honour `signal` the way the real
+ * `fetch` does — a stub that ignores it would hang the test rather than prove
+ * the wrapper aborts anything.
+ */
+const never: typeof fetch = (_input, init) =>
+  new Promise<Response>((_resolve, reject) => {
+    const signal = signalOf(init);
+    if (!signal) return;
+    if (signal.aborted) return reject(signal.reason);
+    signal.addEventListener("abort", () => reject(signal.reason));
+  });
+
+const ok: typeof fetch = () => Promise.resolve(new Response("ok"));
+
+Deno.test("disabled: returns the fetcher untouched", () => {
+  // Identity, not equivalence: upgrading must not add a wrapper to the call
+  // path of a site that never opted in.
+  assertStrictEquals(createFetch(never, 0), never);
+  assertStrictEquals(createFetch(never, -1), never);
+  assertStrictEquals(createFetch(never, NaN), never);
+});
+
+Deno.test("enabled: aborts a hanging call with TimeoutError", async () => {
+  const fetcher = createFetch(never, 20);
+
+  const error = await assertRejects(() => fetcher("https://example.com"));
+
+  assert(error instanceof DOMException, `not a DOMException: ${error}`);
+  assertEquals(error.name, "TimeoutError");
+});
+
+Deno.test("enabled: a call that answers in time is untouched", async () => {
+  const fetcher = createFetch(ok, 1_000);
+
+  assertEquals(await (await fetcher("https://example.com")).text(), "ok");
+});
+
+Deno.test("enabled: the deadline still applies when a caller signal is present", async () => {
+  const controller = new AbortController();
+  const fetcher = createFetch(never, 20);
+
+  const error = await assertRejects(() =>
+    fetcher("https://example.com", { signal: controller.signal })
+  );
+
+  assertEquals((error as DOMException).name, "TimeoutError");
+});
+
+Deno.test("enabled: the caller's signal wins when it fires first", async () => {
+  const controller = new AbortController();
+  const reason = new Error("caller gave up");
+  const fetcher = createFetch(never, 5_000);
+
+  const pending = assertRejects(() =>
+    fetcher("https://example.com", { signal: controller.signal })
+  );
+  controller.abort(reason);
+
+  assertStrictEquals(await pending, reason);
+});
+
+Deno.test("enabled: an already-aborted caller signal rejects immediately", async () => {
+  // The Lazy.tsx shape: a signal aborted before the call is ever made.
+  const reason = new Error("dropped deferred section");
+  const fetcher = createFetch(never, 5_000);
+
+  const error = await assertRejects(() =>
+    fetcher("https://example.com", { signal: AbortSignal.abort(reason) })
+  );
+
+  assertStrictEquals(error, reason);
+});

--- a/runtime/fetch/fetchTimeout.ts
+++ b/runtime/fetch/fetchTimeout.ts
@@ -1,0 +1,71 @@
+/**
+ * A deadline for each individual outgoing fetch.
+ *
+ * `utils/patched_fetch.ts` already forwards `RequestContext.signal` to every
+ * outbound call, so cancellation exists — but that signal is scoped to the
+ * *incoming* request. A hanging upstream is therefore only released when the
+ * whole page request is torn down, which on our runner is governed by
+ * `REVISION_TIMEOUT_SECONDS` (300s in production). Nothing bounds a single call.
+ *
+ * That gap is measurable. On one production VTEX store, `outgoing_fetch_duration`
+ * recorded 66 calls to a single host in one hour that failed after an average of
+ * **26.7s**, plus 21 more averaging 19.9s, while the same host answered a
+ * sequential probe in ~470ms. With no admission limit in front of the isolate,
+ * calls that hang that long accumulate until the pod stops answering — the
+ * upstream degrades partially, but the site goes down.
+ *
+ * ## Opt-in
+ *
+ * With `DECO_OUTGOING_FETCH_TIMEOUT_MS` unset or <= 0, `createFetch` returns the
+ * fetcher untouched — no wrapper, no allocation, no behaviour change on upgrade.
+ * Aborting requests that used to be allowed to run forever is exactly the kind
+ * of default that should be proven on one site before it reaches every site, so
+ * flipping the default is deliberately left as a follow-up.
+ *
+ * ## Two things worth weighing before picking a value
+ *
+ * - **The deadline covers the whole exchange, body included.** `AbortSignal` has
+ *   no headers-only mode, so a large slow download can be aborted even when the
+ *   upstream answered promptly. Size the value against the biggest legitimate
+ *   response, not against TTFB.
+ * - **`apps/utils/fetch.ts` retries once** (`retryExceptionOr500`, maxAttempts 1)
+ *   on `connection closed before message completed`. Each attempt gets its own
+ *   deadline, so the worst case a caller observes is roughly twice the value set
+ *   here.
+ *
+ * A caller-supplied `signal` is preserved rather than replaced — whichever fires
+ * first wins. `website/sections/Rendering/Lazy.tsx`, which binds an
+ * already-aborted signal to drop deferred sections, keeps behaving identically.
+ *
+ * Timed-out calls stay visible instead of vanishing: the abort surfaces as a
+ * throw, and `fetchLog.ts` records it under
+ * `http.response.status_class="error"` with the elapsed duration intact.
+ */
+const fromEnv = Number.parseInt(
+  Deno.env.get("DECO_OUTGOING_FETCH_TIMEOUT_MS") ?? "",
+);
+
+/** Milliseconds, or 0 when the feature is off. */
+export const DEFAULT_TIMEOUT_MS: number =
+  Number.isFinite(fromEnv) && fromEnv > 0 ? fromEnv : 0;
+
+export const createFetch = (
+  fetcher: typeof fetch,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): typeof fetch => {
+  if (!(timeoutMs > 0)) {
+    return fetcher;
+  }
+
+  return function fetch(
+    input: string | Request | URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const deadline = AbortSignal.timeout(timeoutMs);
+    const signal = init?.signal
+      ? AbortSignal.any([init.signal, deadline])
+      : deadline;
+
+    return fetcher(input, { ...init, signal });
+  };
+};

--- a/runtime/fetch/mod.ts
+++ b/runtime/fetch/mod.ts
@@ -1,4 +1,5 @@
 import { createFetch as withLogs } from "./fetchLog.ts";
+import { createFetch as withTimeout } from "./fetchTimeout.ts";
 
 interface FechInfo {
   (input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
@@ -14,10 +15,15 @@ interface FechInfo {
 /**
  * A modified fetch function that includes logging and caching features.
  *
+ * Order matters: `withLogs` sits outermost so a call aborted by `withTimeout`
+ * is still recorded, with the time it spent hanging, instead of disappearing
+ * from `outgoing_fetch_duration`.
+ *
  * @type {FechInfo}
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/fetch}
  */
 
 export const fetch: FechInfo = [
   withLogs,
+  withTimeout,
 ].filter(Boolean).reduceRight((acc, curr) => curr!(acc), globalThis.fetch);


### PR DESCRIPTION
## Problem

`utils/patched_fetch.ts` already forwards `RequestContext.signal` to every outbound call, so cancellation exists — but that signal is scoped to the **incoming** request. A hanging upstream is therefore only released when the whole page request is torn down, which on the runner is `REVISION_TIMEOUT_SECONDS` (300s in production). **Nothing bounds a single call.**

## Measured

On a production VTEX store, using `outgoing_fetch_duration` (added in #1218), calls to `secure.farmrio.com.br` recorded under `http.response.status_class="error"`:

| hour (UTC) | calls | mean duration before failing |
|---|---|---|
| 07:00 | 18 | 12.5s |
| 11:00 | 66 | **26.7s** |
| 12:00 | 21 | 19.9s |
| 13:00 | 7 | 17.6s |

Plus slow `5xx`: 841 averaging 2.1s at 07:00, 172 averaging **7.9s** at 08:00.

For contrast, a sequential `curl` to the same host from a pod on the same node answered in ~470ms during the same window, and four other VTEX tenants on the same cluster stayed flat at 123–462ms. The upstream was degrading intermittently, in bursts of minutes, on one account.

The consequence is not partial degradation. `CONTAINER_CONCURRENCY=0` means no admission limit in front of the isolate, so calls hanging for 20s+ accumulate until the pod stops answering. Container restarts correlate exactly with those bursts — zero restarts in every window where the upstream was at baseline, 12 restarts in the two hours it was not.

## Fix

A `withTimeout` wrapper in the existing `runtime/fetch/mod.ts` chain. `apps/utils/fetch.ts` imports `fetch` from `@deco/deco`, so every app client — VTEX `fetchSafe` included — goes through it.

**It is opt-in.** With `DECO_OUTGOING_FETCH_TIMEOUT_MS` unset or `<= 0`, `createFetch` returns the fetcher by identity: no wrapper, no allocation, no behaviour change on upgrade. Aborting calls that were previously allowed to run indefinitely is exactly the kind of default that should be proven on one site before it reaches every site, so flipping the default is deliberately left as a follow-up.

## Ordering

`withLogs` stays outermost:

```ts
export const fetch: FechInfo = [
  withLogs,
  withTimeout,
].filter(Boolean).reduceRight((acc, curr) => curr!(acc), globalThis.fetch);
```

A call killed by the deadline is therefore still recorded, with the time it spent hanging, under `status_class="error"` — instead of disappearing from the metric that made this diagnosable in the first place.

## Trade-offs a reviewer should weigh

- **The deadline covers the whole exchange, body included.** `AbortSignal` has no headers-only mode, so a large slow download can be aborted even when the upstream answered promptly. The value should be sized against the biggest legitimate response, not against TTFB. On the store measured, the `>5s` bucket is 0–0.08% in baseline hours and 5.4% at the worst, so ~10s cuts the hangs without touching normal traffic.
- **`apps/utils/fetch.ts` retries once** (`retryExceptionOr500`, `maxAttempts: 1`) on `connection closed before message completed`. Each attempt gets its own deadline, so the worst case a caller observes is roughly twice the configured value.
- **A caller-supplied `signal` is preserved, not replaced** — `AbortSignal.any([caller, deadline])`, whichever fires first wins. `website/sections/Rendering/Lazy.tsx` binds an already-aborted signal to drop deferred sections; there is a test pinning that shape.

## What this does not fix

This converts "wedged pod" into "fast failure", which is partial degradation instead of an outage. It does **not** replace the two platform-side gaps, both outside this repo:

- `CONTAINER_CONCURRENCY=0` — no admission limit, so requests can still pile up.
- `SERVING_READINESS_PROBE` is `tcpSocket` only, so a wedged event loop still reports Ready and keeps receiving traffic.

## Verification

```
deno fmt runtime/fetch/          # Checked 4 files
deno check live.ts               # clean
deno test --unstable-http -A blocks/matcher.test.ts runtime/middleware.test.ts runtime/fetch/
# ok | 32 passed | 0 failed
```

Six new tests in `runtime/fetch/fetchTimeout.test.ts` cover: identity when disabled, `TimeoutError` on a hang, untouched fast calls, the deadline applying alongside a caller signal, the caller signal winning when it fires first, and an already-aborted caller signal rejecting with its own reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in per-call deadline to outgoing `fetch` to prevent hung upstreams from wedging pods. Previously only the incoming request’s `RequestContext.signal` could cancel; now each outbound call can be bounded via `DECO_OUTGOING_FETCH_TIMEOUT_MS`, with no behavior change by default.

- Default is no-op: when `DECO_OUTGOING_FETCH_TIMEOUT_MS` is unset or <= 0, `createFetch` returns the original fetcher.
- To enable, set `DECO_OUTGOING_FETCH_TIMEOUT_MS=<ms>`; choose a value sized to the largest valid response (the deadline covers headers and body).
- `apps/utils/fetch.ts` retries once; each attempt gets its own deadline, so observed worst case is ~2× the configured value.
- Caller `signal` is preserved using `AbortSignal.any`; paths like `website/sections/Rendering/Lazy.tsx` keep their current semantics.
- `withLogs` remains outermost; timed-out calls are still recorded under `status_class="error"` in `outgoing_fetch_duration`.
- All app clients that import `fetch` from `@deco/deco` pick up the behavior automatically when enabled.

<sup>Written for commit 28fbb662b8c92bada95b3ec9b84889c7d5571b77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/deco/pull/1229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional timeouts for outgoing network requests.
  * Requests now respect whichever occurs first: the configured timeout or the caller’s cancellation signal.
  * Timed-out requests are reported as timeout errors, while request logging includes their elapsed duration.

* **Bug Fixes**
  * Prevented requests from hanging indefinitely when a timeout is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->