### PR TITLE
fix(engine): don't let an aborted read poison the shared resolvable memo

### DIFF
--- a/engine/core/mod.test.ts
+++ b/engine/core/mod.test.ts
@@ -7,6 +7,7 @@ import {
   type ResolverMap,
 } from "../../engine/core/resolver.ts";
 import defaults from "../manifest/fresh.ts";
+import { RequestContext } from "../../deco.ts";
 
 Deno.test("resolve", async (t) => {
   const context: BaseContext = {
@@ -341,4 +342,81 @@ Deno.test("resolve", async (t) => {
     );
     assertEquals(result, { foo: "hello", bar: { value: 10 } });
   });
+});
+
+Deno.test("aborted reads must not poison the shared memo", async (t) => {
+  // A loader-like resolver that fails when the active RequestContext signal is
+  // aborted (mirrors `blocks/loader.ts` calling `signal.throwIfAborted()`) and
+  // otherwise returns its resolved props unchanged.
+  const flakyLoader = (props: unknown): unknown => {
+    RequestContext?.signal?.throwIfAborted();
+    return props;
+  };
+
+  const makeContext = (): BaseContext => ({
+    revision: "",
+    resolveChain: [],
+    resolveId: "1",
+    resolverId: "unknown",
+    // A shared *named* block (top-level decofile key): resolution is memoized
+    // by key in `context.memo`, so every reference shares one promise.
+    resolvables: {
+      SharedBlock: { __resolveType: "flakyLoader", title: "hello" },
+    },
+    resolvers: { ...defaults, flakyLoader } as unknown as ResolverMap,
+    resolveHints: {},
+    memo: {},
+    runOnce: (_key, f) => f(),
+    resolve: <T>(data: unknown) => data as T,
+  });
+
+  const tryResolve = async (ctx: BaseContext) => {
+    try {
+      return await resolve<{ title: string }>("SharedBlock", ctx);
+    } catch (e) {
+      return `threw:${(e as Error).name}`;
+    }
+  };
+
+  await t.step(
+    "sequential: a live consumer re-resolves after an aborted one",
+    async () => {
+      const ctx = makeContext();
+      const aborted = new AbortController();
+      aborted.abort();
+
+      // Consumer A resolves the shared block under an already-aborted signal
+      // (as `website/sections/Rendering/Lazy.tsx` does to render a fallback).
+      const a = await RequestContext.bind(
+        { signal: aborted.signal },
+        () => tryResolve(ctx),
+      )();
+      // Consumer B (the real render) has a live signal and must get the value.
+      const b = await tryResolve(ctx);
+
+      assertEquals(a, "threw:AbortError");
+      assertEquals(b, { title: "hello" });
+    },
+  );
+
+  await t.step(
+    "concurrent: a live consumer does not inherit a co-scheduled abort",
+    async () => {
+      const ctx = makeContext();
+      const aborted = new AbortController();
+      aborted.abort();
+
+      // A (aborted) and B (live) await the same in-flight memo promise.
+      const [a, b] = await Promise.all([
+        RequestContext.bind(
+          { signal: aborted.signal },
+          () => tryResolve(ctx),
+        )(),
+        tryResolve(ctx),
+      ]);
+
+      assertEquals(a, "threw:AbortError");
+      assertEquals(b, { title: "hello" });
+    },
+  );
 });

--- a/engine/core/resolver.ts
+++ b/engine/core/resolver.ts
@@ -1,5 +1,6 @@
 // deno-lint-ignore-file no-explicit-any
 import type { Context, Span, Tracer } from "../../deps.ts";
+import { RequestContext } from "../../deco.ts";
 import { identity } from "../../utils/object.ts";
 import type { createServerTimings } from "../../utils/timings.ts";
 import { type HintNode, type ResolveHints, traverseAny } from "./hints.ts";
