### PR TITLE
fix(engine): don't inherit stale resolve hints on release swap (Fast Preview blank page)

### DIFF
--- a/engine/core/mod.test.ts
+++ b/engine/core/mod.test.ts
@@ -6,8 +6,49 @@ import {
   resolve,
   type ResolverMap,
 } from "../../engine/core/resolver.ts";
+import { ReleaseResolver } from "../../engine/core/mod.ts";
+import { fromJSON } from "../../engine/decofile/fetcher.ts";
 import defaults from "../manifest/fresh.ts";
 import { RequestContext } from "../../deco.ts";
+
+Deno.test(".with({ release }) does not inherit stale resolve hints", async () => {
+  // Hints are cached by resolveType (block id) and derived from the release's
+  // resolvables. Fast Preview binds a request-scoped draft via
+  // `resolver.with({ release: draftProvider })`. If `.with` inherits the base
+  // resolver's hints, a block whose SHAPE changed between the published release
+  // and the draft (same id, different content) resolves against the stale shape
+  // and silently drops everything the old hints don't cover — the exact failure
+  // that blanked a page whose `sections` went from a plain array (published) to
+  // a `multivariate` flag (draft).
+  const resolvers = {
+    passthrough: (props: unknown) => props,
+  } as unknown as ResolverMap;
+
+  // Published: block "page" has a plain `content` (no nested resolvable).
+  const published = fromJSON({
+    page: { __resolveType: "passthrough", content: "plain" },
+  });
+  // Draft: SAME id "page", but `content` is now a nested resolvable — the draft
+  // needs a hint at `content` that the published shape never produced.
+  const draft = fromJSON({
+    page: { __resolveType: "passthrough", content: { __resolveType: "inner" } },
+    inner: { __resolveType: "passthrough", value: "from-draft" },
+  });
+
+  const base = new ReleaseResolver<BaseContext>({ release: published, resolvers });
+
+  // Resolve against the published release first — this populates (poisons) the
+  // base resolver's hint cache for "page" with the plain-content shape.
+  assertEquals(await base.resolve<{ content: unknown }>("page", {}), {
+    content: "plain",
+  });
+
+  // Swap the release for the draft, as Fast Preview does.
+  const drafted = base.with({ release: draft });
+  assertEquals(await drafted.resolve<{ content: unknown }>("page", {}), {
+    content: { value: "from-draft" },
+  });
+});
 
 Deno.test("resolve", async (t) => {
   const context: BaseContext = {

--- a/engine/core/mod.ts
+++ b/engine/core/mod.ts
@@ -113,19 +113,30 @@ export class ReleaseResolver<TContext extends BaseContext = BaseContext> {
     { resolvers, resolvables, release, danglingRecover }: ExtensionOptions<
       TContext
     >,
-  ): ReleaseResolver<TContext> =>
-    new ReleaseResolver<TContext>(
+  ): ReleaseResolver<TContext> => {
+    // Hints are derived from the release's resolvables and cached by resolveType
+    // (block id). When the release is swapped — as Fast Preview does to bind a
+    // request-scoped draft (`resolver.with({ release: draftProvider })`) — the
+    // base hints are stale: the SAME block id can now resolve to different
+    // content (e.g. a page whose `sections` was a plain array in the published
+    // release but a `multivariate` flag in the draft). Inheriting them makes the
+    // draft resolve against the published shape and silently drop everything the
+    // old hints don't cover. This mirrors the `release.onChange` invariant in the
+    // constructor, which already clears hints whenever the release changes.
+    const releaseChanged = release !== undefined && release !== this.release;
+    return new ReleaseResolver<TContext>(
       {
         release: release ?? this.release,
         danglingRecover: danglingRecover ?? this.danglingRecover,
         resolvables: { ...this.resolvables, ...resolvables },
         resolvers: { ...this.resolvers, ...resolvers },
       },
-      { ...this.resolveHints },
+      releaseChanged ? {} : { ...this.resolveHints },
       {
         ...this.runOncePerRelease,
       },
     );
+  };
 
   public getResolvers(): ResolverMap<BaseContext> {
     return this._cachedResolvers ??= {


### PR DESCRIPTION
## Problem

Fast Preview (`?__draft=`) renders a **blank page** on a production server for pages whose block **shape** changed between the published release and the draft — e.g. a page whose `sections` was a plain array when published but became a `website/flags/multivariate` flag in the draft. The whole page body disappears (header → content → **footer**); only globally-injected sections survive. It fails fast (a resolution no-op, not a timeout), and only on long-running servers — a fresh process that resolves the draft *first* renders it fine.

## Root cause

Resolve hints are cached by `resolveType` (block id) and derived from the release's resolvables:

```ts
// engine/core/resolver.ts
const hints = context.resolveHints[resolveType] ??= traverseAny(resolvableObj) ?? {};
```

Fast Preview binds a request-scoped draft by swapping the release via `resolver.with({ release: draftProvider })` (`runtime/mod.ts`). But `.with` copied the base resolver's hints:

```ts
new ReleaseResolver(/* ... */, { ...this.resolveHints }, /* ... */)
```

A server that serves the published release populates `resolveHints["<page>"]` with the **published** shape (`sections.0`, `sections.1`, …). When the draft is then resolved, it **reuses those stale hints**. The draft's `sections` is now a `multivariate` flag, whose variant values live at `sections.variants.*.value.*` — paths the stale hints don't cover — so nothing under them resolves. `@sections` resolves in ~0ms to empty and the page renders blank.

This was reproduced against a real deployment: `server-timing: <page>@sections;dur=0` on the affected server vs `dur=2688` (resolving `variants.0.value.*`) on a fresh process — identical code, identical draft.

## Fix

When `.with` swaps the release, start from **empty** hints instead of inheriting them. Hints belong to a release's resolvables, so a different release invalidates them. This mirrors the existing `release.onChange` invariant in the constructor, which already clears `resolveHints` on every release change — `.with({ release })` was the one path that bypassed it.

## Tradeoffs / blast radius

- Only the two **release-swap** call sites are affected: Fast Preview draft (`runtime/mod.ts`) and block preview (`runtime/routes/blockPreview.tsx`). Both are exactly the preview scenario this bug breaks.
- `.with` calls that pass **no** `release` (the app-install/setup path in `engine/manifest/manifest.ts`, which passes `resolvers`/`resolvables`) keep inheriting hints — **unchanged**.
- **Normal request traffic is unaffected** (no release swap).
- Cost: preview/draft renders recompute hints lazily per block instead of reusing the base's. Negligible — draft renders are `no-store`/uncached and low-volume, and `traverseAny` is cheap next to loader fetches.
- Out of scope: `.with({ resolvables })` that overrides a block's content without swapping the release would still inherit hints for that block. Not hit by the preview paths; left for a follow-up if needed.

## Test

`engine/core/mod.test.ts` → `.with({ release }) does not inherit stale resolve hints`: resolves a block against a "published" release (plain content), then `.with({ release: draft })` where the same block id has a nested resolvable. Fails without the fix (nested value left unresolved), passes with it. Full engine suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Fast Preview (`?__draft=`) rendering blank pages on production servers when a block's shape changed between the published release and the draft. `resolver.with({ release })` now starts from empty resolve hints instead of inheriting the base resolver's, which were derived from the published release's resolvables.

Only the release-swap paths (Fast Preview draft and block preview) are affected; normal traffic and the setup path that pass no `release` keep inheriting hints unchanged. Draft and preview renders now recompute hints lazily per block, a negligible cost for low-volume, uncached renders.

<sup>Written for commit 7bb7c77c60e6a6efec2c0af288d9d57408e8e5f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/deco/pull/1232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed release switching so content resolves using the active release’s structure.
  * Prevented stale resolution information from a previous release affecting draft or preview content.
* **Tests**
  * Added coverage verifying correct resolution when switching between published and draft releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->