### PR TITLE
fix(ci): drop invalid `--reload=file:` from deno cache step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
         run: deno run -A --lock=deno.lock --frozen=false --reload mod.ts
       - name: fetch any uncached dependencies
         run: |
-          deno cache --lock=deno.lock --frozen=false --reload=file: ./mod.ts
+          deno cache --lock=deno.lock --frozen=false ./mod.ts
 
       - run: |
           deno test --lock=deno.lock --frozen=false -A .


### PR DESCRIPTION
## Problem

The **Setup deno** job fails on every run (main and PRs) with:

```
Run deno cache --lock=deno.lock --frozen=false --reload=file: ./mod.ts
error: invalid reload URL: 'file:'
Error: Process completed with exit code 1.
```

CI installs `deno-version: v2.x`, which now resolves to a Deno that rejects a bare `file:` as a `--reload` specifier (older versions accepted it — runs from ~Aug 21 passed, runs after the Deno bump fail). Not tied to any source change; it broke on the toolchain upgrade.

## Fix

Drop `--reload=file:` from the "fetch any uncached dependencies" step. It's redundant: the preceding **Build Deno Module** step already runs `deno run -A --reload mod.ts`, so every dependency is cached by the time this step runs. Plain `deno cache ./mod.ts` fetches anything still missing — exactly what the step name says — and works on all Deno versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CI "Setup deno" job that fails on every run when Deno v2.x rejects a bare `file:` as a `--reload` specifier (`invalid reload URL: 'file:'`). Drops the `--reload=file:` flag from the `deno cache` step since the preceding build step already runs `deno run --reload mod.ts`, and plain `deno cache ./mod.ts` still fetches anything missing.

<sup>Written for commit 10ef850440c292f021e2c5c27cd3181239aa86db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deco-cx/deco/pull/1233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency caching during continuous integration by avoiding unnecessary refreshes of already cached files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->