@@ -517,6 +518,17 @@ const invokeResolverWithProps = async <
 };
 
 /**
+ * True when `err` is an abort caused by an aborted `AbortSignal`
+ * (`signal.throwIfAborted()` / `AbortController.abort()`), whose default reason
+ * is a `DOMException` named `"AbortError"`. Custom reasons that preserve that
+ * name match too.
+ */
+const isAbortError = (err: unknown): boolean =>
+  (err instanceof DOMException && err.name === "AbortError") ||
+  (typeof err === "object" && err !== null && "name" in err &&
+    (err as { name?: unknown }).name === "AbortError");
+
+/**
  * Receives the props resolved and a type that should be called with the given props.
  * This type can be a resolvable which currently just ignore the resolved props and returns the given resolved resolvable.
  * If the type wasn't found, it will throw a DanglingReference or calls it recover if configured.
@@ -533,11 +545,36 @@ const resolveWithType = <
   const { resolvers: resolverMap, resolvables } = context;
 
   if (resolveType in resolvables) {
-    return context.memo[resolveType] ??= resolveResolvable<T>(
+    // Resolve the shared (memoized) resolvable, evicting the cache entry when
+    // the resolution fails because of an aborted RequestContext signal. That
+    // abort belongs to whichever consumer happened to trigger the shared
+    // resolution first (e.g. `website/sections/Rendering/Lazy.tsx` deliberately
+    // aborts to render a loading fallback) — it is NOT a property of the block,
+    // so it must not be cached and served to the block's other references.
+    const resolveShared = (): Promise<
+      T
+    > => (context.memo[resolveType] ??= resolveResolvable<T>(
       resolveType,
       context,
       opts,
-    );
+    ).catch((err: unknown) => {
+      if (isAbortError(err) && context.memo[resolveType] !== undefined) {
+        delete context.memo[resolveType];
+      }
+      throw err;
+    }));
+
+    return resolveShared().catch((err: unknown) => {
+      // A consumer whose own signal is still live must not inherit an abort it
+      // did not cause — this happens when it awaited the same in-flight promise
+      // as an aborted consumer. The entry was evicted above, so re-resolve it
+      // fresh under this (live) caller. Without this, a multivariate page whose
+      // real render is co-scheduled with an aborted lazy read renders blank.
+      if (isAbortError(err) && RequestContext.signal?.aborted !== true) {
+        return resolveShared();
+      }
+      throw err;
+    });
   } else if (resolveType in resolverMap) {
     const resolver = resolverMap[resolveType];
     const proceed = () =>


### PR DESCRIPTION
## Problem

On the montecarlo Fast Preview, adding a **page variant** makes the page render **blank** most of the time (flaky — occasionally full). Reproduced deterministically against the live runtime:

| Page | Variants | Render (draft) |
|---|---|---|
| single-variant multivariate | 1 | ✅ full, always |
| two variants, **distinct** content | 2 | ✅ full, always |
| two variants, **cloned/near-identical** content (`/masculino`) | 2 | ❌ blank ~80%, flaky |

The rule combo (`always`+`always`, `always`+`never`) is irrelevant — I confirmed both blank while other 2-variant pages with the same rules render fine. The Studio-served decofile is correct and byte-stable; the fault is in resolution.

## Root cause

Named blocks are memoized per request by key in `context.memo` (`engine/core/resolver.ts`), and the cached value is the **promise** of whichever consumer resolves the key first — everyone else awaits that same promise.

`website/sections/Rendering/Lazy.tsx` resolves its inner section under an **already-aborted** `AbortController` (to render a loading fallback fast, then hydrate lazily). When that inner section is a named block also referenced elsewhere on the page, the aborted resolution's **rejected** promise is what gets cached and handed to the other references → they all throw `AbortError` → the render collapses to empty sections → blank page.

Adding a second page variant (`website/flags/multivariate.ts`) changes resolution ordering/concurrency enough that the aborted lazy read wins the memo race — hence the flakiness and the "only with 2 variants" trigger.

## Fix

The abort is a property of *one consumer*, not of the block, so it must not be cached:

- When a memoized resolvable rejects with an abort, **evict** the cache entry so later reads re-resolve.
- If a consumer whose **own** signal is still live inherited a co-scheduled aborted promise, **re-resolve fresh** under that live caller.
- Consumers that are themselves aborted still reject, unchanged.

## Repro / tests

Minimal engine-level reproduction added in `engine/core/mod.test.ts`:
- **sequential** — an aborted read followed by a live read (was: live read got `AbortError`; now: gets the value)
- **concurrent** — an aborted read and a live read awaiting the same in-flight memo promise (was: both `AbortError`; now: live read gets the value)

Both fail on `main` and pass with this change. `deno test engine/core/mod.test.ts`, `deno fmt --check`, and `deno lint` are green.

> Note: verified analytically + via the engine regression tests. Please also sanity-check against the montecarlo `/masculino` draft in a preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents an aborted read from poisoning the shared memo for named blocks, fixing flaky blank renders on multivariate pages. Previously, an aborted consumer cached a rejected promise that other references inherited; now, aborts are treated as consumer-local.

- On abort, evict the memo entry and let live consumers re-resolve; aborted consumers still receive AbortError.
- Changes are limited to `engine/core/resolver.ts` (abort detection, memo eviction, retry for live callers) with regression tests added in `engine/core/mod.test.ts` for sequential and concurrent cases.
- No API changes or migrations; only abort errors are special-cased—other failures remain memoized as before.

<sup>Written for commit 0b524abacc07f22286f97b80ebbb40b87e5ce580. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/deco/pull/1230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling for shared in-progress resolutions.
  * Aborted requests now fail with an abort error without affecting later or concurrent live requests.
  * Live requests can retry successfully when a shared resolution is interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->